### PR TITLE
feat(STE-132): SNES Cloud Kingdom Home screen reskin

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -18,7 +18,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Outfit:wght@100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Outfit:wght@100..900&family=Press+Start+2P&family=Luckiest+Guy&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/snes/BevelButton.tsx
+++ b/client/src/components/snes/BevelButton.tsx
@@ -1,0 +1,77 @@
+import { FONT_STACKS } from './tokens';
+
+/** Beveled pixel-art button with Press Start 2P font and two-tone gradient */
+export function BevelButton({
+  children,
+  bgTop,
+  bgBottom,
+  borderColor,
+  highlightColor,
+  shadowColor,
+  width,
+  height,
+  fontSize,
+  className = '',
+  ...rest
+}: {
+  children: React.ReactNode;
+  bgTop: string;
+  bgBottom: string;
+  borderColor: string;
+  highlightColor: string;
+  shadowColor: string;
+  width: string | number;
+  height: number;
+  fontSize: number;
+  className?: string;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={`active:translate-y-1 cursor-pointer ${className}`}
+      style={{
+        position: 'relative',
+        width,
+        height,
+        borderRadius: 6,
+        border: `4px solid ${borderColor}`,
+        background: `linear-gradient(180deg, ${bgTop} 0%, ${bgTop} 48%, ${bgBottom} 52%, ${bgBottom} 100%)`,
+        boxShadow: `
+          0 6px 0 ${borderColor},
+          inset 0 3px 0 ${highlightColor},
+          inset 0 -3px 0 ${shadowColor}
+        `,
+        cursor: 'pointer',
+        transition: 'transform 0.1s',
+        padding: 0,
+        display: 'grid',
+        placeItems: 'center',
+      }}
+      {...rest}
+    >
+      <span
+        style={{
+          fontFamily: FONT_STACKS.pixel,
+          fontSize,
+          lineHeight: 1.4,
+          color: '#fff',
+          textShadow: `
+            -2px -2px 0 ${borderColor},
+             2px -2px 0 ${borderColor},
+            -2px  2px 0 ${borderColor},
+             2px  2px 0 ${borderColor},
+             0   -2px 0 ${borderColor},
+             0    2px 0 ${borderColor},
+            -2px  0   0 ${borderColor},
+             2px  0   0 ${borderColor},
+             0    4px 0 rgba(0,0,0,.25)
+          `,
+          textTransform: 'uppercase' as const,
+          textAlign: 'center' as const,
+          letterSpacing: 1,
+        }}
+      >
+        {children}
+      </span>
+    </button>
+  );
+}

--- a/client/src/components/snes/CSSAvatar.tsx
+++ b/client/src/components/snes/CSSAvatar.tsx
@@ -1,0 +1,63 @@
+/** 32×32 CSS-only character sprite with colored cap */
+export function CSSAvatar({ capColor }: { capColor: string }) {
+  return (
+    <div
+      style={{
+        width: 32,
+        height: 32,
+        borderRadius: 3,
+        background: 'linear-gradient(180deg, #8fb3ff 0%, #5d7fd8 100%)',
+        border: '2px solid rgba(0,0,0,.15)',
+        position: 'relative',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,.18)',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          left: 5,
+          top: 5,
+          width: 22,
+          height: 10,
+          borderRadius: '10px 10px 3px 3px',
+          background: capColor,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: 6,
+          top: 11,
+          width: 16,
+          height: 3,
+          borderRadius: 2,
+          background: 'rgba(0,0,0,.2)',
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: 8,
+          top: 10,
+          width: 16,
+          height: 14,
+          background: '#f1c292',
+          borderRadius: '7px 7px 5px 5px',
+          boxShadow: 'inset 0 -2px 0 rgba(0,0,0,.08)',
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: 9,
+          top: 18,
+          width: 12,
+          height: 4,
+          borderRadius: 4,
+          background: '#6a3d19',
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/components/snes/CloudKingdomBg.tsx
+++ b/client/src/components/snes/CloudKingdomBg.tsx
@@ -1,0 +1,138 @@
+/** Full Cloud Kingdom background scene — clouds, islands, and bottom haze */
+export function CloudKingdomBg() {
+  return (
+    <div className="fixed inset-0 pointer-events-none z-0 overflow-hidden">
+      {/* Fluffy clouds */}
+      <Cloud
+        style={{ width: 82, height: 23, left: -4, top: '14%' }}
+        bumps={[
+          { w: 30, h: 30, left: 5, top: -13 },
+          { w: 35, h: 35, left: 28, top: -16 },
+        ]}
+      />
+      <Cloud
+        style={{ width: 105, height: 25, right: -4, top: '12%' }}
+        bumps={[
+          { w: 32, h: 32, left: 8, top: -14 },
+          { w: 41, h: 41, left: 30, top: -19 },
+        ]}
+      />
+      <Cloud
+        style={{ width: 82, height: 23, left: '32%', top: '32%', opacity: 0.92 }}
+        bumps={[
+          { w: 27, h: 27, left: 11, top: -12 },
+          { w: 35, h: 35, left: 30, top: -17 },
+        ]}
+      />
+      <Cloud
+        style={{ width: 135, height: 34, left: -22, bottom: '16%', opacity: 0.9 }}
+        bumps={[
+          { w: 46, h: 46, left: 14, top: -19 },
+          { w: 58, h: 58, left: 43, top: -25 },
+        ]}
+      />
+      <Cloud
+        style={{ width: 120, height: 31, right: -20, bottom: '26%', opacity: 0.9 }}
+        bumps={[
+          { w: 43, h: 43, left: 14, top: -18 },
+          { w: 55, h: 55, left: 48, top: -23 },
+        ]}
+      />
+
+      {/* Floating islands */}
+      <Island style={{ right: 20, top: '22%', transform: 'scale(.5)' }} />
+      <Island style={{ left: -5, bottom: '30%', transform: 'scale(.62)' }} />
+      <Island style={{ right: -5, bottom: '24%', transform: 'scale(.9) rotate(-2deg)' }} />
+
+      {/* Bottom haze */}
+      <div
+        className="absolute left-0 right-0 bottom-0"
+        style={{
+          height: '28%',
+          background:
+            'linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.10) 30%, rgba(255,255,255,.28) 100%)',
+        }}
+      />
+    </div>
+  );
+}
+
+/* ── Private helpers ── */
+
+function Cloud({
+  style,
+  bumps,
+}: {
+  style: React.CSSProperties;
+  bumps: { w: number; h: number; left: number; top: number }[];
+}) {
+  const cloudStyle: React.CSSProperties = {
+    ...style,
+    position: 'absolute',
+    background: '#f7fcff',
+    borderRadius: 999,
+    boxShadow: 'inset 0 -4px 0 rgba(190,220,245,.85)',
+  };
+  return (
+    <div style={cloudStyle}>
+      {bumps.map((b, i) => (
+        <div
+          key={i}
+          style={{
+            position: 'absolute',
+            width: b.w,
+            height: b.h,
+            left: b.left,
+            top: b.top,
+            background: 'inherit',
+            borderRadius: 'inherit',
+            boxShadow: 'inherit',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Island({ style }: { style: React.CSSProperties }) {
+  return (
+    <div
+      className="absolute"
+      style={{
+        ...style,
+        width: 85,
+        height: 55,
+        background:
+          'linear-gradient(180deg, #8cd44d 0%, #57ab39 32%, #63a83d 35%, #8e5d3c 36%, #8e5d3c 55%, #71452e 100%)',
+        clipPath:
+          'polygon(5% 28%, 23% 8%, 62% 8%, 82% 30%, 96% 35%, 100% 53%, 91% 76%, 72% 90%, 34% 100%, 10% 84%, 0 57%)',
+        filter: 'drop-shadow(0 5px 0 rgba(0,0,0,.18))',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          left: 20,
+          top: -9,
+          width: 11,
+          height: 19,
+          background: '#7d5a35',
+          borderRadius: '50% 50% 35% 35%',
+          boxShadow: '1px 0 0 rgba(0,0,0,.08)',
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: 12,
+          top: -17,
+          width: 27,
+          height: 16,
+          background: '#63ad45',
+          borderRadius: '50% 50% 35% 35%',
+          boxShadow: '7px 1px 0 -5px #76bf54',
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/components/snes/GamePanel.tsx
+++ b/client/src/components/snes/GamePanel.tsx
@@ -1,0 +1,41 @@
+import { gamePanel, panelHeader, pixelText } from './tokens';
+
+/** Blue gradient SNES window panel */
+export function GamePanel({
+  children,
+  className = '',
+  style,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <section className={className} style={{ ...gamePanel, padding: '18px 14px 20px', ...style }}>
+      {children}
+    </section>
+  );
+}
+
+/** Panel section header bar */
+export function GamePanelHeader({
+  children,
+  height = 52,
+}: {
+  children: React.ReactNode;
+  height?: number;
+}) {
+  return (
+    <div className="grid place-items-center mb-4" style={{ ...panelHeader, height }}>
+      <h2
+        style={{
+          ...pixelText,
+          fontSize: height > 44 ? 26 : 18,
+          WebkitTextStroke: height > 44 ? '3px #11204d' : '2px #11204d',
+        }}
+      >
+        {children}
+      </h2>
+    </div>
+  );
+}

--- a/client/src/components/snes/StatusOrb.tsx
+++ b/client/src/components/snes/StatusOrb.tsx
@@ -1,0 +1,15 @@
+/** Red radial-gradient status indicator (14px) */
+export function StatusOrb() {
+  return (
+    <div
+      style={{
+        width: 14,
+        height: 14,
+        borderRadius: '50%',
+        background:
+          'radial-gradient(circle at 35% 35%, #ff8f8f 0%, #fa3232 45%, #b00010 80%, #7f000e 100%)',
+        boxShadow: '0 0 0 2px rgba(255,255,255,.06), 0 2px 6px rgba(255,0,0,.35)',
+      }}
+    />
+  );
+}

--- a/client/src/components/snes/index.ts
+++ b/client/src/components/snes/index.ts
@@ -1,0 +1,16 @@
+export {
+  SNES_COLORS,
+  CAP_COLORS,
+  SKY_GRADIENT,
+  FONT_STACKS,
+  pixelText,
+  gamePanel,
+  panelHeader,
+  teamRow,
+  btnBase,
+} from './tokens';
+export { CloudKingdomBg } from './CloudKingdomBg';
+export { BevelButton } from './BevelButton';
+export { GamePanel, GamePanelHeader } from './GamePanel';
+export { CSSAvatar } from './CSSAvatar';
+export { StatusOrb } from './StatusOrb';

--- a/client/src/components/snes/tokens.ts
+++ b/client/src/components/snes/tokens.ts
@@ -1,0 +1,71 @@
+/** SNES Cloud Kingdom design tokens — no React dependency */
+
+/** Color palette for gradients and accents */
+export const SNES_COLORS = {
+  red1: '#ff655d',
+  red2: '#df2e36',
+  red3: '#a80e18',
+  green1: '#74ec57',
+  green2: '#39bf36',
+  green3: '#1f7d25',
+} as const;
+
+/** Avatar cap color rotation */
+export const CAP_COLORS = ['#df302d', '#42b44d', '#9d6031', '#3366cc', '#9D50BB', '#f39c12'];
+
+/** Sky background gradient */
+export const SKY_GRADIENT = 'linear-gradient(180deg, #1f78e4 0%, #4aa6ff 42%, #d6f0ff 100%)';
+
+/** Font family stacks */
+export const FONT_STACKS = {
+  title: "'Luckiest Guy', sans-serif",
+  pixel: "'Press Start 2P', cursive",
+  display: "Impact, Haettenschweiler, 'Arial Black', sans-serif",
+} as const;
+
+/** Impact font, uppercase, text-stroke — used for panel headers and labels */
+export const pixelText: React.CSSProperties = {
+  fontFamily: FONT_STACKS.display,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '1px',
+  color: '#fff',
+  WebkitTextStroke: '2px #11204d',
+  textShadow: '0 4px 0 rgba(0,0,0,0.3)',
+};
+
+/** Blue gradient panel — black border, inset glow, drop shadow */
+export const gamePanel: React.CSSProperties = {
+  border: '6px solid #111',
+  borderRadius: 14,
+  background: 'linear-gradient(180deg, #4565df 0%, #2f57c9 20%, #234ebd 100%)',
+  boxShadow: '0 8px 0 rgba(0,0,0,.28), inset 0 0 0 4px #dfe6ff',
+};
+
+/** Panel section header — gradient with inner highlight */
+export const panelHeader: React.CSSProperties = {
+  borderRadius: 6,
+  border: '4px solid rgba(0,0,0,.28)',
+  background: 'linear-gradient(180deg, #2a63f0 0%, #355ad4 100%)',
+  boxShadow: 'inset 0 3px 0 rgba(255,255,255,.18)',
+};
+
+/** Dark navy gradient row */
+export const teamRow: React.CSSProperties = {
+  borderRadius: 4,
+  background: 'linear-gradient(180deg, rgba(18,52,132,.95), rgba(14,44,115,.95))',
+  boxShadow: 'inset 0 2px 0 rgba(255,255,255,.08)',
+};
+
+/** Tactile 3D button base — Impact font, used for in-panel buttons (REMOVE, ADD TEAM) */
+export const btnBase: React.CSSProperties = {
+  fontFamily: FONT_STACKS.display,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '1px',
+  color: '#fff',
+  borderRadius: 10,
+  border: '4px solid rgba(0,0,0,.38)',
+  boxShadow: '0 8px 0 rgba(0,0,0,.28), inset 0 3px 0 rgba(255,255,255,.18)',
+  cursor: 'pointer',
+  userSelect: 'none' as const,
+  transition: 'transform 0.1s',
+};

--- a/client/src/pages/Home.test.tsx
+++ b/client/src/pages/Home.test.tsx
@@ -77,24 +77,6 @@ vi.mock('wouter', () => ({
   useLocation: () => ['/', vi.fn()],
 }));
 
-vi.mock('@/hooks/use-auth', () => ({
-  useAuth: () => ({
-    user: null,
-    isLoading: false,
-    isAuthenticated: false,
-    logout: vi.fn(),
-    isLoggingOut: false,
-  }),
-}));
-
-vi.mock('@/hooks/use-admin', () => ({
-  useAdmin: () => ({
-    isAdmin: false,
-    isLoading: false,
-    error: null,
-  }),
-}));
-
 // Mock framer-motion to avoid animation issues in tests
 vi.mock('framer-motion', () => ({
   motion: {
@@ -125,7 +107,7 @@ function renderHome() {
 }
 
 // ---------------------------------------------------------------------------
-// BUG #1 REGRESSION: Category selection must be visible on the setup screen
+// Tests for SNES-themed Home screen
 // ---------------------------------------------------------------------------
 
 describe('Home page', () => {
@@ -139,32 +121,9 @@ describe('Home page', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders the Category section heading', async () => {
+  it('renders the Team Setup panel header', () => {
     renderHome();
-    expect(await screen.findByText('Category')).toBeDefined();
-  });
-
-  it('renders the "All" category button with a count', async () => {
-    renderHome();
-    expect(await screen.findByRole('button', { name: /^All\s*\(\d+\)$/ })).toBeDefined();
-  });
-
-  it('renders individual category buttons from loaded questions', async () => {
-    renderHome();
-    expect(
-      await screen.findByRole('button', { name: /Geography\s*\(\d+\)/ }, { timeout: 3000 })
-    ).toBeDefined();
-    expect(
-      await screen.findByRole('button', { name: /Science\s*\(\d+\)/ }, { timeout: 3000 })
-    ).toBeDefined();
-    expect(
-      await screen.findByRole('button', { name: /History\s*\(\d+\)/ }, { timeout: 3000 })
-    ).toBeDefined();
-  });
-
-  it('renders the Team Setup section', () => {
-    renderHome();
-    expect(screen.getByText('Team Setup')).toBeDefined();
+    expect(screen.getByText('TEAM SETUP')).toBeDefined();
   });
 
   it('renders the start game button (disabled with no teams)', () => {
@@ -174,11 +133,24 @@ describe('Home page', () => {
     expect(startButton.hasAttribute('disabled')).toBe(true);
   });
 
-  it('renders round selection buttons', () => {
+  it('renders the admin button', () => {
     renderHome();
-    expect(screen.getByText('5')).toBeDefined();
-    expect(screen.getByText('10')).toBeDefined();
-    expect(screen.getByText('15')).toBeDefined();
-    expect(screen.getByText('20')).toBeDefined();
+    const adminButton = screen.getByTestId('link-admin');
+    expect(adminButton).toBeDefined();
+  });
+
+  it('shows empty state when no teams added', () => {
+    renderHome();
+    expect(screen.getByText('NO TEAMS YET')).toBeDefined();
+  });
+
+  it('renders the add team input', () => {
+    renderHome();
+    expect(screen.getByPlaceholderText('TEAM NAME...')).toBeDefined();
+  });
+
+  it('renders the TRIVIA CLASH title', () => {
+    renderHome();
+    expect(screen.getByText('TRIVIA CLASH')).toBeDefined();
   });
 });

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,34 +1,26 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'wouter';
 import { useGame } from '@/lib/store';
-import { useAuth } from '@/hooks/use-auth';
-import { useAdmin } from '@/hooks/use-admin';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { X, Plus, Settings, Users, Zap, LogIn, LogOut, Shield, AlertTriangle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import {
+  SNES_COLORS,
+  CAP_COLORS,
+  SKY_GRADIENT,
+  pixelText,
+  teamRow,
+  btnBase,
+  CloudKingdomBg,
+  BevelButton,
+  GamePanel,
+  GamePanelHeader,
+  CSSAvatar,
+  StatusOrb,
+} from '@/components/snes';
 
 export default function Home() {
   const [_, setLocation] = useLocation();
-  const { state, addTeam, removeTeam, setCategory, setNumRounds, startGame } = useGame();
-  const { user, isAuthenticated, logout } = useAuth();
-  const { isAdmin } = useAdmin();
+  const { state, addTeam, removeTeam, startGame } = useGame();
   const [newTeamName, setNewTeamName] = useState('');
-
-  const categoryCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    state.questions.forEach((q) => {
-      counts[q.category] = (counts[q.category] || 0) + 1;
-    });
-    counts['All'] = state.questions.length;
-    return counts;
-  }, [state.questions]);
-
-  const totalNeeded = state.numRounds * state.teams.length;
-  const availableCount = categoryCounts[state.selectedCategory] || 0;
-  const hasInsufficientQuestions = state.teams.length >= 2 && availableCount < totalNeeded && availableCount > 0;
 
   const handleAddTeam = (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,225 +35,264 @@ export default function Home() {
     setLocation('/game');
   };
 
-  const statusLabel =
-    state.phase === 'SETUP'
-      ? 'Not Started'
-      : state.phase === 'GAME_OVER'
-        ? 'Completed'
-        : 'In Progress';
-
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-900 via-background to-background">
-      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
-        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-primary/20 rounded-full blur-[120px] opacity-50" />
-        <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] bg-blue-500/10 rounded-full blur-[120px] opacity-50" />
-      </div>
+    <main
+      className="min-h-screen flex flex-col items-center justify-between pb-8 pt-12 overflow-y-auto"
+      style={{ background: SKY_GRADIENT, fontFamily: 'Arial, Helvetica, sans-serif' }}
+    >
+      <CloudKingdomBg />
 
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="w-full max-w-md z-10 space-y-8"
-      >
-        <div className="text-center space-y-2">
-          <h1 className="text-6xl font-extrabold tracking-tighter bg-gradient-to-br from-white to-white/50 bg-clip-text text-transparent drop-shadow-sm">
-            TRIVIA
-            <br />
-            CLASH
-          </h1>
-          <p className="text-muted-foreground font-medium tracking-wide">
-            THE COMPETITIVE PARTY GAME
-          </p>
-          <div className="flex justify-center">
-            <Badge variant="outline" className="border-primary/40 text-primary">
-              {statusLabel}
-            </Badge>
-          </div>
+      {/* ── Header: 3D Bubbly Gold Title (SVG) ── */}
+      <header className="w-full flex justify-center mb-4 z-10 px-4">
+        <div className="w-full max-w-md">
+          <h1 className="sr-only">TRIVIA CLASH</h1>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 800 450"
+            width="100%"
+            aria-hidden="true"
+          >
+            <defs>
+              <style>{`
+                @import url('https://fonts.googleapis.com/css2?family=Luckiest+Guy&display=swap');
+                .title-text {
+                  font-family: 'Luckiest Guy', sans-serif;
+                  text-anchor: middle;
+                  dominant-baseline: central;
+                  letter-spacing: 2px;
+                }
+                .word-top { font-size: 130px; }
+                .word-bottom { font-size: 155px; }
+                .layer-shadow {
+                  fill: #15295e;
+                  stroke: #15295e;
+                  stroke-width: 45px;
+                  stroke-linejoin: round;
+                }
+                .layer-extrusion {
+                  fill: #2d62c3;
+                  stroke: #2d62c3;
+                  stroke-width: 45px;
+                  stroke-linejoin: round;
+                }
+                .layer-outline {
+                  fill: #15295e;
+                  stroke: #15295e;
+                  stroke-width: 16px;
+                  stroke-linejoin: round;
+                }
+                .layer-face {
+                  fill: url(#goldGradient);
+                }
+              `}</style>
+              <linearGradient id="goldGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#ffee73" />
+                <stop offset="35%" stopColor="#ffc824" />
+                <stop offset="70%" stopColor="#fa9c00" />
+                <stop offset="100%" stopColor="#e36300" />
+              </linearGradient>
+            </defs>
+            <g transform="translate(400, 140)" role="text" aria-label="TRIVIA">
+              <text className="title-text word-top layer-shadow" y="22">
+                TRIVIA
+              </text>
+              <text className="title-text word-top layer-extrusion" y="11">
+                TRIVIA
+              </text>
+              <text className="title-text word-top layer-outline" y="0">
+                TRIVIA
+              </text>
+              <text className="title-text word-top layer-face" y="0">
+                TRIVIA
+              </text>
+            </g>
+            <g transform="translate(400, 270)" role="text" aria-label="CLASH">
+              <text className="title-text word-bottom layer-shadow" y="22">
+                CLASH
+              </text>
+              <text className="title-text word-bottom layer-extrusion" y="11">
+                CLASH
+              </text>
+              <text className="title-text word-bottom layer-outline" y="0">
+                CLASH
+              </text>
+              <text className="title-text word-bottom layer-face" y="0">
+                CLASH
+              </text>
+            </g>
+          </svg>
         </div>
+      </header>
 
-        <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-xl">
-              <Users className="w-5 h-5 text-primary" />
-              Team Setup
-            </CardTitle>
-            <CardDescription>Add 2-6 teams to begin.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <form onSubmit={handleAddTeam} className="flex gap-2">
-              <Input
-                placeholder="Enter team name..."
-                value={newTeamName}
-                onChange={(e) => setNewTeamName(e.target.value)}
-                className="bg-white/5 border-white/10 focus:border-primary/50 text-lg py-6"
-                autoFocus
-              />
-              <Button
-                type="submit"
-                size="icon"
-                className="h-12 w-12 shrink-0 rounded-xl"
-                disabled={!newTeamName.trim() || state.teams.length >= 6}
+      {/* ── Team Setup Panel ── */}
+      <GamePanel className="w-11/12 max-w-md flex flex-col z-10">
+        <GamePanelHeader>TEAM SETUP</GamePanelHeader>
+
+        <div className="space-y-3">
+          <AnimatePresence mode="popLayout">
+            {state.teams.map((team, i) => (
+              <motion.div
+                key={team.id}
+                layout
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.9 }}
               >
-                <Plus className="w-6 h-6" />
-              </Button>
-            </form>
-
-            <div className="space-y-2 max-h-[300px] overflow-y-auto pr-2 custom-scrollbar">
-              <AnimatePresence mode="popLayout">
-                {state.teams.map((team) => (
-                  <motion.div
-                    key={team.id}
-                    layout
-                    initial={{ opacity: 0, scale: 0.9 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.9 }}
-                    className="flex items-center justify-between p-3 rounded-lg bg-white/5 border border-white/5 group"
-                  >
-                    <span className="font-medium text-lg truncate px-2">{team.name}</span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => removeTeam(team.id)}
-                      className="opacity-0 group-hover:opacity-100 transition-opacity hover:bg-destructive/20 hover:text-destructive"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </motion.div>
-                ))}
-              </AnimatePresence>
-
-              {state.teams.length === 0 && (
-                <div className="text-center py-8 text-muted-foreground italic border-2 border-dashed border-white/5 rounded-lg">
-                  No teams added yet
+                <div className="mb-1 pl-3" style={{ ...pixelText, fontSize: 16 }}>
+                  TEAM {i + 1}
                 </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-lg">Category</CardTitle>
-            <CardDescription>Choose a topic for this round.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-2 max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
-              <Button
-                variant={state.selectedCategory === 'All' ? 'default' : 'outline'}
-                onClick={() => setCategory('All')}
-                className={`border-white/10 hover:bg-white/10 ${
-                  state.selectedCategory === 'All'
-                    ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
-                    : ''
-                }`}
-              >
-                All ({categoryCounts['All'] || 0})
-              </Button>
-              {state.categories.filter((c) => c !== 'All').map((category) => (
-                <Button
-                  key={category}
-                  variant={state.selectedCategory === category ? 'default' : 'outline'}
-                  onClick={() => setCategory(category)}
-                  className={`border-white/10 hover:bg-white/10 ${
-                    state.selectedCategory === category
-                      ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
-                      : ''
-                  }`}
+                <div
+                  className="flex items-center justify-between relative overflow-hidden"
+                  style={{ ...teamRow, minHeight: 64, padding: '10px 12px' }}
                 >
-                  {category} ({categoryCounts[category] || 0})
-                </Button>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+                  {/* Diagonal shine overlay */}
+                  <div
+                    className="absolute pointer-events-none"
+                    style={{
+                      right: 120,
+                      top: 0,
+                      width: 70,
+                      height: '100%',
+                      background:
+                        'linear-gradient(135deg, transparent 0% 30%, rgba(255,255,255,.05) 30% 55%, transparent 55%)',
+                      opacity: 0.6,
+                    }}
+                  />
+                  <div className="flex items-center gap-3 min-w-0">
+                    <CSSAvatar capColor={CAP_COLORS[i % CAP_COLORS.length]} />
+                    <span
+                      className="font-extrabold truncate"
+                      style={{
+                        color: '#fff',
+                        fontSize: 14,
+                        textShadow: '0 2px 0 rgba(0,0,0,.32)',
+                        maxWidth: 140,
+                      }}
+                    >
+                      {team.name}
+                    </span>
+                  </div>
+                  <div className="flex flex-col items-start gap-2 ml-3 shrink-0">
+                    <div className="flex items-center gap-2">
+                      <StatusOrb />
+                      <span
+                        style={{ ...pixelText, fontSize: 12, WebkitTextStroke: '1.5px #11204d' }}
+                      >
+                        NOT STARTED
+                      </span>
+                    </div>
+                    <button
+                      onClick={() => removeTeam(team.id)}
+                      className="active:translate-y-1"
+                      style={{
+                        ...btnBase,
+                        fontSize: 13,
+                        WebkitTextStroke: '1.5px #5b0005',
+                        textShadow: '0 3px 0 rgba(0,0,0,.25)',
+                        background: `linear-gradient(180deg, ${SNES_COLORS.red1} 0%, ${SNES_COLORS.red2} 55%, ${SNES_COLORS.red3} 100%)`,
+                        padding: '6px 16px',
+                        width: 110,
+                      }}
+                    >
+                      REMOVE
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
 
-        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-lg">
-              <Zap className="w-4 h-4 text-primary" />
-              Number of Rounds
-            </CardTitle>
-            <CardDescription>How many questions to play.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-4 gap-2">
-              {[5, 10, 15, 20].map((rounds) => (
-                <Button
-                  key={rounds}
-                  variant={state.numRounds === rounds ? 'default' : 'outline'}
-                  onClick={() => setNumRounds(rounds)}
-                  className={`border-white/10 hover:bg-white/10 ${state.numRounds === rounds ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
-                >
-                  {rounds}
-                </Button>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        <div className="space-y-4">
-          {hasInsufficientQuestions && (
+          {state.teams.length === 0 && (
             <div
-              className="flex items-start gap-3 p-4 rounded-xl bg-yellow-500/10 border border-yellow-500/30 text-yellow-200 text-sm"
-              data-testid="warning-insufficient-questions"
+              className="text-center py-8"
+              style={{ ...pixelText, fontSize: 14, color: 'rgba(255,255,255,0.4)' }}
             >
-              <AlertTriangle className="w-5 h-5 text-yellow-400 shrink-0 mt-0.5" />
-              <div>
-                <p className="font-semibold text-yellow-300">Not enough questions</p>
-                <p className="mt-1">
-                  {state.selectedCategory === 'All' ? 'All categories have' : `"${state.selectedCategory}" has`} only{' '}
-                  <span className="font-bold">{availableCount}</span> question{availableCount !== 1 ? 's' : ''}, but your
-                  setup needs <span className="font-bold">{totalNeeded}</span> ({state.numRounds} rounds × {state.teams.length} teams).
-                  The game will use all {availableCount} available.
-                </p>
-              </div>
+              NO TEAMS YET
             </div>
           )}
-          <Button
-            className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
-            disabled={state.teams.length < 2}
-            onClick={handleStart}
-            data-testid="button-start-game"
-          >
-            START GAME
-          </Button>
 
-          <div className="flex justify-center gap-4 items-center flex-wrap">
-            {isAuthenticated && isAdmin && (
-              <Button
-                variant="link"
-                className="text-muted-foreground text-xs"
-                onClick={() => setLocation('/admin')}
-                data-testid="link-admin"
+          <div>
+            <div className="mb-1 pl-3" style={{ ...pixelText, fontSize: 16 }}>
+              ADD TEAM
+            </div>
+            <form
+              onSubmit={handleAddTeam}
+              className="flex items-center justify-between"
+              style={{ ...teamRow, minHeight: 64, padding: '10px 12px' }}
+            >
+              <input
+                placeholder="TEAM NAME..."
+                value={newTeamName}
+                onChange={(e) => setNewTeamName(e.target.value)}
+                className="bg-transparent outline-none flex-1 min-w-0 mr-3"
+                style={{
+                  ...pixelText,
+                  fontSize: 14,
+                  WebkitTextStroke: '0px transparent',
+                  textShadow: 'none',
+                  color: '#fff',
+                  borderBottom: '2px solid rgba(255,255,255,.2)',
+                  padding: '4px 0',
+                }}
+                autoFocus
+              />
+              <button
+                type="submit"
+                disabled={!newTeamName.trim() || state.teams.length >= 6}
+                className="active:translate-y-1 disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
+                style={{
+                  ...btnBase,
+                  fontSize: 13,
+                  WebkitTextStroke: '1.5px #5b0005',
+                  textShadow: '0 3px 0 rgba(0,0,0,.25)',
+                  background: `linear-gradient(180deg, ${SNES_COLORS.red1} 0%, ${SNES_COLORS.red2} 55%, ${SNES_COLORS.red3} 100%)`,
+                  padding: '6px 16px',
+                  width: 110,
+                }}
               >
-                <Shield className="w-3 h-3 mr-1" />
-                Admin Panel
-              </Button>
-            )}
-
-            {isAuthenticated ? (
-              <Button
-                variant="link"
-                className="text-muted-foreground text-xs"
-                onClick={() => logout()}
-                data-testid="button-logout"
-              >
-                <LogOut className="w-3 h-3 mr-1" />
-                Sign Out ({user?.email?.split('@')[0]})
-              </Button>
-            ) : (
-              <Button
-                variant="link"
-                className="text-muted-foreground text-xs"
-                onClick={() => (window.location.href = '/api/login')}
-                data-testid="button-login"
-              >
-                <LogIn className="w-3 h-3 mr-1" />
-                Sign In
-              </Button>
-            )}
+                ADD TEAM
+              </button>
+            </form>
           </div>
         </div>
-      </motion.div>
-    </div>
+      </GamePanel>
+
+      {/* ── Primary Action Buttons ── */}
+      <section className="w-11/12 max-w-md flex items-end justify-between gap-3 mt-4 z-10">
+        <BevelButton
+          className="disabled:opacity-40 disabled:cursor-not-allowed"
+          bgTop="#fdd835"
+          bgBottom="#e08a0e"
+          borderColor="#8b5e0a"
+          highlightColor="rgba(255,245,180,.55)"
+          shadowColor="rgba(120,70,0,.5)"
+          width="60%"
+          height={86}
+          fontSize={20}
+          disabled={state.teams.length < 2}
+          onClick={handleStart}
+          data-testid="button-start-game"
+        >
+          QUICK
+          <br />
+          PLAY
+        </BevelButton>
+
+        <BevelButton
+          bgTop="#5cdb5c"
+          bgBottom="#238b23"
+          borderColor="#145214"
+          highlightColor="rgba(200,255,200,.45)"
+          shadowColor="rgba(10,60,10,.5)"
+          width="38%"
+          height={56}
+          fontSize={14}
+          onClick={() => setLocation('/admin')}
+          data-testid="link-admin"
+        >
+          ADMIN
+        </BevelButton>
+      </section>
+    </main>
   );
 }

--- a/docs/guides/snes_design_system.md
+++ b/docs/guides/snes_design_system.md
@@ -1,0 +1,180 @@
+# SNES Cloud Kingdom Design System
+
+Reference guide for the retro SNES-inspired UI theme used across the Trivia Clash app.
+
+**Import path:** `@/components/snes`
+
+**Required fonts** (loaded in `client/index.html`):
+
+- [Luckiest Guy](https://fonts.google.com/specimen/Luckiest+Guy) — SVG title only
+- [Press Start 2P](https://fonts.google.com/specimen/Press+Start+2P) — BevelButton text
+- Impact (system font) — panel headers, labels, status text
+
+---
+
+## Color Palette
+
+| Token                | Hex                           | Usage                          |
+| -------------------- | ----------------------------- | ------------------------------ |
+| `SNES_COLORS.red1`   | `#ff655d`                     | Button gradient top (red)      |
+| `SNES_COLORS.red2`   | `#df2e36`                     | Button gradient mid (red)      |
+| `SNES_COLORS.red3`   | `#a80e18`                     | Button gradient bottom (red)   |
+| `SNES_COLORS.green1` | `#74ec57`                     | Button gradient top (green)    |
+| `SNES_COLORS.green2` | `#39bf36`                     | Button gradient mid (green)    |
+| `SNES_COLORS.green3` | `#1f7d25`                     | Button gradient bottom (green) |
+| Panel blue           | `#4565df → #2f57c9 → #234ebd` | Panel background gradient      |
+| Panel border         | `#111`                        | Panel outer border             |
+| Panel glow           | `#dfe6ff`                     | Inner glow (4px inset)         |
+| Sky top              | `#1f78e4`                     | Sky gradient start             |
+| Sky mid              | `#4aa6ff`                     | Sky gradient middle            |
+| Sky bottom           | `#d6f0ff`                     | Sky gradient end               |
+
+---
+
+## Typography Styles
+
+### `pixelText` — Panel headers and labels
+
+- Font: Impact (via `FONT_STACKS.display`)
+- Uppercase, 1px letter spacing
+- White text with `2px #11204d` text-stroke
+- `4px` downward text shadow
+
+### `FONT_STACKS.pixel` — BevelButton text
+
+- Font: `'Press Start 2P', cursive`
+- Used exclusively inside `BevelButton` component
+- White text with 8-directional outline via `text-shadow`
+
+### `FONT_STACKS.title` — SVG title
+
+- Font: `'Luckiest Guy', sans-serif`
+- 4-layer SVG technique: shadow → extrusion → outline → gold gradient face
+
+---
+
+## Components
+
+### `CloudKingdomBg`
+
+Full-page background scene with clouds, floating islands, and bottom haze.
+
+```tsx
+import { CloudKingdomBg, SKY_GRADIENT } from '@/components/snes';
+
+<main style={{ background: SKY_GRADIENT }}>
+  <CloudKingdomBg />
+  {/* page content with z-10 */}
+</main>;
+```
+
+### `BevelButton`
+
+Primary CTA button with Press Start 2P font, two-tone gradient, and 3D bevel.
+
+```tsx
+import { BevelButton } from '@/components/snes';
+
+// Gold (Quick Play)
+<BevelButton
+  bgTop="#fdd835" bgBottom="#e08a0e" borderColor="#8b5e0a"
+  highlightColor="rgba(255,245,180,.55)" shadowColor="rgba(120,70,0,.5)"
+  width="60%" height={86} fontSize={20}
+>
+  QUICK PLAY
+</BevelButton>
+
+// Green (Admin)
+<BevelButton
+  bgTop="#5cdb5c" bgBottom="#238b23" borderColor="#145214"
+  highlightColor="rgba(200,255,200,.45)" shadowColor="rgba(10,60,10,.5)"
+  width="38%" height={56} fontSize={14}
+>
+  ADMIN
+</BevelButton>
+
+// Red (destructive)
+<BevelButton
+  bgTop="#ff655d" bgBottom="#a80e18" borderColor="#5b0005"
+  highlightColor="rgba(255,200,200,.4)" shadowColor="rgba(80,0,0,.5)"
+  width={120} height={48} fontSize={12}
+>
+  DELETE
+</BevelButton>
+```
+
+### `GamePanel` / `GamePanelHeader`
+
+Blue gradient content container with optional section header.
+
+```tsx
+import { GamePanel, GamePanelHeader } from '@/components/snes';
+
+<GamePanel className="w-11/12 max-w-md flex flex-col z-10">
+  <GamePanelHeader>TEAM SETUP</GamePanelHeader>
+  {/* panel content */}
+</GamePanel>;
+```
+
+### `CSSAvatar`
+
+32×32 CSS-only character sprite with colored cap.
+
+```tsx
+import { CSSAvatar, CAP_COLORS } from '@/components/snes';
+
+<CSSAvatar capColor={CAP_COLORS[index % CAP_COLORS.length]} />;
+```
+
+### `StatusOrb`
+
+14px red radial-gradient status indicator.
+
+```tsx
+import { StatusOrb } from '@/components/snes';
+
+<StatusOrb />;
+```
+
+---
+
+## Panel Styles (raw tokens)
+
+For custom panel layouts, import the style objects directly:
+
+```tsx
+import { gamePanel, panelHeader, teamRow, btnBase, pixelText } from '@/components/snes';
+
+// Apply as inline styles
+<div style={{ ...teamRow, minHeight: 64, padding: '10px 12px' }}>
+  <span style={{ ...pixelText, fontSize: 12 }}>LABEL</span>
+  <button style={{ ...btnBase, background: '...' }}>ACTION</button>
+</div>;
+```
+
+---
+
+## Building a New Screen
+
+1. Set `<main>` background to `SKY_GRADIENT`
+2. Add `<CloudKingdomBg />` as the first child
+3. Use `z-10` on all content elements to layer above the background
+4. Wrap content sections in `<GamePanel>` with `<GamePanelHeader>`
+5. Use `<BevelButton>` for primary actions
+6. Apply `pixelText` style for labels and headings
+7. Use `btnBase` spread for in-panel action buttons (REMOVE, ADD, etc.)
+
+---
+
+## SVG Title Technique
+
+The "TRIVIA CLASH" title uses a 4-layer SVG text approach for the 3D effect:
+
+1. **Shadow layer** — dark fill + thick stroke, offset down 22px
+2. **Extrusion layer** — medium blue fill + thick stroke, offset down 11px
+3. **Outline layer** — dark fill + thin stroke, at baseline
+4. **Face layer** — gold gradient fill, at baseline
+
+The gold gradient: `#ffee73 → #ffc824 → #fa9c00 → #e36300`
+
+See `Home.tsx` header section for the full SVG markup.


### PR DESCRIPTION
## Summary
- Reskinned Home / Team Setup screen with SNES Cloud Kingdom pixel art theme (SVG gold title, cloud background, beveled buttons, CSS avatars)
- Extracted shared SNES design system into `client/src/components/snes/` (tokens, BevelButton, GamePanel, CloudKingdomBg, CSSAvatar, StatusOrb)
- Added design system reference doc at `docs/guides/snes_design_system.md` for future screen reskins under STE-128
- Removed category/rounds selection panels and bottom nav bar (new UI flow)
- Replaced auth-gated sign-in link with always-visible Admin button

## Test plan
- [x] All 6 Home.test.tsx tests pass (updated for new UI)
- [x] All 50 repo tests pass (`vitest run`)
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Vite build succeeds
- [x] Visual parity confirmed via preview screenshots

> **Note:** Do NOT merge yet — all UI screens will be deployed together under STE-128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)