### PR TITLE
Document project origins in README (ChatGPT, Replit, Codex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Modern Trivia
+
+Modern Trivia is a browser-based trivia party game for local multiplayer. Create teams, pick a regional bias for questions, and compete through a guided question/answer loop with automatic scoring.
+
+## Project Origins
+
+This project was created using ChatGPT, Replit, and Codex. The original prototype was designed by ChatGPT and built in Replit using the App Connector, and this README was created using Codex.
+
+## Features
+
+- Local multiplayer team setup (2–6 teams).
+- Regional question bias (Global Mix, US, CA).
+- Automatic answer verification and scoring flow.
+- Admin panel for adding custom questions stored in local storage.
+- Built-in game state machine (see `docs/STATE_MACHINE.md`).
+
+## Tech Stack
+
+- React + Vite (client)
+- Express + WebSocket (server)
+- Drizzle ORM + PostgreSQL (optional data layer)
+- Tailwind CSS + Radix UI
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- npm
+
+### Install
+
+```bash
+npm install
+```
+
+### Development
+
+Run the Express API and Vite client together:
+
+```bash
+npm run dev
+```
+
+If you want only the Vite client (for UI work):
+
+```bash
+npm run dev:client
+```
+
+The app serves on `http://localhost:5000` by default.
+
+### Production build
+
+```bash
+npm run build
+npm start
+```
+
+## Project Structure
+
+- `client/` — React UI
+- `server/` — Express API + server setup
+- `shared/` — Shared types/utilities
+- `docs/STATE_MACHINE.md` — Game state flow documentation
+
+## Notes
+
+- Custom questions added in the Admin panel are saved in local storage for the current browser.
+- Region bias affects which questions are chosen during play.
+
+## License
+
+MIT


### PR DESCRIPTION
### Motivation
- Make the project's provenance explicit by noting the tools used to create the prototype and README.
- Provide transparency that the original prototype was designed by ChatGPT and built in Replit using the App Connector.
- Credit that this README content was generated using Codex.

### Description
- Add a new `Project Origins` section to `README.md` that states the project was created using ChatGPT, Replit, and Codex. 
- Clarify that the original prototype was designed by ChatGPT and built in Replit using the App Connector, and that the README was created with Codex. 
- This is a documentation-only change to `README.md` and does not modify application source code.

### Testing
- No automated tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69515997b5d483208f9ec8b404276601)