### PR TITLE
Add per-round score update screen

### DIFF
--- a/client/src/lib/store.tsx
+++ b/client/src/lib/store.tsx
@@ -59,6 +59,7 @@ interface GameContextType {
   submitAnswer: () => void;
   passQuestion: () => void;
   advanceToScoreUpdate: () => void;
+  continueAfterScoreUpdate: () => void;
   resetGame: () => void;
   addQuestion: (q: Question) => void;
 }
@@ -314,6 +315,12 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
 
       if (nextIndex >= prev.questions.length) {
         nextPhase = "GAME_OVER";
+      } else {
+        const questionsPerRound = updatedTeams.length * QUESTIONS_PER_TEAM_ROTATION;
+        const roundComplete = questionsPerRound > 0 && nextIndex % questionsPerRound === 0;
+        if (roundComplete) {
+          nextPhase = "SCORE_UPDATE";
+        }
       }
 
       return {
@@ -324,6 +331,16 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         activeTeamId: nextActiveTeamId,
         phase: nextPhase,
         typedAnswer: "", // Clear for next question
+      };
+    });
+  };
+
+  const continueAfterScoreUpdate = () => {
+    setState((prev) => {
+      if (prev.phase !== "SCORE_UPDATE") return prev;
+      return {
+        ...prev,
+        phase: "QUESTION"
       };
     });
   };
@@ -357,6 +374,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         submitAnswer,
         passQuestion,
         advanceToScoreUpdate,
+        continueAfterScoreUpdate,
         resetGame,
         addQuestion
       }}


### PR DESCRIPTION
### Motivation
- Pause gameplay at the end of each round to show team standings so players can review scores before continuing.
- Compute round boundaries based on the existing team rotation size to determine when to show the score update.
- Provide a clear UI to present ranked standings and a way to resume play.
- Avoid interrupting existing reveal/score application logic while inserting the summary step.

### Description
- Detect round completion in `advanceToScoreUpdate` and set the game `phase` to `SCORE_UPDATE` when a round ends by checking `questionsPerRound` and `nextIndex % questionsPerRound`.
- Add a `continueAfterScoreUpdate` action in `client/src/lib/store.tsx` and expose it via the `GameContext` to resume the `QUESTION` phase.
- Implement the score update UI in `client/src/pages/Game.tsx`, including `Round X Complete`, ranked standings, and a `START NEXT ROUND` button that calls `continueAfterScoreUpdate`.
- Adjust question rendering to handle the `SCORE_UPDATE` phase and compute `completedRounds` and `rankedTeams` for the summary view.

### Testing
- Started the dev server with `npm run dev` and executed an end-to-end Playwright script that added teams, progressed through questions by passing, and waited for the `Score Update` screen; the Playwright script succeeded and produced a screenshot artifact.
- The Playwright run verified the `Score Update` screen is rendered and the continue button is present and actionable.
- No unit tests were added for this change.
- Automated checks during the rollout (dev server launch and the Playwright scenario) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951d41397a8832090e664ad2262cb9b)