### PR TITLE
feat(quality-sweep): show category, difficulty, and source in detail view [STE-150]

### DIFF
--- a/client/src/pages/admin-quality-sweep.tsx
+++ b/client/src/pages/admin-quality-sweep.tsx
@@ -294,6 +294,25 @@ function ExpandableDetails({
       </button>
       {open && (
         <div className="mt-2 pt-2 border-t border-white/10 space-y-3">
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="text-xs border-white/20">
+              {snapshot.category}
+            </Badge>
+            {snapshot.difficulty && (
+              <Badge variant="outline" className="text-xs border-white/20">
+                {snapshot.difficulty}
+              </Badge>
+            )}
+            {snapshot.sourceDomain ? (
+              <Badge variant="outline" className="text-xs border-white/20">
+                Source: {snapshot.sourceDomain}
+              </Badge>
+            ) : !snapshot.hasSource ? (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-300">
+                no source
+              </span>
+            ) : null}
+          </div>
           <div>
             <p className="text-[10px] uppercase text-muted-foreground mb-1">Answer</p>
             <HiddenAnswer answer={snapshot.answer} />
@@ -1164,9 +1183,25 @@ function DuplicatesSection({
                       <div className="flex items-center gap-2 flex-wrap">
                         <span className="font-mono text-[10px] text-muted-foreground">{qId}</span>
                         {snapshot && (
-                          <span className="text-[10px] text-muted-foreground">
-                            {snapshot.category} / {snapshot.pillar}
-                          </span>
+                          <>
+                            <Badge variant="outline" className="text-xs border-white/20">
+                              {snapshot.category}
+                            </Badge>
+                            {snapshot.difficulty && (
+                              <Badge variant="outline" className="text-xs border-white/20">
+                                {snapshot.difficulty}
+                              </Badge>
+                            )}
+                            {snapshot.sourceDomain ? (
+                              <Badge variant="outline" className="text-xs border-white/20">
+                                Source: {snapshot.sourceDomain}
+                              </Badge>
+                            ) : !snapshot.hasSource ? (
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-300">
+                                no source
+                              </span>
+                            ) : null}
+                          </>
                         )}
                       </div>
                       <p className="text-sm font-medium text-white/90 leading-snug">
@@ -1320,10 +1355,26 @@ function FactCheckSection({
                   <span className="font-mono text-xs text-muted-foreground">
                     {result.questionId}
                   </span>
-                  {snapshot && !snapshot.hasSource && (
-                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-300">
-                      no source
-                    </span>
+                  {snapshot && (
+                    <>
+                      <Badge variant="outline" className="text-xs border-white/20">
+                        {snapshot.category}
+                      </Badge>
+                      {snapshot.difficulty && (
+                        <Badge variant="outline" className="text-xs border-white/20">
+                          {snapshot.difficulty}
+                        </Badge>
+                      )}
+                      {snapshot.sourceDomain ? (
+                        <Badge variant="outline" className="text-xs border-white/20">
+                          Source: {snapshot.sourceDomain}
+                        </Badge>
+                      ) : !snapshot.hasSource ? (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-300">
+                          no source
+                        </span>
+                      ) : null}
+                    </>
                   )}
                 </div>
                 {snapshot && (

--- a/client/src/pages/admin-quality-sweep.tsx
+++ b/client/src/pages/admin-quality-sweep.tsx
@@ -303,15 +303,16 @@ function ExpandableDetails({
                 {snapshot.difficulty}
               </Badge>
             )}
-            {snapshot.sourceDomain ? (
+            {snapshot.sourceDomain && (
               <Badge variant="outline" className="text-xs border-white/20">
                 Source: {snapshot.sourceDomain}
               </Badge>
-            ) : !snapshot.hasSource ? (
+            )}
+            {!snapshot.hasSource && (
               <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-300">
                 no source
               </span>
-            ) : null}
+            )}
           </div>
           <div>
             <p className="text-[10px] uppercase text-muted-foreground mb-1">Answer</p>
@@ -1192,15 +1193,16 @@ function DuplicatesSection({
                                 {snapshot.difficulty}
                               </Badge>
                             )}
-                            {snapshot.sourceDomain ? (
+                            {snapshot.sourceDomain && (
                               <Badge variant="outline" className="text-xs border-white/20">
                                 Source: {snapshot.sourceDomain}
                               </Badge>
-                            ) : !snapshot.hasSource ? (
+                            )}
+                            {!snapshot.hasSource && (
                               <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-300">
                                 no source
                               </span>
-                            ) : null}
+                            )}
                           </>
                         )}
                       </div>
@@ -1365,15 +1367,16 @@ function FactCheckSection({
                           {snapshot.difficulty}
                         </Badge>
                       )}
-                      {snapshot.sourceDomain ? (
+                      {snapshot.sourceDomain && (
                         <Badge variant="outline" className="text-xs border-white/20">
                           Source: {snapshot.sourceDomain}
                         </Badge>
-                      ) : !snapshot.hasSource ? (
+                      )}
+                      {!snapshot.hasSource && (
                         <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-300">
                           no source
                         </span>
-                      ) : null}
+                      )}
                     </>
                   )}
                 </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -978,26 +978,11 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             if (hostname.includes('britannica.com')) return 'Britannica';
             if (hostname.includes('history.com')) return 'History.com';
             if (hostname.includes('nationalgeographic.com')) return 'National Geographic';
-            // Reduce unknown hosts to registrable domain to strip
-            // answer-bearing subdomains like "denali.fandom.com".
-            // Handle multi-level TLDs (.co.uk, .com.au, .org.uk, etc.)
-            const parts = hostname.split('.');
-            const MULTI_LEVEL_TLDS = new Set([
-              'co.uk',
-              'org.uk',
-              'com.au',
-              'co.nz',
-              'co.jp',
-              'co.kr',
-              'com.br',
-              'co.in',
-              'co.za',
-            ]);
-            const lastTwo = parts.slice(-2).join('.');
-            if (parts.length >= 3 && MULTI_LEVEL_TLDS.has(lastTwo)) {
-              return parts.slice(-3).join('.');
-            }
-            return lastTwo;
+            // Unknown domain — suppress rather than risk leaking the answer
+            // via the domain itself (e.g. "denali.com") or a subdomain.
+            // Known providers above cover the major sources; for everything
+            // else, omit the badge entirely.
+            return null;
           } catch {
             // URL parse failed — fall through to sourceName
           }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -14,6 +14,7 @@ import {
   questionEdits,
   questionQualitySweepDismissals,
   duplicatePairKey,
+  type QuestionSnapshot,
 } from '@shared/schema';
 import { eq, and, sql } from 'drizzle-orm';
 import { analyzeDispute } from './lib/ai';
@@ -962,17 +963,34 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
         ...(factCheck?.results.map((r) => r.questionId) ?? []),
         ...(duplicates?.duplicatesFound.flatMap((m) => [m.questionIdA, m.questionIdB]) ?? []),
       ]);
-      const questionsById: Record<
-        string,
-        {
-          question: string;
-          answer: string;
-          tags: string[];
-          category: string;
-          pillar: string;
-          hasSource: boolean;
+
+      // Sanitize source URL/name to a domain label (e.g. "Wikipedia") so the
+      // raw article title never reaches the client and can't leak the answer.
+      const extractSourceDomain = (
+        sourceUrl: string | null | undefined,
+        sourceName: string | null | undefined
+      ): string | null => {
+        if (!sourceUrl && !sourceName) return null;
+        if (sourceUrl) {
+          try {
+            const hostname = new URL(sourceUrl).hostname.replace(/^www\./, '');
+            if (hostname.includes('wikipedia.org')) return 'Wikipedia';
+            if (hostname.includes('britannica.com')) return 'Britannica';
+            if (hostname.includes('history.com')) return 'History.com';
+            if (hostname.includes('nationalgeographic.com')) return 'National Geographic';
+            return hostname;
+          } catch {
+            // URL parse failed — fall through to sourceName
+          }
         }
-      > = {};
+        if (sourceName) {
+          const cleaned = sourceName.split(/\s*[-–—:]\s*/)[0].trim();
+          return cleaned || sourceName;
+        }
+        return null;
+      };
+
+      const questionsById: Record<string, QuestionSnapshot> = {};
       for (const q of allQuestions) {
         if (flaggedIds.has(q.id)) {
           questionsById[q.id] = {
@@ -982,6 +1000,8 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             category: q.category,
             pillar: q.pillar,
             hasSource: !!(q.sourceUrl && q.sourceName),
+            difficulty: q.difficulty,
+            sourceDomain: extractSourceDomain(q.sourceUrl, q.sourceName),
           };
         }
       }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -978,7 +978,10 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             if (hostname.includes('britannica.com')) return 'Britannica';
             if (hostname.includes('history.com')) return 'History.com';
             if (hostname.includes('nationalgeographic.com')) return 'National Geographic';
-            return hostname;
+            // Reduce unknown hosts to registrable domain (last 2 parts) to
+            // strip answer-bearing subdomains like "denali.fandom.com".
+            const parts = hostname.split('.');
+            return parts.slice(-2).join('.');
           } catch {
             // URL parse failed — fall through to sourceName
           }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -984,8 +984,20 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
           }
         }
         if (sourceName) {
-          const cleaned = sourceName.split(/\s*[-–—:]\s*/)[0].trim();
-          return cleaned || sourceName;
+          // Search all tokens for a known provider rather than blindly taking
+          // the first token — e.g. "Denali - Wikipedia" must not return "Denali".
+          const KNOWN_PROVIDERS: [RegExp, string][] = [
+            [/wikipedia/i, 'Wikipedia'],
+            [/britannica/i, 'Britannica'],
+            [/history\.com|history channel/i, 'History.com'],
+            [/national\s*geographic/i, 'National Geographic'],
+          ];
+          for (const [pattern, label] of KNOWN_PROVIDERS) {
+            if (pattern.test(sourceName)) return label;
+          }
+          // No known provider found — omit the badge rather than risk leaking
+          // an article title that contains the answer.
+          return null;
         }
         return null;
       };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -978,10 +978,26 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             if (hostname.includes('britannica.com')) return 'Britannica';
             if (hostname.includes('history.com')) return 'History.com';
             if (hostname.includes('nationalgeographic.com')) return 'National Geographic';
-            // Reduce unknown hosts to registrable domain (last 2 parts) to
-            // strip answer-bearing subdomains like "denali.fandom.com".
+            // Reduce unknown hosts to registrable domain to strip
+            // answer-bearing subdomains like "denali.fandom.com".
+            // Handle multi-level TLDs (.co.uk, .com.au, .org.uk, etc.)
             const parts = hostname.split('.');
-            return parts.slice(-2).join('.');
+            const MULTI_LEVEL_TLDS = new Set([
+              'co.uk',
+              'org.uk',
+              'com.au',
+              'co.nz',
+              'co.jp',
+              'co.kr',
+              'com.br',
+              'co.in',
+              'co.za',
+            ]);
+            const lastTwo = parts.slice(-2).join('.');
+            if (parts.length >= 3 && MULTI_LEVEL_TLDS.has(lastTwo)) {
+              return parts.slice(-3).join('.');
+            }
+            return lastTwo;
           } catch {
             // URL parse failed — fall through to sourceName
           }
@@ -1016,7 +1032,11 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             pillar: q.pillar,
             hasSource: !!(q.sourceUrl && q.sourceName),
             difficulty: q.difficulty,
-            sourceDomain: extractSourceDomain(q.sourceUrl, q.sourceName),
+            // Only expose sourceDomain when full metadata is present (both URL
+            // and name). This keeps hasSource and sourceDomain consistent so the
+            // UI never shows "Source: ..." and "no source" simultaneously.
+            sourceDomain:
+              q.sourceUrl && q.sourceName ? extractSourceDomain(q.sourceUrl, q.sourceName) : null,
           };
         }
       }

--- a/shared/models/quality-sweep.ts
+++ b/shared/models/quality-sweep.ts
@@ -36,6 +36,8 @@ export interface QuestionSnapshot {
   category: string;
   pillar: string;
   hasSource: boolean;
+  difficulty: string;
+  sourceDomain: string | null;
 }
 
 export interface QuestionQualityAuditReport {


### PR DESCRIPTION
## Summary

- Expand the finding detail view in quality sweep to show category, difficulty, and source — matching the staging/review screens
- Server sanitizes source URLs to domain-only labels (e.g. `https://en.wikipedia.org/wiki/Denali` → `"Wikipedia"`) so article titles cannot accidentally leak the answer
- Answer stays hidden by default via the existing reveal toggle

## Changes

- `shared/models/quality-sweep.ts` — added `difficulty: string` and `sourceDomain: string | null` to `QuestionSnapshot`
- `server/routes.ts` — added `extractSourceDomain()` helper; updated snapshot builder to include new fields; typed with shared `QuestionSnapshot`
- `client/src/pages/admin-quality-sweep.tsx` — updated `ExpandableDetails`, `DuplicatesSection`, and `FactCheckSection` to show the new badges

## Test plan

- [ ] Run a quality sweep and expand details on an audit finding — verify category, difficulty, and source badges appear
- [ ] Verify answer remains hidden by default with reveal toggle working
- [ ] Check a question with a Wikipedia source — confirm only "Wikipedia" appears, not the article title
- [ ] Check a question with no source — confirm "no source" orange badge appears
- [ ] Verify duplicates cluster cards show difficulty and source alongside category
- [ ] Verify fact-check rows show category, difficulty, and source

Closes STE-150 / part of STE-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)