### PR TITLE
Review README before making repository public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+
+# Environment variables
+.env
+.env.*
+.env.local
+.env.production
+.env.development


### PR DESCRIPTION
Explicitly exclude environment variable files to prevent accidental exposure of sensitive credentials when making repository public.