### PR TITLE
feat(STE-9): AI quality sweep — CLI, admin panel, and actionable findings

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import Game from '@/pages/Game';
 import Admin from '@/pages/Admin';
 import AdminDisputes from '@/pages/admin-disputes';
 import AdminSettings from '@/pages/admin-settings';
+import AdminQualitySweep from '@/pages/admin-quality-sweep';
 import NotFound from '@/pages/not-found';
 
 function Router() {
@@ -18,6 +19,7 @@ function Router() {
       <Route path="/admin" component={Admin} />
       <Route path="/admin/disputes" component={AdminDisputes} />
       <Route path="/admin/settings" component={AdminSettings} />
+      <Route path="/admin/quality-sweep" component={AdminQualitySweep} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -1,6 +1,13 @@
 import { Link, useLocation } from 'wouter';
 import { cn } from '@/lib/utils';
-import { LayoutDashboard, MessageSquareWarning, Settings, PlusCircle, LogOut } from 'lucide-react';
+import {
+  LayoutDashboard,
+  MessageSquareWarning,
+  Settings,
+  PlusCircle,
+  LogOut,
+  ScanSearch,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface AdminLayoutProps {
@@ -13,6 +20,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
   const navItems = [
     { href: '/admin', icon: PlusCircle, label: 'Questions' },
     { href: '/admin/disputes', icon: MessageSquareWarning, label: 'Disputes' },
+    { href: '/admin/quality-sweep', icon: ScanSearch, label: 'Quality Sweep' },
     { href: '/admin/settings', icon: Settings, label: 'Settings' },
   ];
 

--- a/client/src/lib/store.tsx
+++ b/client/src/lib/store.tsx
@@ -72,6 +72,7 @@ interface GameContextType {
   resetGame: () => void;
   addQuestion: (q: Question) => Promise<void>;
   updateQuestion: (q: Question) => Promise<void>;
+  deleteQuestion: (id: string) => Promise<void>;
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined);
@@ -216,7 +217,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     try {
       const res = await fetch(
         `/api/questions?shuffle=true&limit=${totalNeeded}&excludeSeen=true${categoryParam}`,
-        { credentials: 'include' },
+        { credentials: 'include' }
       );
       if (!res.ok) throw new Error('Failed to fetch game questions');
       const data = await res.json();
@@ -418,6 +419,23 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const deleteQuestion = async (id: string) => {
+    try {
+      const res = await fetch(`/api/questions/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('Failed to delete question');
+      setState((prev) => ({
+        ...prev,
+        questions: prev.questions.filter((q) => q.id !== id),
+      }));
+    } catch (error) {
+      console.error('Failed to delete question:', error);
+      throw error;
+    }
+  };
+
   return (
     <GameContext.Provider
       value={{
@@ -436,6 +454,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         resetGame,
         addQuestion,
         updateQuestion,
+        deleteQuestion,
       }}
     >
       {children}

--- a/client/src/pages/admin-quality-sweep.tsx
+++ b/client/src/pages/admin-quality-sweep.tsx
@@ -1,0 +1,478 @@
+import { useState } from 'react';
+import { useLocation } from 'wouter';
+import { ScanSearch, Play, LogIn, Shield } from 'lucide-react';
+import { AdminLayout } from '@/components/admin-layout';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useToast } from '@/hooks/use-toast';
+import { apiRequest } from '@/lib/queryClient';
+import { useAuth } from '@/hooks/use-auth';
+import { useAdmin } from '@/hooks/use-admin';
+import type {
+  QualitySweepReport,
+  QuestionQualityFinding,
+  DuplicateMatch,
+  FactCheckVerdict,
+} from '@shared/models/quality-sweep';
+
+function truncate(text: string, max = 80): string {
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+function SeverityBadge({ severity }: { severity: string }) {
+  const variant =
+    severity === 'high' ? 'destructive' : severity === 'medium' ? 'secondary' : 'outline';
+  return <Badge variant={variant}>{severity}</Badge>;
+}
+
+function VerdictBadge({ verdict }: { verdict: string }) {
+  const variant = verdict === 'fail' ? 'destructive' : 'secondary';
+  return <Badge variant={variant}>{verdict}</Badge>;
+}
+
+function MatchTypeBadge({ type }: { type: string }) {
+  const label = type === 'near_duplicate' ? 'near-duplicate' : type;
+  const variant =
+    type === 'exact' ? 'destructive' : type === 'near_duplicate' ? 'secondary' : 'outline';
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+// --- Report section components ---
+
+function SummarySection({ report }: { report: QualitySweepReport }) {
+  return (
+    <Card className="bg-white/5 border-white/10">
+      <CardHeader>
+        <CardTitle className="text-lg">Summary</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">Questions scanned</p>
+            <p className="text-2xl font-bold">{report.totalQuestions}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">High findings</p>
+            <p className="text-2xl font-bold text-red-400">
+              {report.audit.findingsBySeverity.high}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">Medium findings</p>
+            <p className="text-2xl font-bold text-yellow-400">
+              {report.audit.findingsBySeverity.medium}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">Duplicates</p>
+            <p className="text-2xl font-bold">
+              {report.duplicates ? report.duplicates.duplicatesFound.length : '—'}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecommendationsSection({ recommendations }: { recommendations: string[] }) {
+  return (
+    <Card className="bg-white/5 border-white/10">
+      <CardHeader>
+        <CardTitle className="text-lg">Recommendations</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          {recommendations.map((rec, i) => (
+            <li key={i}>{rec}</li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DuplicatesSection({ duplicates }: { duplicates: DuplicateMatch[] }) {
+  if (duplicates.length === 0) {
+    return (
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">Duplicates</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No duplicates found.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-white/5 border-white/10">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          Duplicates ({duplicates.length} pair{duplicates.length !== 1 ? 's' : ''})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Type</TableHead>
+              <TableHead>Score</TableHead>
+              <TableHead>Question A</TableHead>
+              <TableHead>Question B</TableHead>
+              <TableHead>AI Reasoning</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {duplicates.map((match, i) => (
+              <TableRow key={i}>
+                <TableCell>
+                  <MatchTypeBadge type={match.matchType} />
+                </TableCell>
+                <TableCell className="font-mono text-sm">
+                  {match.similarityScore.toFixed(2)}
+                </TableCell>
+                <TableCell className="max-w-[200px]">
+                  <p className="text-xs text-muted-foreground mb-1">{match.questionIdA}</p>
+                  <p className="text-sm">{truncate(match.questionTextA)}</p>
+                </TableCell>
+                <TableCell className="max-w-[200px]">
+                  <p className="text-xs text-muted-foreground mb-1">{match.questionIdB}</p>
+                  <p className="text-sm">{truncate(match.questionTextB)}</p>
+                </TableCell>
+                <TableCell className="max-w-[200px] text-sm">
+                  {match.aiReasoning ? truncate(match.aiReasoning) : '—'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AuditFindingsSection({ findings }: { findings: QuestionQualityFinding[] }) {
+  const grouped = {
+    high: findings.filter((f) => f.severity === 'high'),
+    medium: findings.filter((f) => f.severity === 'medium'),
+    low: findings.filter((f) => f.severity === 'low'),
+  };
+
+  if (findings.length === 0) {
+    return (
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">Static Audit Findings</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No static audit findings.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-white/5 border-white/10">
+      <CardHeader>
+        <CardTitle className="text-lg">Static Audit Findings ({findings.length})</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {(['high', 'medium', 'low'] as const).map((severity) => {
+          const group = grouped[severity];
+          if (group.length === 0) return null;
+          return (
+            <div key={severity}>
+              <h4 className="text-sm font-semibold mb-2 flex items-center gap-2">
+                <SeverityBadge severity={severity} />
+                {group.length} finding{group.length !== 1 ? 's' : ''}
+              </h4>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Question ID</TableHead>
+                    <TableHead>Rule</TableHead>
+                    <TableHead>Message</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {group.map((finding, i) => (
+                    <TableRow key={i}>
+                      <TableCell className="font-mono text-xs">{finding.questionId}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{finding.rule}</Badge>
+                      </TableCell>
+                      <TableCell className="text-sm">{finding.message}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+function FactCheckSection({ results }: { results: FactCheckVerdict[] }) {
+  const actionable = results
+    .filter((r) => r.verdict === 'fail' || r.verdict === 'flag')
+    .sort((a, b) => (a.verdict === 'fail' ? -1 : 1) - (b.verdict === 'fail' ? -1 : 1));
+
+  if (actionable.length === 0) {
+    return (
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">Fact-Check Results</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">All questions passed fact-check.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-white/5 border-white/10">
+      <CardHeader>
+        <CardTitle className="text-lg">
+          Fact-Check Results ({actionable.length} need attention)
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Question ID</TableHead>
+              <TableHead>Verdict</TableHead>
+              <TableHead>Confidence</TableHead>
+              <TableHead>Reason</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {actionable.map((result, i) => (
+              <TableRow key={i}>
+                <TableCell className="font-mono text-xs">{result.questionId}</TableCell>
+                <TableCell>
+                  <VerdictBadge verdict={result.verdict} />
+                </TableCell>
+                <TableCell className="font-mono text-sm">{result.confidence}%</TableCell>
+                <TableCell className="text-sm max-w-[400px]">{result.reason}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+// --- Main page component ---
+
+export default function AdminQualitySweep() {
+  const [_, setLocation] = useLocation();
+  const { toast } = useToast();
+  const { user, isLoading: authLoading, isAuthenticated } = useAuth();
+  const { isAdmin, isLoading: adminLoading } = useAdmin();
+
+  const [skipFactCheck, setSkipFactCheck] = useState(false);
+  const [skipDuplicates, setSkipDuplicates] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [report, setReport] = useState<QualitySweepReport | null>(null);
+
+  const handleRunSweep = async () => {
+    setIsRunning(true);
+    setReport(null);
+    try {
+      const response = await apiRequest('POST', '/api/admin/quality-sweep', {
+        skipFactCheck,
+        skipDuplicates,
+      });
+      const data = (await response.json()) as QualitySweepReport;
+      setReport(data);
+      toast({
+        title: 'Sweep Complete',
+        description: `Scanned ${data.totalQuestions} question(s). ${data.recommendations.length} recommendation(s).`,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Quality sweep could not be completed.';
+      const isRateLimited = message.startsWith('429');
+      toast({
+        title: isRateLimited ? 'Rate Limit Reached' : 'Sweep Failed',
+        description: isRateLimited ? 'Please wait before running another sweep.' : message,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  // Auth guards — same pattern as admin-settings.tsx
+  if (authLoading || adminLoading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto" />
+          <p className="text-muted-foreground">Checking permissions...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-6">
+        <Card className="max-w-md w-full bg-white/5 border-white/10">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center">
+              <Shield className="w-8 h-8 text-primary" />
+            </div>
+            <CardTitle className="text-2xl">Admin Access Required</CardTitle>
+            <CardDescription>Please sign in to access the admin panel</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Button
+              className="w-full"
+              size="lg"
+              onClick={() => (window.location.href = '/api/login')}
+            >
+              <LogIn className="w-4 h-4 mr-2" />
+              Sign In with Replit
+            </Button>
+            <Button variant="outline" className="w-full" onClick={() => setLocation('/')}>
+              Back to Home
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-6">
+        <Card className="max-w-md w-full bg-white/5 border-white/10 border-red-500/30">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 w-16 h-16 bg-red-500/10 rounded-full flex items-center justify-center">
+              <Shield className="w-8 h-8 text-red-500" />
+            </div>
+            <CardTitle className="text-2xl">Access Denied</CardTitle>
+            <CardDescription>
+              You don't have admin permissions. Contact an administrator to get access.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="p-3 bg-muted/50 rounded-lg text-sm">
+              <p className="text-muted-foreground">Signed in as:</p>
+              <p className="font-medium">{user?.email || 'Unknown user'}</p>
+            </div>
+            <Button variant="outline" className="w-full" onClick={() => setLocation('/')}>
+              Back to Home
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight flex items-center gap-3">
+            <ScanSearch className="w-8 h-8" />
+            Quality Sweep
+          </h2>
+          <p className="text-muted-foreground">
+            Scan all approved questions for duplicates, quality issues, and factual accuracy.
+          </p>
+        </div>
+
+        {/* Controls */}
+        <Card className="bg-white/5 border-white/10">
+          <CardHeader>
+            <CardTitle>Sweep Options</CardTitle>
+            <CardDescription>
+              Configure which checks to run. Fact-checking and conceptual duplicate detection use
+              GPT-4o and may take a few minutes.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="skip-fact-check"
+                  checked={skipFactCheck}
+                  onCheckedChange={(checked) => setSkipFactCheck(checked === true)}
+                  disabled={isRunning}
+                />
+                <Label htmlFor="skip-fact-check" className="text-sm cursor-pointer">
+                  Skip fact-checking (faster, no GPT-4o API cost)
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="skip-duplicates"
+                  checked={skipDuplicates}
+                  onCheckedChange={(checked) => setSkipDuplicates(checked === true)}
+                  disabled={isRunning}
+                />
+                <Label htmlFor="skip-duplicates" className="text-sm cursor-pointer">
+                  Skip duplicate detection
+                </Label>
+              </div>
+            </div>
+
+            <Button onClick={handleRunSweep} disabled={isRunning} size="lg">
+              <Play className="w-4 h-4 mr-2" />
+              {isRunning ? 'Running Sweep...' : 'Run Quality Sweep'}
+            </Button>
+
+            {isRunning && (
+              <p className="text-sm text-muted-foreground animate-pulse">
+                Scanning questions... This may take a few minutes if fact-checking is enabled.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Report */}
+        {report && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-semibold">Report</h3>
+              <p className="text-xs text-muted-foreground">
+                Generated: {new Date(report.generatedAt).toLocaleString()}
+              </p>
+            </div>
+
+            <SummarySection report={report} />
+            <RecommendationsSection recommendations={report.recommendations} />
+
+            {report.duplicates && (
+              <DuplicatesSection duplicates={report.duplicates.duplicatesFound} />
+            )}
+
+            <AuditFindingsSection findings={report.audit.findings} />
+
+            {report.factCheck && <FactCheckSection results={report.factCheck.results} />}
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/client/src/pages/admin-quality-sweep.tsx
+++ b/client/src/pages/admin-quality-sweep.tsx
@@ -1,29 +1,39 @@
 import { useState } from 'react';
 import { useLocation } from 'wouter';
-import { ScanSearch, Play, LogIn, Shield } from 'lucide-react';
+import { ScanSearch, Play, LogIn, Shield, Check, Pencil, Trash2, Save, X } from 'lucide-react';
 import { AdminLayout } from '@/components/admin-layout';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import { useAuth } from '@/hooks/use-auth';
 import { useAdmin } from '@/hooks/use-admin';
-import type {
-  QualitySweepReport,
-  QuestionQualityFinding,
-  DuplicateMatch,
-  FactCheckVerdict,
+import { useGame, type Question } from '@/lib/store';
+import {
+  duplicatePairKey,
+  FACT_CHECK_FINDING_KEY,
+  type DismissFindingRequest,
+  type DuplicateMatch,
+  type FactCheckVerdict,
+  type QualityFindingType,
+  type QualitySweepReport,
+  type QuestionQualityFinding,
 } from '@shared/models/quality-sweep';
 
 function truncate(text: string, max = 80): string {
@@ -48,254 +58,198 @@ function MatchTypeBadge({ type }: { type: string }) {
   return <Badge variant={variant}>{label}</Badge>;
 }
 
-// --- Report section components ---
+// --- Edit draft state ---
 
-function SummarySection({ report }: { report: QualitySweepReport }) {
-  return (
-    <Card className="bg-white/5 border-white/10">
-      <CardHeader>
-        <CardTitle className="text-lg">Summary</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">Questions scanned</p>
-            <p className="text-2xl font-bold">{report.totalQuestions}</p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">High findings</p>
-            <p className="text-2xl font-bold text-red-400">
-              {report.audit.findingsBySeverity.high}
-            </p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">Medium findings</p>
-            <p className="text-2xl font-bold text-yellow-400">
-              {report.audit.findingsBySeverity.medium}
-            </p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">Duplicates</p>
-            <p className="text-2xl font-bold">
-              {report.duplicates ? report.duplicates.duplicatesFound.length : '—'}
-            </p>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
+type EditField = 'question' | 'answer' | 'explanation';
+
+interface EditDraft {
+  question: string;
+  answer: string;
+  explanation: string;
+  touched: Record<EditField, boolean>;
 }
 
-function RecommendationsSection({ recommendations }: { recommendations: string[] }) {
-  return (
-    <Card className="bg-white/5 border-white/10">
-      <CardHeader>
-        <CardTitle className="text-lg">Recommendations</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <ul className="list-disc list-inside space-y-1 text-sm">
-          {recommendations.map((rec, i) => (
-            <li key={i}>{rec}</li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
-  );
-}
-
-function DuplicatesSection({ duplicates }: { duplicates: DuplicateMatch[] }) {
-  if (duplicates.length === 0) {
-    return (
-      <Card className="bg-white/5 border-white/10">
-        <CardHeader>
-          <CardTitle className="text-lg">Duplicates</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">No duplicates found.</p>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  return (
-    <Card className="bg-white/5 border-white/10">
-      <CardHeader>
-        <CardTitle className="text-lg">
-          Duplicates ({duplicates.length} pair{duplicates.length !== 1 ? 's' : ''})
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Type</TableHead>
-              <TableHead>Score</TableHead>
-              <TableHead>Question A</TableHead>
-              <TableHead>Question B</TableHead>
-              <TableHead>AI Reasoning</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {duplicates.map((match, i) => (
-              <TableRow key={i}>
-                <TableCell>
-                  <MatchTypeBadge type={match.matchType} />
-                </TableCell>
-                <TableCell className="font-mono text-sm">
-                  {match.similarityScore.toFixed(2)}
-                </TableCell>
-                <TableCell className="max-w-[200px]">
-                  <p className="text-xs text-muted-foreground mb-1">{match.questionIdA}</p>
-                  <p className="text-sm">{truncate(match.questionTextA)}</p>
-                </TableCell>
-                <TableCell className="max-w-[200px]">
-                  <p className="text-xs text-muted-foreground mb-1">{match.questionIdB}</p>
-                  <p className="text-sm">{truncate(match.questionTextB)}</p>
-                </TableCell>
-                <TableCell className="max-w-[200px] text-sm">
-                  {match.aiReasoning ? truncate(match.aiReasoning) : '—'}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </CardContent>
-    </Card>
-  );
-}
-
-function AuditFindingsSection({ findings }: { findings: QuestionQualityFinding[] }) {
-  const grouped = {
-    high: findings.filter((f) => f.severity === 'high'),
-    medium: findings.filter((f) => f.severity === 'medium'),
-    low: findings.filter((f) => f.severity === 'low'),
+function buildDraft(q: Question): EditDraft {
+  return {
+    question: q.question,
+    answer: q.answer,
+    explanation: q.explanation ?? '',
+    touched: { question: false, answer: false, explanation: false },
   };
+}
 
-  if (findings.length === 0) {
-    return (
-      <Card className="bg-white/5 border-white/10">
-        <CardHeader>
-          <CardTitle className="text-lg">Static Audit Findings</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">No static audit findings.</p>
-        </CardContent>
-      </Card>
-    );
-  }
+// --- Action button group (used by every finding row) ---
 
+interface ActionRowProps {
+  questionId: string;
+  onAccept: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  busy: boolean;
+  isEditing: boolean;
+}
+
+function ActionRow({ questionId, onAccept, onEdit, onDelete, busy, isEditing }: ActionRowProps) {
   return (
-    <Card className="bg-white/5 border-white/10">
-      <CardHeader>
-        <CardTitle className="text-lg">Static Audit Findings ({findings.length})</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {(['high', 'medium', 'low'] as const).map((severity) => {
-          const group = grouped[severity];
-          if (group.length === 0) return null;
-          return (
-            <div key={severity}>
-              <h4 className="text-sm font-semibold mb-2 flex items-center gap-2">
-                <SeverityBadge severity={severity} />
-                {group.length} finding{group.length !== 1 ? 's' : ''}
-              </h4>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Question ID</TableHead>
-                    <TableHead>Rule</TableHead>
-                    <TableHead>Message</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {group.map((finding, i) => (
-                    <TableRow key={i}>
-                      <TableCell className="font-mono text-xs">{finding.questionId}</TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{finding.rule}</Badge>
-                      </TableCell>
-                      <TableCell className="text-sm">{finding.message}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          );
-        })}
-      </CardContent>
-    </Card>
+    <div className="flex flex-wrap gap-2">
+      <Button
+        size="sm"
+        variant="outline"
+        className="border-green-500/30 hover:bg-green-500/10 hover:text-green-500"
+        onClick={onAccept}
+        disabled={busy}
+        data-testid={`button-accept-${questionId}`}
+      >
+        <Check className="w-3 h-3 mr-1" /> Accept
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        className="border-amber-500/30 hover:bg-amber-500/10 hover:text-amber-500"
+        onClick={onEdit}
+        disabled={busy || isEditing}
+        data-testid={`button-edit-${questionId}`}
+      >
+        <Pencil className="w-3 h-3 mr-1" /> Edit
+      </Button>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button
+            size="sm"
+            variant="outline"
+            className="border-red-500/30 hover:bg-red-500/10 hover:text-red-500"
+            disabled={busy}
+            data-testid={`button-delete-${questionId}`}
+          >
+            <Trash2 className="w-3 h-3 mr-1" /> Delete
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this question?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes the question from the database. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={onDelete}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
   );
 }
 
-function FactCheckSection({ results }: { results: FactCheckVerdict[] }) {
-  const actionable = results
-    .filter((r) => r.verdict === 'fail' || r.verdict === 'flag')
-    .sort((a, b) => (a.verdict === 'fail' ? -1 : 1) - (b.verdict === 'fail' ? -1 : 1));
+// --- Inline editor (3 fields) ---
 
-  if (actionable.length === 0) {
-    return (
-      <Card className="bg-white/5 border-white/10">
-        <CardHeader>
-          <CardTitle className="text-lg">Fact-Check Results</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">All questions passed fact-check.</p>
-        </CardContent>
-      </Card>
-    );
-  }
+interface InlineEditorProps {
+  draft: EditDraft;
+  onChange: (field: EditField, value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  busy: boolean;
+  questionId: string;
+}
 
+function InlineEditor({ draft, onChange, onSave, onCancel, busy, questionId }: InlineEditorProps) {
   return (
-    <Card className="bg-white/5 border-white/10">
-      <CardHeader>
-        <CardTitle className="text-lg">
-          Fact-Check Results ({actionable.length} need attention)
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Question ID</TableHead>
-              <TableHead>Verdict</TableHead>
-              <TableHead>Confidence</TableHead>
-              <TableHead>Reason</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {actionable.map((result, i) => (
-              <TableRow key={i}>
-                <TableCell className="font-mono text-xs">{result.questionId}</TableCell>
-                <TableCell>
-                  <VerdictBadge verdict={result.verdict} />
-                </TableCell>
-                <TableCell className="font-mono text-sm">{result.confidence}%</TableCell>
-                <TableCell className="text-sm max-w-[400px]">{result.reason}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </CardContent>
-    </Card>
+    <div className="mt-3 p-3 rounded-md border border-amber-500/20 bg-amber-500/5 space-y-3">
+      <p className="text-[10px] uppercase tracking-wide text-amber-500 font-semibold">
+        Editing question
+      </p>
+      <div className="space-y-1">
+        <p className="text-[10px] uppercase text-muted-foreground">Question</p>
+        <Textarea
+          value={draft.question}
+          onChange={(e) => onChange('question', e.target.value)}
+          className="min-h-[60px] text-xs"
+          data-testid={`edit-question-${questionId}`}
+        />
+      </div>
+      <div className="space-y-1">
+        <p className="text-[10px] uppercase text-muted-foreground">Answer</p>
+        <Input
+          value={draft.answer}
+          onChange={(e) => onChange('answer', e.target.value)}
+          className="text-xs"
+          data-testid={`edit-answer-${questionId}`}
+        />
+      </div>
+      <div className="space-y-1">
+        <p className="text-[10px] uppercase text-muted-foreground">Explanation</p>
+        <Textarea
+          value={draft.explanation}
+          onChange={(e) => onChange('explanation', e.target.value)}
+          className="min-h-[60px] text-xs"
+          data-testid={`edit-explanation-${questionId}`}
+        />
+      </div>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={onSave} disabled={busy} data-testid={`save-${questionId}`}>
+          <Save className="w-3 h-3 mr-1" />
+          {busy ? 'Saving...' : 'Save'}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onCancel}
+          disabled={busy}
+          data-testid={`cancel-${questionId}`}
+        >
+          <X className="w-3 h-3 mr-1" /> Cancel
+        </Button>
+      </div>
+    </div>
   );
 }
 
-// --- Main page component ---
+// --- Main page ---
+
+interface RemovedFindings {
+  static: Set<string>; // `${questionId}::${rule}`
+  duplicate: Set<string>; // pair key
+  factCheck: Set<string>; // questionId
+  deletedQuestionIds: Set<string>;
+}
 
 export default function AdminQualitySweep() {
   const [_, setLocation] = useLocation();
   const { toast } = useToast();
   const { user, isLoading: authLoading, isAuthenticated } = useAuth();
   const { isAdmin, isLoading: adminLoading } = useAdmin();
+  const { state, updateQuestion, deleteQuestion } = useGame();
 
   const [skipFactCheck, setSkipFactCheck] = useState(false);
   const [skipDuplicates, setSkipDuplicates] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [report, setReport] = useState<QualitySweepReport | null>(null);
 
+  const [removed, setRemoved] = useState<RemovedFindings>({
+    static: new Set(),
+    duplicate: new Set(),
+    factCheck: new Set(),
+    deletedQuestionIds: new Set(),
+  });
+
+  // Edit drafts keyed by `${editKey}` (unique per finding row)
+  const [editDrafts, setEditDrafts] = useState<Record<string, EditDraft>>({});
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
   const handleRunSweep = async () => {
     setIsRunning(true);
     setReport(null);
+    setRemoved({
+      static: new Set(),
+      duplicate: new Set(),
+      factCheck: new Set(),
+      deletedQuestionIds: new Set(),
+    });
+    setEditDrafts({});
+    setEditingKey(null);
     try {
       const response = await apiRequest('POST', '/api/admin/quality-sweep', {
         skipFactCheck,
@@ -321,7 +275,502 @@ export default function AdminQualitySweep() {
     }
   };
 
-  // Auth guards — same pattern as admin-settings.tsx
+  // --- Action handlers ---
+
+  const dismissOnServer = async (req: DismissFindingRequest) => {
+    await apiRequest('POST', '/api/admin/quality-sweep/dismiss', req);
+  };
+
+  const handleAccept = async (
+    findingType: QualityFindingType,
+    questionId: string,
+    findingKey: string,
+    editKey: string
+  ) => {
+    setBusyKey(editKey);
+    try {
+      await dismissOnServer({ questionId, findingType, findingKey });
+      setRemoved((prev) => {
+        const next = { ...prev };
+        if (findingType === 'static') {
+          next.static = new Set(prev.static).add(`${questionId}::${findingKey}`);
+        } else if (findingType === 'duplicate') {
+          next.duplicate = new Set(prev.duplicate).add(findingKey);
+        } else {
+          next.factCheck = new Set(prev.factCheck).add(questionId);
+        }
+        return next;
+      });
+      toast({ title: 'Finding dismissed', description: 'It will not appear in future sweeps.' });
+    } catch (error) {
+      toast({
+        title: 'Dismiss failed',
+        description: error instanceof Error ? error.message : 'Could not dismiss finding.',
+        variant: 'destructive',
+      });
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleStartEdit = (editKey: string, questionId: string) => {
+    const sourceQ = state.questions.find((q) => q.id === questionId);
+    if (!sourceQ) {
+      toast({
+        title: 'Question not loaded',
+        description: 'The question is not in the local catalog. Reload the app and retry.',
+        variant: 'destructive',
+      });
+      return;
+    }
+    setEditDrafts((prev) => ({ ...prev, [editKey]: buildDraft(sourceQ) }));
+    setEditingKey(editKey);
+  };
+
+  const handleDraftChange = (editKey: string, field: EditField, value: string) => {
+    setEditDrafts((prev) => {
+      const existing = prev[editKey];
+      if (!existing) return prev;
+      return {
+        ...prev,
+        [editKey]: {
+          ...existing,
+          [field]: value,
+          touched: { ...existing.touched, [field]: true },
+        },
+      };
+    });
+  };
+
+  const handleSaveEdit = async (editKey: string, questionId: string) => {
+    const draft = editDrafts[editKey];
+    if (!draft) return;
+    const sourceQ = state.questions.find((q) => q.id === questionId);
+    if (!sourceQ) return;
+
+    if (!draft.question.trim() || !draft.answer.trim()) {
+      toast({
+        title: 'Missing required fields',
+        description: 'Question and answer are required.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setBusyKey(editKey);
+    try {
+      await updateQuestion({
+        ...sourceQ,
+        question: draft.question.trim(),
+        answer: draft.answer.trim(),
+        explanation: draft.explanation.trim() || sourceQ.explanation,
+      });
+      setEditingKey(null);
+      setEditDrafts((prev) => {
+        const next = { ...prev };
+        delete next[editKey];
+        return next;
+      });
+      toast({ title: 'Question updated', description: 'The fix has been saved.' });
+    } catch (error) {
+      toast({
+        title: 'Update failed',
+        description: error instanceof Error ? error.message : 'Could not update question.',
+        variant: 'destructive',
+      });
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleCancelEdit = (editKey: string) => {
+    setEditingKey(null);
+    setEditDrafts((prev) => {
+      const next = { ...prev };
+      delete next[editKey];
+      return next;
+    });
+  };
+
+  const handleDelete = async (editKey: string, questionId: string) => {
+    setBusyKey(editKey);
+    try {
+      await deleteQuestion(questionId);
+      setRemoved((prev) => ({
+        ...prev,
+        deletedQuestionIds: new Set(prev.deletedQuestionIds).add(questionId),
+      }));
+      toast({ title: 'Question deleted' });
+    } catch (error) {
+      toast({
+        title: 'Delete failed',
+        description: error instanceof Error ? error.message : 'Could not delete question.',
+        variant: 'destructive',
+      });
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  // --- Filtering helpers (apply local removals on top of server report) ---
+
+  const visibleStaticFindings = (findings: QuestionQualityFinding[]) =>
+    findings.filter(
+      (f) =>
+        !removed.deletedQuestionIds.has(f.questionId) &&
+        !removed.static.has(`${f.questionId}::${f.rule}`)
+    );
+
+  const visibleDuplicates = (matches: DuplicateMatch[]) =>
+    matches.filter((m) => {
+      if (
+        removed.deletedQuestionIds.has(m.questionIdA) ||
+        removed.deletedQuestionIds.has(m.questionIdB)
+      ) {
+        return false;
+      }
+      return !removed.duplicate.has(duplicatePairKey(m.questionIdA, m.questionIdB));
+    });
+
+  const visibleFactCheck = (results: FactCheckVerdict[]) =>
+    results.filter(
+      (r) => !removed.deletedQuestionIds.has(r.questionId) && !removed.factCheck.has(r.questionId)
+    );
+
+  // --- Section renderers ---
+
+  function SummarySection({ report }: { report: QualitySweepReport }) {
+    const visibleAuditCount = visibleStaticFindings(report.audit.findings).length;
+    const visibleHigh = visibleStaticFindings(report.audit.findings).filter(
+      (f) => f.severity === 'high'
+    ).length;
+    const visibleMedium = visibleStaticFindings(report.audit.findings).filter(
+      (f) => f.severity === 'medium'
+    ).length;
+    const visibleDupCount = report.duplicates
+      ? visibleDuplicates(report.duplicates.duplicatesFound).length
+      : null;
+    return (
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">Summary</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">Questions scanned</p>
+              <p className="text-2xl font-bold">{report.totalQuestions}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">Open findings</p>
+              <p className="text-2xl font-bold">{visibleAuditCount}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">High</p>
+              <p className="text-2xl font-bold text-red-400">{visibleHigh}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">Medium</p>
+              <p className="text-2xl font-bold text-yellow-400">{visibleMedium}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">Duplicates</p>
+              <p className="text-2xl font-bold">{visibleDupCount ?? '—'}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  function FindingRow({
+    editKey,
+    questionId,
+    findingType,
+    findingKey,
+    children,
+  }: {
+    editKey: string;
+    questionId: string;
+    findingType: QualityFindingType;
+    findingKey: string;
+    children: React.ReactNode;
+  }) {
+    const isEditing = editingKey === editKey;
+    const draft = editDrafts[editKey];
+    const busy = busyKey === editKey;
+    return (
+      <div className="border border-white/10 rounded-md p-3 space-y-3 bg-white/[0.02]">
+        {children}
+        <ActionRow
+          questionId={questionId}
+          onAccept={() => handleAccept(findingType, questionId, findingKey, editKey)}
+          onEdit={() => handleStartEdit(editKey, questionId)}
+          onDelete={() => handleDelete(editKey, questionId)}
+          busy={busy}
+          isEditing={isEditing}
+        />
+        {isEditing && draft && (
+          <InlineEditor
+            draft={draft}
+            questionId={questionId}
+            busy={busy}
+            onChange={(field, value) => handleDraftChange(editKey, field, value)}
+            onSave={() => handleSaveEdit(editKey, questionId)}
+            onCancel={() => handleCancelEdit(editKey)}
+          />
+        )}
+      </div>
+    );
+  }
+
+  function AuditFindingsSection({ findings }: { findings: QuestionQualityFinding[] }) {
+    const visible = visibleStaticFindings(findings);
+    const grouped = {
+      high: visible.filter((f) => f.severity === 'high'),
+      medium: visible.filter((f) => f.severity === 'medium'),
+      low: visible.filter((f) => f.severity === 'low'),
+    };
+
+    if (visible.length === 0) {
+      return (
+        <Card className="bg-white/5 border-white/10">
+          <CardHeader>
+            <CardTitle className="text-lg">Static Audit Findings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">No static audit findings.</p>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    return (
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">Static Audit Findings ({visible.length})</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {(['high', 'medium', 'low'] as const).map((severity) => {
+            const group = grouped[severity];
+            if (group.length === 0) return null;
+            return (
+              <div key={severity} className="space-y-3">
+                <h4 className="text-sm font-semibold flex items-center gap-2">
+                  <SeverityBadge severity={severity} />
+                  {group.length} finding{group.length !== 1 ? 's' : ''}
+                </h4>
+                <div className="space-y-2">
+                  {group.map((finding) => {
+                    const editKey = `static::${finding.questionId}::${finding.rule}`;
+                    return (
+                      <FindingRow
+                        key={editKey}
+                        editKey={editKey}
+                        questionId={finding.questionId}
+                        findingType="static"
+                        findingKey={finding.rule}
+                      >
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <Badge variant="outline">{finding.rule}</Badge>
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {finding.questionId}
+                            </span>
+                          </div>
+                          <p className="text-sm">{finding.message}</p>
+                        </div>
+                      </FindingRow>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  function DuplicatesSection({ duplicates }: { duplicates: DuplicateMatch[] }) {
+    const visible = visibleDuplicates(duplicates);
+    if (visible.length === 0) {
+      return (
+        <Card className="bg-white/5 border-white/10">
+          <CardHeader>
+            <CardTitle className="text-lg">Duplicates</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">No duplicates found.</p>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    return (
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">
+            Duplicates ({visible.length} pair{visible.length !== 1 ? 's' : ''})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {visible.map((match) => {
+            const pairKey = duplicatePairKey(match.questionIdA, match.questionIdB);
+            const editKeyA = `dup::${pairKey}::A`;
+            const editKeyB = `dup::${pairKey}::B`;
+            const isAEditing = editingKey === editKeyA;
+            const isBEditing = editingKey === editKeyB;
+            const busyA = busyKey === editKeyA;
+            const busyB = busyKey === editKeyB;
+
+            return (
+              <div
+                key={pairKey}
+                className="border border-white/10 rounded-md p-3 space-y-3 bg-white/[0.02]"
+              >
+                <div className="flex items-center gap-2 flex-wrap">
+                  <MatchTypeBadge type={match.matchType} />
+                  <span className="text-xs font-mono">
+                    score {match.similarityScore.toFixed(2)}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="ml-auto border-green-500/30 hover:bg-green-500/10 hover:text-green-500"
+                    onClick={() =>
+                      handleAccept('duplicate', match.questionIdA, pairKey, `dup::${pairKey}`)
+                    }
+                    disabled={busyKey === `dup::${pairKey}`}
+                    data-testid={`button-accept-pair-${pairKey}`}
+                  >
+                    <Check className="w-3 h-3 mr-1" /> Accept pair
+                  </Button>
+                </div>
+                {match.aiReasoning && (
+                  <p className="text-xs text-muted-foreground italic">
+                    AI: {truncate(match.aiReasoning, 200)}
+                  </p>
+                )}
+                <div className="grid md:grid-cols-2 gap-3">
+                  {/* Side A */}
+                  <div className="border border-white/10 rounded p-2 space-y-2">
+                    <p className="font-mono text-[10px] text-muted-foreground">
+                      {match.questionIdA}
+                    </p>
+                    <p className="text-sm">{match.questionTextA}</p>
+                    <p className="text-xs text-muted-foreground">A: {match.answerA}</p>
+                    <ActionRow
+                      questionId={match.questionIdA}
+                      onAccept={() =>
+                        handleAccept('duplicate', match.questionIdA, pairKey, `dup::${pairKey}`)
+                      }
+                      onEdit={() => handleStartEdit(editKeyA, match.questionIdA)}
+                      onDelete={() => handleDelete(editKeyA, match.questionIdA)}
+                      busy={busyA}
+                      isEditing={isAEditing}
+                    />
+                    {isAEditing && editDrafts[editKeyA] && (
+                      <InlineEditor
+                        draft={editDrafts[editKeyA]}
+                        questionId={match.questionIdA}
+                        busy={busyA}
+                        onChange={(field, value) => handleDraftChange(editKeyA, field, value)}
+                        onSave={() => handleSaveEdit(editKeyA, match.questionIdA)}
+                        onCancel={() => handleCancelEdit(editKeyA)}
+                      />
+                    )}
+                  </div>
+                  {/* Side B */}
+                  <div className="border border-white/10 rounded p-2 space-y-2">
+                    <p className="font-mono text-[10px] text-muted-foreground">
+                      {match.questionIdB}
+                    </p>
+                    <p className="text-sm">{match.questionTextB}</p>
+                    <p className="text-xs text-muted-foreground">A: {match.answerB}</p>
+                    <ActionRow
+                      questionId={match.questionIdB}
+                      onAccept={() =>
+                        handleAccept('duplicate', match.questionIdB, pairKey, `dup::${pairKey}`)
+                      }
+                      onEdit={() => handleStartEdit(editKeyB, match.questionIdB)}
+                      onDelete={() => handleDelete(editKeyB, match.questionIdB)}
+                      busy={busyB}
+                      isEditing={isBEditing}
+                    />
+                    {isBEditing && editDrafts[editKeyB] && (
+                      <InlineEditor
+                        draft={editDrafts[editKeyB]}
+                        questionId={match.questionIdB}
+                        busy={busyB}
+                        onChange={(field, value) => handleDraftChange(editKeyB, field, value)}
+                        onSave={() => handleSaveEdit(editKeyB, match.questionIdB)}
+                        onCancel={() => handleCancelEdit(editKeyB)}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  function FactCheckSection({ results }: { results: FactCheckVerdict[] }) {
+    const actionable = visibleFactCheck(
+      results.filter((r) => r.verdict === 'fail' || r.verdict === 'flag')
+    );
+    if (actionable.length === 0) {
+      return (
+        <Card className="bg-white/5 border-white/10">
+          <CardHeader>
+            <CardTitle className="text-lg">Fact-Check Results</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">All questions passed fact-check.</p>
+          </CardContent>
+        </Card>
+      );
+    }
+    return (
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">
+            Fact-Check Results ({actionable.length} need attention)
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {actionable.map((result) => {
+            const editKey = `fc::${result.questionId}`;
+            return (
+              <FindingRow
+                key={editKey}
+                editKey={editKey}
+                questionId={result.questionId}
+                findingType="fact_check"
+                findingKey={FACT_CHECK_FINDING_KEY}
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <VerdictBadge verdict={result.verdict} />
+                    <span className="text-xs font-mono">{result.confidence}%</span>
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {result.questionId}
+                    </span>
+                  </div>
+                  <p className="text-sm">{result.reason}</p>
+                </div>
+              </FindingRow>
+            );
+          })}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Auth guards
   if (authLoading || adminLoading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
@@ -461,7 +910,21 @@ export default function AdminQualitySweep() {
             </div>
 
             <SummarySection report={report} />
-            <RecommendationsSection recommendations={report.recommendations} />
+
+            {report.recommendations.length > 0 && (
+              <Card className="bg-white/5 border-white/10">
+                <CardHeader>
+                  <CardTitle className="text-lg">Recommendations</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="list-disc list-inside space-y-1 text-sm">
+                    {report.recommendations.map((rec, i) => (
+                      <li key={i}>{rec}</li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            )}
 
             {report.duplicates && (
               <DuplicatesSection duplicates={report.duplicates.duplicatesFound} />

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:seed": "tsx script/seed-questions.ts",
     "audit:questions": "node --import tsx script/question-quality-audit.ts",
     "audit:questions:strict": "node --import tsx script/question-quality-audit.ts --fail-on-high",
+    "sweep:questions": "node --import tsx script/quality-sweep.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",

--- a/script/quality-sweep.ts
+++ b/script/quality-sweep.ts
@@ -1,0 +1,406 @@
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+import { eq } from 'drizzle-orm';
+
+import { db, pool } from '../server/db';
+import { questions } from '@shared/models/questions';
+import type { Question } from '@shared/models/questions';
+import {
+  auditQuestionQuality,
+  type QuestionQualityAuditReport,
+  type QuestionQualityFinding,
+} from '../server/lib/question-quality-audit';
+import { detectDuplicates, type DuplicateDetectionReport } from '../server/lib/duplicate-detector';
+import { batchFactCheck, type FactCheckReport } from '../server/lib/verifier';
+
+// ---------------------------------------------------------------------------
+// CLI options
+// ---------------------------------------------------------------------------
+
+type CliOptions = {
+  skipFactCheck: boolean;
+  skipDuplicates: boolean;
+  failOnHigh: boolean;
+  jsonOutputPath: string;
+  markdownOutputPath: string;
+};
+
+const DEFAULT_JSON_OUTPUT_PATH = 'reports/quality-sweep-report.json';
+const DEFAULT_MARKDOWN_OUTPUT_PATH = 'reports/quality-sweep-report.md';
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    skipFactCheck: false,
+    skipDuplicates: false,
+    failOnHigh: false,
+    jsonOutputPath: DEFAULT_JSON_OUTPUT_PATH,
+    markdownOutputPath: DEFAULT_MARKDOWN_OUTPUT_PATH,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === '--skip-fact-check') {
+      options.skipFactCheck = true;
+      continue;
+    }
+    if (arg === '--skip-duplicates') {
+      options.skipDuplicates = true;
+      continue;
+    }
+    if (arg === '--fail-on-high') {
+      options.failOnHigh = true;
+      continue;
+    }
+    if (arg === '--json') {
+      options.jsonOutputPath = argv[i + 1] ?? options.jsonOutputPath;
+      i++;
+      continue;
+    }
+    if (arg === '--markdown') {
+      options.markdownOutputPath = argv[i + 1] ?? options.markdownOutputPath;
+      i++;
+      continue;
+    }
+  }
+
+  return options;
+}
+
+function absolutePathFromCwd(targetPath: string): string {
+  return path.isAbsolute(targetPath) ? targetPath : path.resolve(process.cwd(), targetPath);
+}
+
+async function writeOutput(filePath: string, content: string): Promise<void> {
+  const resolved = absolutePathFromCwd(filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, content, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Type adapter: Question → shape expected by auditQuestionQuality
+// ---------------------------------------------------------------------------
+
+function toAuditShape(q: Question) {
+  return {
+    id: q.id,
+    category: q.category,
+    difficulty: q.difficulty,
+    question: q.question,
+    answer: q.answer,
+    acceptableAnswers: q.acceptableAnswers ?? [],
+    explanation: q.explanation,
+    tags: q.tags ?? [],
+    sourceUrl: q.sourceUrl ?? undefined,
+    sourceName: q.sourceName ?? undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown report builder
+// ---------------------------------------------------------------------------
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function truncate(text: string, max = 120): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function buildRecommendations(
+  auditReport: QuestionQualityAuditReport,
+  duplicateReport: DuplicateDetectionReport | null,
+  factCheckReport: FactCheckReport | null
+): string[] {
+  const recs: string[] = [];
+
+  if (auditReport.findingsBySeverity.high > 0) {
+    recs.push(
+      `${auditReport.findingsBySeverity.high} high-severity static findings — fix before next release.`
+    );
+  }
+  if (auditReport.findingsBySeverity.medium > 0) {
+    recs.push(
+      `${auditReport.findingsBySeverity.medium} medium-severity static findings — review and improve.`
+    );
+  }
+
+  if (duplicateReport) {
+    const total = duplicateReport.duplicatesFound.length;
+    if (total > 0) {
+      recs.push(
+        `${total} duplicate pair(s) found (${duplicateReport.duplicatesByType.exact} exact, ` +
+          `${duplicateReport.duplicatesByType.near_duplicate} near-duplicate, ` +
+          `${duplicateReport.duplicatesByType.conceptual} conceptual) — ` +
+          `recommend removing the lower-quality version of each pair.`
+      );
+    }
+  }
+
+  if (factCheckReport) {
+    const failures = factCheckReport.results.filter((r) => r.verdict === 'fail').length;
+    const flags = factCheckReport.results.filter((r) => r.verdict === 'flag').length;
+    if (failures > 0) recs.push(`${failures} question(s) failed fact-check — review immediately.`);
+    if (flags > 0)
+      recs.push(`${flags} question(s) flagged by fact-check — verify before next release.`);
+  }
+
+  if (recs.length === 0) {
+    recs.push('No critical issues found. All approved questions passed the sweep.');
+  }
+
+  return recs;
+}
+
+function buildMarkdownReport(
+  generatedAt: string,
+  allQuestions: Question[],
+  auditReport: QuestionQualityAuditReport,
+  duplicateReport: DuplicateDetectionReport | null,
+  factCheckReport: FactCheckReport | null
+): string {
+  const lines: string[] = [];
+
+  lines.push('# Quality Sweep Report');
+  lines.push('');
+  lines.push(`Generated: ${generatedAt}`);
+  lines.push('');
+
+  // --- Summary ---
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- Questions scanned: ${allQuestions.length}`);
+  lines.push(`- Static findings (high): ${auditReport.findingsBySeverity.high}`);
+  lines.push(`- Static findings (medium): ${auditReport.findingsBySeverity.medium}`);
+  lines.push(`- Static findings (low): ${auditReport.findingsBySeverity.low}`);
+  if (duplicateReport) {
+    lines.push(`- Duplicate pairs found: ${duplicateReport.duplicatesFound.length}`);
+  } else {
+    lines.push('- Duplicate detection: skipped');
+  }
+  if (factCheckReport) {
+    const failed = factCheckReport.results.filter((r) => r.verdict === 'fail').length;
+    const flagged = factCheckReport.results.filter((r) => r.verdict === 'flag').length;
+    lines.push(`- Fact-check failures: ${failed}`);
+    lines.push(`- Fact-check flags: ${flagged}`);
+  } else {
+    lines.push('- Fact-check: skipped');
+  }
+  lines.push('');
+
+  // --- Recommendations ---
+  lines.push('## Recommendations');
+  lines.push('');
+  const recs = buildRecommendations(auditReport, duplicateReport, factCheckReport);
+  for (const rec of recs) {
+    lines.push(`- ${rec}`);
+  }
+  lines.push('');
+
+  // --- Duplicates ---
+  lines.push('## Duplicates');
+  lines.push('');
+  if (!duplicateReport) {
+    lines.push('_Duplicate detection was skipped._');
+    lines.push('');
+  } else if (duplicateReport.duplicatesFound.length === 0) {
+    lines.push('No duplicates found.');
+    lines.push('');
+  } else {
+    lines.push(
+      `${duplicateReport.duplicatesFound.length} pair(s) found across ${duplicateReport.totalPairsChecked} pair(s) checked.`
+    );
+    lines.push('');
+    lines.push(
+      '| Type | Score | ID A | ID B | Question A | Question B | Answer A | Answer B | AI Reasoning |'
+    );
+    lines.push('| --- | ---: | --- | --- | --- | --- | --- | --- | --- |');
+
+    for (const match of duplicateReport.duplicatesFound) {
+      const reasoning = match.aiReasoning ? escapeCell(truncate(match.aiReasoning, 80)) : '—';
+      lines.push(
+        `| ${match.matchType} | ${match.similarityScore.toFixed(2)} | ${match.questionIdA} | ${match.questionIdB} | ${escapeCell(truncate(match.questionTextA))} | ${escapeCell(truncate(match.questionTextB))} | ${escapeCell(match.answerA)} | ${escapeCell(match.answerB)} | ${reasoning} |`
+      );
+    }
+    lines.push('');
+  }
+
+  // --- Static Audit Findings ---
+  lines.push('## Static Audit Findings');
+  lines.push('');
+  if (auditReport.findings.length === 0) {
+    lines.push('No static audit findings.');
+    lines.push('');
+  } else {
+    for (const severity of ['high', 'medium', 'low'] as const) {
+      const group = auditReport.findings.filter((f) => f.severity === severity);
+      if (group.length === 0) continue;
+
+      lines.push(`### ${severity.charAt(0).toUpperCase() + severity.slice(1)} (${group.length})`);
+      lines.push('');
+      lines.push('| Question ID | Index | Rule | Message |');
+      lines.push('| --- | ---: | --- | --- |');
+
+      for (const finding of group) {
+        lines.push(
+          `| ${escapeCell(finding.questionId)} | ${finding.questionIndex} | ${finding.rule} | ${escapeCell(finding.message)} |`
+        );
+      }
+      lines.push('');
+    }
+  }
+
+  // --- Fact-Check Results ---
+  lines.push('## Fact-Check Results');
+  lines.push('');
+  if (!factCheckReport) {
+    lines.push('_Fact-checking was skipped._');
+    lines.push('');
+  } else {
+    const actionable = factCheckReport.results.filter(
+      (r) => r.verdict === 'flag' || r.verdict === 'fail'
+    );
+    if (actionable.length === 0) {
+      lines.push('All questions passed fact-check.');
+      lines.push('');
+    } else {
+      lines.push(`${actionable.length} question(s) require attention:`);
+      lines.push('');
+      lines.push('| Question ID | Verdict | Confidence | Reason |');
+      lines.push('| --- | --- | ---: | --- |');
+
+      for (const result of actionable) {
+        lines.push(
+          `| ${result.questionId} | ${result.verdict} | ${result.confidence} | ${escapeCell(truncate(result.reason))} |`
+        );
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Report JSON shape
+// ---------------------------------------------------------------------------
+
+interface SweepReport {
+  generatedAt: string;
+  totalQuestionsScanned: number;
+  staticAudit: QuestionQualityAuditReport;
+  duplicates: DuplicateDetectionReport | null;
+  factCheck: FactCheckReport | null;
+  findingsSummary: {
+    highSeverityStatic: number;
+    mediumSeverityStatic: number;
+    lowSeverityStatic: number;
+    duplicatePairs: number;
+    factCheckFailed: number;
+    factCheckFlagged: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const generatedAt = new Date().toISOString();
+
+  // 1. Query approved questions from DB
+  console.log('Querying approved questions from database…');
+  const rows = await db.select().from(questions).where(eq(questions.status, 'approved'));
+  console.log(`Found ${rows.length} approved question(s).`);
+
+  if (rows.length === 0) {
+    console.warn('No approved questions found. Exiting.');
+    await pool.end();
+    return;
+  }
+
+  // 2. Static audit
+  console.log('Running static quality audit…');
+  const auditReport = auditQuestionQuality(rows.map(toAuditShape));
+  console.log(
+    `Static audit complete: ${auditReport.totalFindings} finding(s) ` +
+      `(high: ${auditReport.findingsBySeverity.high}, medium: ${auditReport.findingsBySeverity.medium}, ` +
+      `low: ${auditReport.findingsBySeverity.low})`
+  );
+
+  // 3. Duplicate detection
+  let duplicateReport: DuplicateDetectionReport | null = null;
+  if (!options.skipDuplicates) {
+    console.log('Running duplicate detection…');
+    duplicateReport = await detectDuplicates(rows);
+    console.log(
+      `Duplicate detection complete: ${duplicateReport.duplicatesFound.length} pair(s) found ` +
+        `across ${duplicateReport.totalPairsChecked} pair(s) checked.`
+    );
+  } else {
+    console.log('Skipping duplicate detection (--skip-duplicates).');
+  }
+
+  // 4. Fact-checking
+  let factCheckReport: FactCheckReport | null = null;
+  if (!options.skipFactCheck) {
+    console.log('Running batch fact-check via GPT-4o…');
+    factCheckReport = await batchFactCheck(rows);
+    const failed = factCheckReport.results.filter((r) => r.verdict === 'fail').length;
+    const flagged = factCheckReport.results.filter((r) => r.verdict === 'flag').length;
+    console.log(`Fact-check complete: ${failed} fail(s), ${flagged} flag(s).`);
+  } else {
+    console.log('Skipping fact-check (--skip-fact-check).');
+  }
+
+  // 5. Build combined report
+  const sweepReport: SweepReport = {
+    generatedAt,
+    totalQuestionsScanned: rows.length,
+    staticAudit: auditReport,
+    duplicates: duplicateReport,
+    factCheck: factCheckReport,
+    findingsSummary: {
+      highSeverityStatic: auditReport.findingsBySeverity.high,
+      mediumSeverityStatic: auditReport.findingsBySeverity.medium,
+      lowSeverityStatic: auditReport.findingsBySeverity.low,
+      duplicatePairs: duplicateReport?.duplicatesFound.length ?? 0,
+      factCheckFailed: factCheckReport?.results.filter((r) => r.verdict === 'fail').length ?? 0,
+      factCheckFlagged: factCheckReport?.results.filter((r) => r.verdict === 'flag').length ?? 0,
+    },
+  };
+
+  // 6. Write reports
+  await writeOutput(options.jsonOutputPath, `${JSON.stringify(sweepReport, null, 2)}\n`);
+  await writeOutput(
+    options.markdownOutputPath,
+    buildMarkdownReport(generatedAt, rows, auditReport, duplicateReport, factCheckReport)
+  );
+
+  console.log(`JSON report:     ${absolutePathFromCwd(options.jsonOutputPath)}`);
+  console.log(`Markdown report: ${absolutePathFromCwd(options.markdownOutputPath)}`);
+
+  await pool.end();
+
+  // 7. Fail-on-high exit code
+  if (options.failOnHigh && auditReport.findingsBySeverity.high > 0) {
+    throw new Error(
+      `Quality sweep exceeded fail threshold: ${auditReport.findingsBySeverity.high} high-severity finding(s).`
+    );
+  }
+}
+
+void main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Quality sweep failed: ${message}`);
+  if (error instanceof Error && error.stack) {
+    console.error(error.stack);
+  }
+  if (error instanceof Error && error.cause) {
+    console.error('Caused by:', error.cause);
+  }
+  process.exit(1);
+});

--- a/server/lib/duplicate-detector.test.ts
+++ b/server/lib/duplicate-detector.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { detectDuplicates } from './duplicate-detector';
+import type { Question } from '@shared/models/questions';
+
+// vi.hoisted ensures mockCreate is available both inside the vi.mock factory
+// and in the test body (vi.mock is hoisted to the top of the file).
+const mockCreate = vi.hoisted(() => vi.fn());
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockCreate } };
+  },
+}));
+
+// Helper to build minimal valid Question objects
+function makeQuestion(
+  overrides: Partial<Question> & { id: string; question: string; answer: string }
+): Question {
+  return {
+    category: 'General Knowledge',
+    difficulty: 'Easy',
+    explanation: 'Test explanation.',
+    pillar: 'GlobalEh',
+    tags: ['Global', 'GlobalEh'],
+    acceptableAnswers: [],
+    sourceUrl: null,
+    sourceName: null,
+    status: 'approved',
+    aiAnalysis: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockCreate.mockReset();
+  // Default: GPT-4o says not a duplicate (prevents conceptual matches from
+  // interfering with tests that don't expect them)
+  mockCreate.mockResolvedValue({
+    choices: [
+      { message: { content: JSON.stringify({ isDuplicate: false, reasoning: 'Different.' }) } },
+    ],
+  });
+});
+
+describe('detectDuplicates — exact duplicates', () => {
+  it('detects exact duplicate question text (case-insensitive)', async () => {
+    const questions: Question[] = [
+      makeQuestion({ id: 'q1', question: 'What is the capital of France?', answer: 'Paris' }),
+      makeQuestion({ id: 'q2', question: 'What is the capital of France?', answer: 'Paris' }),
+      makeQuestion({ id: 'q3', question: 'What is the capital of Germany?', answer: 'Berlin' }),
+    ];
+
+    const report = await detectDuplicates(questions);
+
+    const exact = report.duplicatesFound.filter((m) => m.matchType === 'exact');
+    expect(exact).toHaveLength(1);
+    expect(exact[0].questionIdA).toBe('q1');
+    expect(exact[0].questionIdB).toBe('q2');
+    expect(exact[0].similarityScore).toBe(1);
+    expect(report.duplicatesByType.exact).toBe(1);
+    expect(report.duplicatesByType.near_duplicate).toBe(0);
+  });
+
+  it('detects exact duplicates with different casing and extra whitespace', async () => {
+    const questions: Question[] = [
+      makeQuestion({ id: 'q1', question: 'Who wrote Hamlet?', answer: 'Shakespeare' }),
+      makeQuestion({ id: 'q2', question: '  who wrote hamlet?  ', answer: 'Shakespeare' }),
+    ];
+
+    const report = await detectDuplicates(questions);
+
+    const exact = report.duplicatesFound.filter((m) => m.matchType === 'exact');
+    expect(exact).toHaveLength(1);
+    expect(exact[0].matchType).toBe('exact');
+  });
+
+  it('counts total pairs checked correctly for 3 questions', async () => {
+    const questions: Question[] = [
+      makeQuestion({ id: 'q1', question: 'Unique question one?', answer: 'Answer one' }),
+      makeQuestion({ id: 'q2', question: 'Unique question two?', answer: 'Answer two' }),
+      makeQuestion({ id: 'q3', question: 'Unique question three?', answer: 'Answer three' }),
+    ];
+
+    const report = await detectDuplicates(questions);
+    // 3 questions → 3 pairs: (q1,q2), (q1,q3), (q2,q3)
+    expect(report.totalPairsChecked).toBe(3);
+  });
+});
+
+describe('detectDuplicates — near-duplicates', () => {
+  it('detects near-duplicate question text at or above the 0.8 threshold', async () => {
+    const questions: Question[] = [
+      makeQuestion({
+        id: 'q1',
+        question: 'Which city is the capital of France?',
+        answer: 'Paris',
+      }),
+      makeQuestion({
+        id: 'q2',
+        // Very similar wording — should score >= 0.8
+        question: 'Which city is the capital of France, the country?',
+        answer: 'Paris',
+      }),
+    ];
+
+    const report = await detectDuplicates(questions);
+
+    const nearDups = report.duplicatesFound.filter(
+      (m) => m.matchType === 'near_duplicate' || m.matchType === 'exact'
+    );
+    expect(nearDups.length).toBeGreaterThanOrEqual(1);
+    expect(nearDups[0].similarityScore).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('does not flag clearly different question pairs as duplicates', async () => {
+    const questions: Question[] = [
+      makeQuestion({ id: 'q1', question: 'What is the capital of France?', answer: 'Paris' }),
+      makeQuestion({
+        id: 'q2',
+        question: 'Name the longest river in South America.',
+        answer: 'Amazon',
+      }),
+    ];
+
+    const report = await detectDuplicates(questions);
+
+    const textDups = report.duplicatesFound.filter(
+      (m) => m.matchType === 'near_duplicate' || m.matchType === 'exact'
+    );
+    expect(textDups).toHaveLength(0);
+  });
+});
+
+describe('detectDuplicates — conceptual duplicates', () => {
+  it('returns a conceptual match when GPT-4o says isDuplicate: true', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ isDuplicate: true, reasoning: 'Same underlying question.' }),
+          },
+        },
+      ],
+    });
+
+    const questions: Question[] = [
+      makeQuestion({ id: 'q1', question: 'What is the capital of France?', answer: 'Paris' }),
+      makeQuestion({
+        id: 'q2',
+        question: "Which city serves as France's capital?",
+        answer: 'Paris',
+      }),
+    ];
+
+    const report = await detectDuplicates(questions);
+
+    const conceptual = report.duplicatesFound.filter((m) => m.matchType === 'conceptual');
+    expect(conceptual.length).toBeGreaterThanOrEqual(1);
+    expect(conceptual[0].aiReasoning).toBe('Same underlying question.');
+    expect(report.duplicatesByType.conceptual).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not flag a pair as conceptual when GPT-4o returns isDuplicate: false', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ isDuplicate: false, reasoning: 'Different questions.' }),
+          },
+        },
+      ],
+    });
+
+    const questions: Question[] = [
+      makeQuestion({
+        id: 'q1',
+        question: 'Who invented the telephone?',
+        answer: 'Alexander Graham Bell',
+      }),
+      makeQuestion({
+        id: 'q2',
+        question: 'Who invented the light bulb?',
+        answer: 'Alexander Graham Bell',
+      }),
+    ];
+
+    const report = await detectDuplicates(questions);
+
+    const conceptual = report.duplicatesFound.filter((m) => m.matchType === 'conceptual');
+    expect(conceptual).toHaveLength(0);
+  });
+
+  it('does not call GPT-4o for pairs with dissimilar answers', async () => {
+    const questions: Question[] = [
+      makeQuestion({ id: 'q1', question: 'What is the capital of France?', answer: 'Paris' }),
+      makeQuestion({ id: 'q2', question: 'What is the tallest mountain?', answer: 'Everest' }),
+    ];
+
+    await detectDuplicates(questions);
+
+    // "Paris" vs "Everest" answer similarity is well below 0.7 — GPT should not be called
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('detectDuplicates — report structure', () => {
+  it('returns empty report for a single question', async () => {
+    const questions: Question[] = [
+      makeQuestion({ id: 'q1', question: 'What is 2 + 2?', answer: '4' }),
+    ];
+
+    const report = await detectDuplicates(questions);
+
+    expect(report.totalPairsChecked).toBe(0);
+    expect(report.duplicatesFound).toHaveLength(0);
+    expect(report.duplicatesByType.exact).toBe(0);
+    expect(report.duplicatesByType.near_duplicate).toBe(0);
+    expect(report.duplicatesByType.conceptual).toBe(0);
+  });
+
+  it('returns empty report for an empty array', async () => {
+    const report = await detectDuplicates([]);
+
+    expect(report.totalPairsChecked).toBe(0);
+    expect(report.duplicatesFound).toHaveLength(0);
+  });
+});

--- a/server/lib/duplicate-detector.ts
+++ b/server/lib/duplicate-detector.ts
@@ -1,0 +1,192 @@
+import stringSimilarity from 'string-similarity';
+import OpenAI from 'openai';
+
+import { batchProcess } from '../replit_integrations/batch';
+import type { Question } from '@shared/models/questions';
+
+const openai = new OpenAI({
+  apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY,
+  baseURL: process.env.AI_INTEGRATIONS_OPENAI_BASE_URL,
+});
+
+export interface DuplicateMatch {
+  questionIdA: string;
+  questionIdB: string;
+  matchType: 'exact' | 'near_duplicate' | 'conceptual';
+  similarityScore: number; // 0–1
+  questionTextA: string;
+  questionTextB: string;
+  answerA: string;
+  answerB: string;
+  aiReasoning?: string; // only for conceptual duplicates
+}
+
+export interface DuplicateDetectionReport {
+  totalPairsChecked: number;
+  duplicatesFound: DuplicateMatch[];
+  duplicatesByType: Record<DuplicateMatch['matchType'], number>;
+}
+
+const NEAR_DUPLICATE_THRESHOLD = 0.8;
+const ANSWER_SIMILARITY_THRESHOLD = 0.7;
+
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+interface ConceptualPair {
+  a: Question;
+  b: Question;
+  answerSimilarity: number;
+}
+
+interface RawConceptualResult {
+  isDuplicate?: boolean;
+  reasoning?: string;
+}
+
+async function checkConceptualDuplicate(pair: ConceptualPair): Promise<DuplicateMatch | null> {
+  const prompt = `Are these two trivia questions asking the same thing, despite different wording?
+
+Question A: "${pair.a.question}"
+Answer A: "${pair.a.answer}"
+
+Question B: "${pair.b.question}"
+Answer B: "${pair.b.answer}"
+
+Respond with JSON:
+{
+  "isDuplicate": true | false,
+  "reasoning": "short explanation"
+}`;
+
+  try {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a trivia content reviewer. Always respond with valid JSON.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      response_format: { type: 'json_object' },
+      max_tokens: 256,
+    });
+
+    const content = response.choices[0]?.message?.content || '{}';
+    const parsed = JSON.parse(content) as RawConceptualResult;
+
+    if (!parsed.isDuplicate) return null;
+
+    return {
+      questionIdA: pair.a.id,
+      questionIdB: pair.b.id,
+      matchType: 'conceptual',
+      similarityScore: pair.answerSimilarity,
+      questionTextA: pair.a.question,
+      questionTextB: pair.b.question,
+      answerA: pair.a.answer,
+      answerB: pair.b.answer,
+      aiReasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function detectDuplicates(questions: Question[]): Promise<DuplicateDetectionReport> {
+  const duplicatesFound: DuplicateMatch[] = [];
+  const seenPairs = new Set<string>();
+  const conceptualCandidates: ConceptualPair[] = [];
+
+  let totalPairsChecked = 0;
+
+  for (let i = 0; i < questions.length; i++) {
+    for (let j = i + 1; j < questions.length; j++) {
+      const a = questions[i];
+      const b = questions[j];
+      totalPairsChecked++;
+
+      const pairKey = `${a.id}::${b.id}`;
+
+      const normA = normalize(a.question);
+      const normB = normalize(b.question);
+
+      // Phase 1: Exact duplicate
+      if (normA === normB) {
+        seenPairs.add(pairKey);
+        duplicatesFound.push({
+          questionIdA: a.id,
+          questionIdB: b.id,
+          matchType: 'exact',
+          similarityScore: 1,
+          questionTextA: a.question,
+          questionTextB: b.question,
+          answerA: a.answer,
+          answerB: b.answer,
+        });
+        continue;
+      }
+
+      // Phase 2: Near-duplicate on question text
+      const questionSimilarity = stringSimilarity.compareTwoStrings(normA, normB);
+      if (questionSimilarity >= NEAR_DUPLICATE_THRESHOLD) {
+        seenPairs.add(pairKey);
+        duplicatesFound.push({
+          questionIdA: a.id,
+          questionIdB: b.id,
+          matchType: 'near_duplicate',
+          similarityScore: questionSimilarity,
+          questionTextA: a.question,
+          questionTextB: b.question,
+          answerA: a.answer,
+          answerB: b.answer,
+        });
+        continue;
+      }
+
+      // Phase 3: Collect candidates for conceptual duplicate check
+      // Only check pairs where answers are similar — avoids sending all pairs to GPT-4o
+      if (!seenPairs.has(pairKey)) {
+        const answerSimilarity = stringSimilarity.compareTwoStrings(
+          normalize(a.answer),
+          normalize(b.answer)
+        );
+        if (answerSimilarity >= ANSWER_SIMILARITY_THRESHOLD) {
+          conceptualCandidates.push({ a, b, answerSimilarity });
+        }
+      }
+    }
+  }
+
+  // Phase 3: Batch GPT-4o conceptual duplicate check
+  if (conceptualCandidates.length > 0) {
+    const conceptualResults = await batchProcess(
+      conceptualCandidates,
+      (pair) => checkConceptualDuplicate(pair),
+      { concurrency: 3 }
+    );
+
+    for (const result of conceptualResults) {
+      if (result !== null) {
+        duplicatesFound.push(result);
+      }
+    }
+  }
+
+  const duplicatesByType: Record<DuplicateMatch['matchType'], number> = {
+    exact: 0,
+    near_duplicate: 0,
+    conceptual: 0,
+  };
+  for (const match of duplicatesFound) {
+    duplicatesByType[match.matchType]++;
+  }
+
+  return {
+    totalPairsChecked,
+    duplicatesFound,
+    duplicatesByType,
+  };
+}

--- a/server/lib/verifier.ts
+++ b/server/lib/verifier.ts
@@ -1,0 +1,93 @@
+import OpenAI from 'openai';
+
+import { batchProcess } from '../replit_integrations/batch';
+import type { Question } from '@shared/models/questions';
+
+const openai = new OpenAI({
+  apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY,
+  baseURL: process.env.AI_INTEGRATIONS_OPENAI_BASE_URL,
+});
+
+export interface FactCheckVerdict {
+  questionId: string;
+  verdict: 'pass' | 'flag' | 'fail';
+  confidence: number; // 0–100
+  reason: string;
+}
+
+export interface FactCheckReport {
+  totalChecked: number;
+  results: FactCheckVerdict[];
+}
+
+interface RawVerdict {
+  verdict?: string;
+  confidence?: number;
+  reason?: string;
+}
+
+async function factCheckOne(question: Question): Promise<FactCheckVerdict> {
+  const prompt = `You are a trivia fact-checker. Evaluate the accuracy of the following trivia question and answer.
+
+Question: "${question.question}"
+Answer: "${question.answer}"
+Explanation: "${question.explanation}"
+
+Respond with JSON:
+{
+  "verdict": "pass" | "flag" | "fail",
+  "confidence": 0-100,
+  "reason": "short explanation"
+}
+
+Guidelines:
+- "pass": Factually correct and unambiguous
+- "flag": Possibly outdated, ambiguous, or could use verification
+- "fail": Clearly incorrect or misleading`;
+
+  const response = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are a fact-checking assistant for a trivia game. Always respond with valid JSON.',
+      },
+      { role: 'user', content: prompt },
+    ],
+    response_format: { type: 'json_object' },
+    max_tokens: 512,
+  });
+
+  const content = response.choices[0]?.message?.content || '{}';
+
+  try {
+    const parsed = JSON.parse(content) as RawVerdict;
+    const verdict =
+      parsed.verdict === 'pass' || parsed.verdict === 'fail' ? parsed.verdict : 'flag';
+    return {
+      questionId: question.id,
+      verdict,
+      confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 50,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : 'No reason provided.',
+    };
+  } catch {
+    return {
+      questionId: question.id,
+      verdict: 'flag',
+      confidence: 0,
+      reason: 'Failed to parse AI response.',
+    };
+  }
+}
+
+export async function batchFactCheck(questions: Question[]): Promise<FactCheckReport> {
+  const results = await batchProcess(questions, (question) => factCheckOne(question), {
+    concurrency: 3,
+  });
+
+  return {
+    totalChecked: questions.length,
+    results,
+  };
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -14,6 +14,9 @@ import {
 import { eq, and, sql, isNull } from 'drizzle-orm';
 import { analyzeDispute } from './lib/ai';
 import { generateQuestions } from './lib/guardian';
+import { auditQuestionQuality } from './lib/question-quality-audit';
+import { detectDuplicates } from './lib/duplicate-detector';
+import { batchFactCheck } from './lib/verifier';
 import { z } from 'zod';
 import { aiLimiter } from './middleware/rateLimiter';
 
@@ -464,6 +467,98 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     } catch (error) {
       console.error('Error promoting question:', error);
       res.status(500).json({ message: 'Failed to promote question' });
+    }
+  });
+
+  // Quality Sweep (Admin Only)
+  const sweepRequestSchema = z.object({
+    skipFactCheck: z.boolean().optional().default(false),
+    skipDuplicates: z.boolean().optional().default(false),
+  });
+
+  app.post('/api/admin/quality-sweep', isAuthenticated, isAdmin, aiLimiter, async (req, res) => {
+    try {
+      const parsed = sweepRequestSchema.parse(req.body);
+      const { skipFactCheck, skipDuplicates } = parsed;
+
+      // 1. Fetch all approved questions
+      const allQuestions = await db
+        .select()
+        .from(questions)
+        .where(eq(questions.status, 'approved'));
+
+      if (allQuestions.length === 0) {
+        return res.json({
+          generatedAt: new Date().toISOString(),
+          totalQuestions: 0,
+          audit: {
+            generatedAt: new Date().toISOString(),
+            totalQuestions: 0,
+            totalFindings: 0,
+            flaggedQuestionCount: 0,
+            findingsBySeverity: { high: 0, medium: 0, low: 0 },
+            findingsByRule: {},
+            findings: [],
+          },
+          duplicates: null,
+          factCheck: null,
+          recommendations: ['No approved questions found in the database.'],
+        });
+      }
+
+      // 2. Static audit (instant)
+      const audit = auditQuestionQuality(allQuestions);
+
+      // 3. Duplicate detection (GPT-4o for conceptual pairs only)
+      const duplicates = skipDuplicates ? null : await detectDuplicates(allQuestions);
+
+      // 4. Fact-checking (GPT-4o per question)
+      const factCheck = skipFactCheck ? null : await batchFactCheck(allQuestions);
+
+      // 5. Compute recommendations
+      const recommendations: string[] = [];
+      if (audit.findingsBySeverity.high > 0) {
+        recommendations.push(
+          `${audit.findingsBySeverity.high} high-severity audit finding(s) — fix before next release.`
+        );
+      }
+      if (audit.findingsBySeverity.medium > 0) {
+        recommendations.push(
+          `${audit.findingsBySeverity.medium} medium-severity audit finding(s) — review and improve.`
+        );
+      }
+      if (duplicates && duplicates.duplicatesFound.length > 0) {
+        recommendations.push(
+          `${duplicates.duplicatesFound.length} duplicate pair(s) found — remove or merge the lower-quality version of each pair.`
+        );
+      }
+      if (factCheck) {
+        const failures = factCheck.results.filter((r) => r.verdict === 'fail').length;
+        const flags = factCheck.results.filter((r) => r.verdict === 'flag').length;
+        if (failures > 0) {
+          recommendations.push(`${failures} question(s) failed fact-check — review immediately.`);
+        }
+        if (flags > 0) {
+          recommendations.push(
+            `${flags} question(s) flagged by fact-check — verify before next release.`
+          );
+        }
+      }
+      if (recommendations.length === 0) {
+        recommendations.push('No critical issues found. All approved questions passed the sweep.');
+      }
+
+      res.json({
+        generatedAt: new Date().toISOString(),
+        totalQuestions: allQuestions.length,
+        audit,
+        duplicates,
+        factCheck,
+        recommendations,
+      });
+    } catch (error) {
+      console.error('Error running quality sweep:', error);
+      res.status(500).json({ message: 'Quality sweep failed' });
     }
   });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -10,6 +10,8 @@ import {
   questions,
   seenQuestions,
   insertQuestionSchema,
+  questionQualitySweepDismissals,
+  duplicatePairKey,
 } from '@shared/schema';
 import { eq, and, sql, isNull } from 'drizzle-orm';
 import { analyzeDispute } from './lib/ai';
@@ -403,6 +405,28 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     }
   });
 
+  // Delete a question (admin only). Cascades to seen_questions and
+  // question_quality_sweep_dismissals via FK on delete cascade.
+  app.delete('/api/questions/:id', isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+
+      // Clean up seen_questions rows that don't have ON DELETE CASCADE.
+      await db.delete(seenQuestions).where(eq(seenQuestions.questionId, id));
+
+      const deleted = await db.delete(questions).where(eq(questions.id, id)).returning();
+
+      if (deleted.length === 0) {
+        return res.status(404).json({ message: 'Question not found' });
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error deleting question:', error);
+      res.status(500).json({ message: 'Failed to delete question' });
+    }
+  });
+
   // Staging API (Admin Only)
   app.get('/api/staging', isAuthenticated, isAdmin, async (req, res) => {
     try {
@@ -507,13 +531,78 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       }
 
       // 2. Static audit (instant)
-      const audit = auditQuestionQuality(allQuestions);
+      const auditRaw = auditQuestionQuality(allQuestions);
 
       // 3. Duplicate detection (GPT-4o for conceptual pairs only)
-      const duplicates = skipDuplicates ? null : await detectDuplicates(allQuestions);
+      const duplicatesRaw = skipDuplicates ? null : await detectDuplicates(allQuestions);
 
       // 4. Fact-checking (GPT-4o per question)
-      const factCheck = skipFactCheck ? null : await batchFactCheck(allQuestions);
+      const factCheckRaw = skipFactCheck ? null : await batchFactCheck(allQuestions);
+
+      // 4.5 Filter out previously-dismissed findings
+      const dismissals = await db.select().from(questionQualitySweepDismissals);
+      const dismissedStatic = new Set(
+        dismissals
+          .filter((d) => d.findingType === 'static')
+          .map((d) => `${d.questionId}::${d.findingKey}`)
+      );
+      const dismissedDuplicates = new Set(
+        dismissals.filter((d) => d.findingType === 'duplicate').map((d) => d.findingKey)
+      );
+      const dismissedFactCheck = new Set(
+        dismissals.filter((d) => d.findingType === 'fact_check').map((d) => d.questionId)
+      );
+
+      const filteredFindings = auditRaw.findings.filter(
+        (f) => !dismissedStatic.has(`${f.questionId}::${f.rule}`)
+      );
+      const recountedSeverity: Record<'high' | 'medium' | 'low', number> = {
+        high: 0,
+        medium: 0,
+        low: 0,
+      };
+      const recountedRule: Record<string, number> = {};
+      for (const ruleKey of Object.keys(auditRaw.findingsByRule)) {
+        recountedRule[ruleKey] = 0;
+      }
+      for (const f of filteredFindings) {
+        recountedSeverity[f.severity]++;
+        recountedRule[f.rule] = (recountedRule[f.rule] ?? 0) + 1;
+      }
+      const audit = {
+        ...auditRaw,
+        findings: filteredFindings,
+        totalFindings: filteredFindings.length,
+        flaggedQuestionCount: new Set(filteredFindings.map((f) => f.questionId)).size,
+        findingsBySeverity: recountedSeverity,
+        findingsByRule: recountedRule as typeof auditRaw.findingsByRule,
+      };
+
+      const duplicates = duplicatesRaw
+        ? (() => {
+            const filtered = duplicatesRaw.duplicatesFound.filter(
+              (m) => !dismissedDuplicates.has(duplicatePairKey(m.questionIdA, m.questionIdB))
+            );
+            const byType: Record<'exact' | 'near_duplicate' | 'conceptual', number> = {
+              exact: 0,
+              near_duplicate: 0,
+              conceptual: 0,
+            };
+            for (const m of filtered) byType[m.matchType]++;
+            return {
+              ...duplicatesRaw,
+              duplicatesFound: filtered,
+              duplicatesByType: byType,
+            };
+          })()
+        : null;
+
+      const factCheck = factCheckRaw
+        ? {
+            ...factCheckRaw,
+            results: factCheckRaw.results.filter((r) => !dismissedFactCheck.has(r.questionId)),
+          }
+        : null;
 
       // 5. Compute recommendations
       const recommendations: string[] = [];
@@ -559,6 +648,59 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     } catch (error) {
       console.error('Error running quality sweep:', error);
       res.status(500).json({ message: 'Quality sweep failed' });
+    }
+  });
+
+  // Dismiss a quality-sweep finding so it stops appearing in future sweeps.
+  const dismissRequestSchema = z.object({
+    questionId: z.string().min(1),
+    findingType: z.enum(['static', 'duplicate', 'fact_check']),
+    findingKey: z.string().min(1),
+    reason: z.string().optional(),
+  });
+
+  app.post('/api/admin/quality-sweep/dismiss', isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const parsed = dismissRequestSchema.parse(req.body);
+      const userId = getUserId(req);
+
+      // Idempotent: on conflict (unique index), return the existing row.
+      const [row] = await db
+        .insert(questionQualitySweepDismissals)
+        .values({
+          questionId: parsed.questionId,
+          findingType: parsed.findingType,
+          findingKey: parsed.findingKey,
+          reason: parsed.reason,
+          dismissedBy: userId,
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      if (row) {
+        return res.json({ id: row.id });
+      }
+
+      // Conflict — fetch the existing row to return its id.
+      const [existing] = await db
+        .select()
+        .from(questionQualitySweepDismissals)
+        .where(
+          and(
+            eq(questionQualitySweepDismissals.questionId, parsed.questionId),
+            eq(questionQualitySweepDismissals.findingType, parsed.findingType),
+            eq(questionQualitySweepDismissals.findingKey, parsed.findingKey)
+          )
+        )
+        .limit(1);
+
+      res.json({ id: existing?.id ?? '' });
+    } catch (error) {
+      console.error('Error dismissing finding:', error);
+      if (error instanceof z.ZodError) {
+        return res.status(422).json({ message: 'Invalid dismiss request', errors: error.errors });
+      }
+      res.status(500).json({ message: 'Failed to dismiss finding' });
     }
   });
 

--- a/shared/models/quality-sweep-dismissals.ts
+++ b/shared/models/quality-sweep-dismissals.ts
@@ -1,0 +1,34 @@
+import { sql } from 'drizzle-orm';
+import { pgTable, varchar, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+
+import { questions } from './questions';
+
+// Tracks quality-sweep findings that an admin has explicitly dismissed
+// (i.e. "Accept" — the finding is a false positive). Future sweep runs
+// filter out any finding whose (questionId, findingType, findingKey) tuple
+// matches a row here.
+export const questionQualitySweepDismissals = pgTable(
+  'question_quality_sweep_dismissals',
+  {
+    id: varchar('id')
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    questionId: varchar('question_id')
+      .notNull()
+      .references(() => questions.id, { onDelete: 'cascade' }),
+    // 'static' | 'duplicate' | 'fact_check'
+    findingType: varchar('finding_type', { length: 20 }).notNull(),
+    // For static: the rule name. For duplicate: sorted "{minId}::{maxId}".
+    // For fact_check: the literal "fact_check".
+    findingKey: text('finding_key').notNull(),
+    dismissedAt: timestamp('dismissed_at').notNull().defaultNow(),
+    dismissedBy: varchar('dismissed_by'),
+    reason: text('reason'),
+  },
+  (table) => [
+    uniqueIndex('idx_qsd_unique').on(table.questionId, table.findingType, table.findingKey),
+  ]
+);
+
+export type QualitySweepDismissal = typeof questionQualitySweepDismissals.$inferSelect;
+export type InsertQualitySweepDismissal = typeof questionQualitySweepDismissals.$inferInsert;

--- a/shared/models/quality-sweep.ts
+++ b/shared/models/quality-sweep.ts
@@ -87,3 +87,26 @@ export interface QualitySweepReport {
   factCheck: FactCheckReport | null;
   recommendations: string[];
 }
+
+// --- Dismissals API ---
+
+export type QualityFindingType = 'static' | 'duplicate' | 'fact_check';
+
+export interface DismissFindingRequest {
+  questionId: string;
+  findingType: QualityFindingType;
+  findingKey: string;
+  reason?: string;
+}
+
+export interface DismissFindingResponse {
+  id: string;
+}
+
+// Build the stable per-pair key used for duplicate dismissals.
+// Sorting ensures the same key regardless of (A, B) order.
+export function duplicatePairKey(idA: string, idB: string): string {
+  return idA < idB ? `${idA}::${idB}` : `${idB}::${idA}`;
+}
+
+export const FACT_CHECK_FINDING_KEY = 'fact_check';

--- a/shared/models/quality-sweep.ts
+++ b/shared/models/quality-sweep.ts
@@ -1,0 +1,89 @@
+// Shared types for the Quality Sweep API contract.
+// These mirror the server-side types from question-quality-audit.ts,
+// duplicate-detector.ts, and verifier.ts so the frontend can consume them.
+
+// --- Static audit types ---
+
+export type QuestionQualitySeverity = 'high' | 'medium' | 'low';
+
+export type QuestionQualityRule =
+  | 'missing_required_field'
+  | 'duplicate_question_id'
+  | 'invalid_difficulty'
+  | 'missing_required_tags'
+  | 'category_tag_mismatch'
+  | 'answer_leakage'
+  | 'subjective_prompt'
+  | 'ambiguous_prompt_format'
+  | 'multi_answer_mismatch'
+  | 'answer_type_mismatch'
+  | 'potentially_incorrect_or_unverifiable'
+  | 'missing_source_metadata';
+
+export interface QuestionQualityFinding {
+  questionId: string;
+  questionIndex: number;
+  severity: QuestionQualitySeverity;
+  rule: QuestionQualityRule;
+  message: string;
+}
+
+export interface QuestionQualityAuditReport {
+  generatedAt: string;
+  totalQuestions: number;
+  totalFindings: number;
+  flaggedQuestionCount: number;
+  findingsBySeverity: Record<QuestionQualitySeverity, number>;
+  findingsByRule: Record<QuestionQualityRule, number>;
+  findings: QuestionQualityFinding[];
+}
+
+// --- Duplicate detection types ---
+
+export interface DuplicateMatch {
+  questionIdA: string;
+  questionIdB: string;
+  matchType: 'exact' | 'near_duplicate' | 'conceptual';
+  similarityScore: number;
+  questionTextA: string;
+  questionTextB: string;
+  answerA: string;
+  answerB: string;
+  aiReasoning?: string;
+}
+
+export interface DuplicateDetectionReport {
+  totalPairsChecked: number;
+  duplicatesFound: DuplicateMatch[];
+  duplicatesByType: Record<DuplicateMatch['matchType'], number>;
+}
+
+// --- Fact-check types ---
+
+export interface FactCheckVerdict {
+  questionId: string;
+  verdict: 'pass' | 'flag' | 'fail';
+  confidence: number;
+  reason: string;
+}
+
+export interface FactCheckReport {
+  totalChecked: number;
+  results: FactCheckVerdict[];
+}
+
+// --- Quality sweep API contract ---
+
+export interface QualitySweepRequest {
+  skipFactCheck?: boolean;
+  skipDuplicates?: boolean;
+}
+
+export interface QualitySweepReport {
+  generatedAt: string;
+  totalQuestions: number;
+  audit: QuestionQualityAuditReport;
+  duplicates: DuplicateDetectionReport | null;
+  factCheck: FactCheckReport | null;
+  recommendations: string[];
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -15,6 +15,9 @@ export * from './models/questions';
 // Export quality sweep API types
 export * from './models/quality-sweep';
 
+// Export quality sweep dismissals (DB table)
+export * from './models/quality-sweep-dismissals';
+
 // Disputes table for QA logging
 export const disputes = pgTable('disputes', {
   id: varchar('id')

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -12,6 +12,9 @@ export * from './models/chat';
 // Export question models (questions DB + seen-question tracking)
 export * from './models/questions';
 
+// Export quality sweep API types
+export * from './models/quality-sweep';
+
 // Disputes table for QA logging
 export const disputes = pgTable('disputes', {
   id: varchar('id')


### PR DESCRIPTION
## Summary

Delivers the full AI Quality Sweep feature (STE-9 / STE-31) in two commits:

- **Commit 1** — CLI sweep script + read-only admin panel page at `/admin/quality-sweep`
- **Commit 2** — Makes every finding actionable: Accept, Edit, Delete

## What's included

### Sweep engine
- `server/lib/verifier.ts` — `batchFactCheck()` via GPT-4o (concurrency 3)
- `server/lib/duplicate-detector.ts` — 3-phase: exact, near-duplicate (string-similarity ≥ 0.8), conceptual (GPT-4o for answer-similar pairs)
- `server/lib/question-quality-audit.ts` — deterministic static audit (12 rules)
- `script/quality-sweep.ts` — CLI with `--skip-fact-check`, `--skip-duplicates`, `--fail-on-high` flags

### Admin panel (`/admin/quality-sweep`)
- Run controls with "skip" checkboxes for expensive GPT-4o operations
- Inline report: Summary, Recommendations, Duplicates, Static Audit Findings, Fact-Check Results

### Per-finding actions
- **Accept** — dismisses to `question_quality_sweep_dismissals` table; filtered out of all future sweeps
- **Edit** — inline editor (question/answer/explanation) with touched-field draft tracking; saves via `PATCH /api/questions/:id`
- **Delete** — AlertDialog confirmation + new `DELETE /api/questions/:id` endpoint
- Duplicate pairs show side-by-side with per-side Edit/Delete + shared "Accept pair"

### New API endpoints
- `POST /api/admin/quality-sweep` — runs the sweep, returns filtered report
- `POST /api/admin/quality-sweep/dismiss` — persists a dismissal (idempotent)
- `DELETE /api/questions/:id` — deletes a question (cascades seen_questions)

### New DB table
`question_quality_sweep_dismissals` — unique on `(questionId, findingType, findingKey)`

> ⚠️ **Run `npm run db:push` in Replit** to create the new table before testing.

## Test plan

- [ ] `npm run db:push` in Replit dev
- [ ] Navigate to `/admin/quality-sweep`, run sweep
- [ ] Accept a static finding → re-run → finding does not reappear
- [ ] Edit a fact-check finding → save → question updated in DB
- [ ] Delete a duplicate pair member → confirm → question removed
- [ ] Non-admin sees access denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)