### PR TITLE
Add category selection and game lifecycle UI states

### DIFF
--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -15,7 +15,8 @@ export default function Game() {
     setTypedAnswer, 
     submitAnswer, 
     passQuestion, 
-    advanceToScoreUpdate 
+    advanceToScoreUpdate,
+    resetGame
   } = useGame();
   
   // Redirect if invalid state
@@ -27,11 +28,48 @@ export default function Game() {
 
   if (state.phase === "GAME_OVER" || !state.questions.length) {
       // Could render a nice game over screen here
+      const rankedTeams = [...state.teams].sort((a, b) => b.score - a.score);
+      const winner = rankedTeams[0];
       return (
           <div className="min-h-screen flex items-center justify-center bg-background">
-              <div className="text-center space-y-4">
-                  <h1 className="text-4xl font-bold">Game Over</h1>
-                  <Button onClick={() => setLocation("/")}>Back to Home</Button>
+              <div className="text-center space-y-6 max-w-2xl w-full px-4">
+                  <div className="space-y-2">
+                      <Badge variant="outline" className="border-primary/40 text-primary">
+                        Completed
+                      </Badge>
+                      <h1 className="text-4xl font-bold">Game Over</h1>
+                      {winner && (
+                        <p className="text-muted-foreground">
+                          Winner: <span className="text-primary font-semibold">{winner.name}</span>
+                        </p>
+                      )}
+                  </div>
+                  <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+                    <CardContent className="p-6 space-y-3">
+                      {rankedTeams.map((team, index) => (
+                        <div
+                          key={team.id}
+                          className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-4 py-3"
+                        >
+                          <div className="flex items-center gap-3">
+                            <span className="text-sm text-muted-foreground">#{index + 1}</span>
+                            <span className="font-semibold">{team.name}</span>
+                          </div>
+                          <span className="font-mono text-lg">{team.score}</span>
+                        </div>
+                      ))}
+                    </CardContent>
+                  </Card>
+                  <div className="flex justify-center">
+                      <Button
+                        onClick={() => {
+                          resetGame();
+                          setLocation("/");
+                        }}
+                      >
+                        Start New Game
+                      </Button>
+                  </div>
               </div>
           </div>
       )
@@ -49,6 +87,7 @@ export default function Game() {
 
   const activeTeam = state.teams.find(t => t.id === state.activeTeamId);
   const isReveal = state.phase === "REVEAL";
+  const statusLabel = state.phase === "GAME_OVER" ? "Completed" : "In Progress";
 
   const getDifficultyColor = (d: string) => {
     switch(d) {
@@ -95,6 +134,9 @@ export default function Game() {
                     </Badge>
                     <Badge className={`text-lg px-4 py-2 ${getDifficultyColor(currentQ.difficulty)} border-none shadow-lg`}>
                     {currentQ.difficulty}
+                    </Badge>
+                    <Badge variant="outline" className="text-lg px-4 py-2 border-primary/40 text-primary">
+                      {statusLabel}
                     </Badge>
                 </div>
                 {activeTeam && (

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,7 +10,7 @@ import { motion, AnimatePresence } from "framer-motion";
 
 export default function Home() {
   const [_, setLocation] = useLocation();
-  const { state, addTeam, removeTeam, setCountryBias, startGame } = useGame();
+  const { state, addTeam, removeTeam, setCountryBias, setCategory, startGame } = useGame();
   const [newTeamName, setNewTeamName] = useState("");
 
   const handleAddTeam = (e: React.FormEvent) => {
@@ -25,6 +25,9 @@ export default function Home() {
     startGame();
     setLocation("/game");
   };
+
+  const statusLabel =
+    state.phase === "SETUP" ? "Not Started" : state.phase === "GAME_OVER" ? "Completed" : "In Progress";
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-900 via-background to-background">
@@ -45,6 +48,11 @@ export default function Home() {
           <p className="text-muted-foreground font-medium tracking-wide">
             THE PARTY GAME
           </p>
+          <div className="flex justify-center">
+            <Badge variant="outline" className="border-primary/40 text-primary">
+              {statusLabel}
+            </Badge>
+          </div>
         </div>
 
         <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
@@ -121,6 +129,44 @@ export default function Home() {
                   className={`border-white/10 hover:bg-white/10 ${state.countryBias === bias ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
                 >
                   {bias === "Mix" ? "Global Mix" : bias}
+                </Button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              Category
+            </CardTitle>
+            <CardDescription>
+              Choose a topic for this round.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-2 max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
+              <Button
+                variant={state.selectedCategory === "All" ? "default" : "outline"}
+                onClick={() => setCategory("All")}
+                className={`border-white/10 hover:bg-white/10 ${
+                  state.selectedCategory === "All" ? "ring-2 ring-primary ring-offset-2 ring-offset-background" : ""
+                }`}
+              >
+                All Categories
+              </Button>
+              {state.categories.map((category) => (
+                <Button
+                  key={category}
+                  variant={state.selectedCategory === category ? "default" : "outline"}
+                  onClick={() => setCategory(category)}
+                  className={`border-white/10 hover:bg-white/10 ${
+                    state.selectedCategory === category
+                      ? "ring-2 ring-primary ring-offset-2 ring-offset-background"
+                      : ""
+                  }`}
+                >
+                  {category}
                 </Button>
               ))}
             </div>


### PR DESCRIPTION
### Motivation
- Provide a way to pick a question category for a game and persist available categories in state.
- Expose clear UI lifecycle states (`Not Started`, `In Progress`, `Completed`) to make the game flow explicit.
- Improve the end-of-game experience with a ranked summary and an easy path to start a new game.
- Ensure state resets and category filtering are applied when starting or resetting a game.

### Description
- Added `categories` and `selectedCategory` to `GameState`, a `setCategory` action, and a `loadCategories` helper in `GameProvider` to discover categories from the question pool and keep them up to date.  
- Filtered questions by `selectedCategory` inside `startGame`, and call `loadCategories` after `addQuestion`; also reset `selectedCategory` to `All` in `resetGame`.  
- Updated the Home setup UI (`client/src/pages/Home.tsx`) to show a lifecycle status badge and a category picker that uses `setCategory`.  
- Enhanced the Game UI (`client/src/pages/Game.tsx`) to display a status badge and to show a richer Game Over summary with ranked teams and a `Start New Game` button that calls `resetGame` and returns to Home.

### Testing
- Started the dev server with `npm run dev` and the server came up and served the app (listening output seen).  
- Ran a Playwright script to load the Home page and capture a screenshot, which succeeded and produced `artifacts/home-status-category.png`.  
- No unit tests were added or modified as part of this change.  
- All automated steps executed in the rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951652646ac832089be1eaf20ae0f40)