### PR TITLE
docs(agents): add Documentation Confirmation rule to agent manuals [STE-145]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,22 @@ When closing a sub-issue with a `parentId`, follow `.agent/workflows/linear-pare
 
 CI gates (`.github/workflows/ci.yml`) must pass before merge. Fix failures, don't bypass.
 
+## Documentation Confirmation
+
+When finishing any task, **always confirm to the user what documentation was updated**. Report:
+
+1. **What** was documented — issue state change, release notes, PR description, test coverage, README/guide edits, config changes, etc.
+2. **Where** it lives — Linear issue ID + URL, GitHub release tag, file path, PR number, etc.
+
+This applies to every task completion. Specific expectations:
+
+- **Linear:** Move the issue to the correct state. Leave a closing comment summarizing what was shipped (what changed, what files, any trade-offs or follow-ups).
+- **GitHub releases:** Create a release when shipping a user-visible fix or feature. Bug fixes → patch version (e.g. v0.5.1). New features → minor version (e.g. v0.6.0). Breaking changes → major version.
+- **PR descriptions:** Must clearly describe what changed and why before requesting merge.
+- **`CLAUDE.md` / `AGENTS.md` / `replit.md`:** Update all three files in sync whenever agent workflow rules change. See Sync Contract above.
+
+Do not report a task as complete until documentation is confirmed. The user's signal that this is working: every task handoff includes an explicit "Documentation updated" confirmation listing the what and where.
+
 ## References
 
 - Product context: `README.md`, `docs/PRODUCT_ROADMAP.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,22 @@ When closing a sub-issue with a `parentId`, follow `.agent/workflows/linear-pare
 
 CI gates (`.github/workflows/ci.yml`) must pass before merge. Fix failures, don't bypass.
 
+## Documentation Confirmation
+
+When finishing any task, **always confirm to the user what documentation was updated**. Report:
+
+1. **What** was documented — issue state change, release notes, PR description, test coverage, README/guide edits, config changes, etc.
+2. **Where** it lives — Linear issue ID + URL, GitHub release tag, file path, PR number, etc.
+
+This applies to every task completion. Specific expectations:
+
+- **Linear:** Move the issue to the correct state. Leave a closing comment summarizing what was shipped (what changed, what files, any trade-offs or follow-ups).
+- **GitHub releases:** Create a release when shipping a user-visible fix or feature. Bug fixes → patch version (e.g. v0.5.1). New features → minor version (e.g. v0.6.0). Breaking changes → major version.
+- **PR descriptions:** Must clearly describe what changed and why before requesting merge.
+- **`CLAUDE.md` / `AGENTS.md` / `replit.md`:** Update all three files in sync whenever agent workflow rules change. See Sync Contract above.
+
+Do not report a task as complete until documentation is confirmed. The user's signal that this is working: every task handoff includes an explicit "Documentation updated" confirmation listing the what and where.
+
 ## References
 
 - Product context: `README.md`, `docs/PRODUCT_ROADMAP.md`

--- a/replit.md
+++ b/replit.md
@@ -102,6 +102,22 @@ When closing a sub-issue with a `parentId`, follow `.agent/workflows/linear-pare
 
 CI gates (`.github/workflows/ci.yml`) must pass before merge. Fix failures, don't bypass.
 
+## Documentation Confirmation
+
+When finishing any task, **always confirm to the user what documentation was updated**. Report:
+
+1. **What** was documented — issue state change, release notes, PR description, test coverage, README/guide edits, config changes, etc.
+2. **Where** it lives — Linear issue ID + URL, GitHub release tag, file path, PR number, etc.
+
+This applies to every task completion. Specific expectations:
+
+- **Linear:** Move the issue to the correct state. Leave a closing comment summarizing what was shipped (what changed, what files, any trade-offs or follow-ups).
+- **GitHub releases:** Create a release when shipping a user-visible fix or feature. Bug fixes → patch version (e.g. v0.5.1). New features → minor version (e.g. v0.6.0). Breaking changes → major version.
+- **PR descriptions:** Must clearly describe what changed and why before requesting merge.
+- **`CLAUDE.md` / `AGENTS.md` / `replit.md`:** Update all three files in sync whenever agent workflow rules change. See Sync Contract above.
+
+Do not report a task as complete until documentation is confirmed. The user's signal that this is working: every task handoff includes an explicit "Documentation updated" confirmation listing the what and where.
+
 ## References
 
 - Product context: `README.md`, `docs/PRODUCT_ROADMAP.md`


### PR DESCRIPTION
## Summary

- Adds a **Documentation Confirmation** section to `CLAUDE.md`, `AGENTS.md`, and `replit.md` (all three kept in sync per the existing Sync Contract).
- The rule requires every agent to explicitly confirm to the user what documentation was updated at the end of each task — what was documented and where (Linear issue ID/URL, GitHub release tag, file path, PR number, etc.).
- Includes specific expectations for Linear state + closing comment, GitHub release versioning guidance (patch/minor/major), PR descriptions, and agent manual sync.

## Why

This rule was requested after completing STE-145: the user's signal that documentation is actually happening is that every task handoff includes an explicit "Documentation updated" confirmation listing the what and where. Without a written rule, agents (Claude, Codex, Replit, Antigravity) won't do this consistently.

## What changed

- `CLAUDE.md` — new "Documentation Confirmation" section between "Quality Gates" and "References"
- `AGENTS.md` — identical update (Sync Contract)
- `replit.md` — identical update (Sync Contract)

No source code changes. No tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)