### PR TITLE
feat(quality-sweep): detect keyword overlap and morphological answer leakage [STE-149]

### DIFF
--- a/server/lib/question-quality-audit.test.ts
+++ b/server/lib/question-quality-audit.test.ts
@@ -80,6 +80,113 @@ describe('auditQuestionQuality', () => {
     expect(report.findingsBySeverity.medium).toBeGreaterThanOrEqual(3);
   });
 
+  it('detects keyword leakage when a significant answer word appears in the question', () => {
+    const report = auditQuestionQuality([
+      {
+        id: 'kw1',
+        category: 'Geography',
+        difficulty: 'Medium',
+        question: 'What is the tallest peak, sometimes called Everest, in the Himalayas?',
+        answer: 'Mount Everest',
+        explanation: 'Mount Everest is the tallest peak at 8,849m.',
+        tags: ['Global', 'Geography', 'GlobalEh'],
+        sourceUrl: 'https://example.com/everest',
+        sourceName: 'National Geographic',
+      },
+    ]);
+
+    const leakFindings = report.findings.filter((f) => f.rule === 'answer_leakage');
+    expect(leakFindings.length).toBeGreaterThanOrEqual(1);
+    expect(leakFindings.some((f) => f.severity === 'medium' && f.message.includes('everest'))).toBe(
+      true
+    );
+  });
+
+  it('detects morphological leakage when question word shares a root with answer keyword', () => {
+    const report = auditQuestionQuality([
+      {
+        id: 'morph1',
+        category: 'Science',
+        difficulty: 'Hard',
+        question: 'Which process is photosynthetic in nature?',
+        answer: 'Photosynthesis',
+        explanation: 'Photosynthesis converts light into chemical energy.',
+        tags: ['Global', 'Science', 'GlobalEh'],
+        sourceUrl: 'https://example.com/bio',
+        sourceName: 'Biology textbook',
+      },
+    ]);
+
+    const leakFindings = report.findings.filter((f) => f.rule === 'answer_leakage');
+    expect(leakFindings.length).toBeGreaterThanOrEqual(1);
+    expect(
+      leakFindings.some((f) => f.severity === 'low' && f.message.includes('shares a root'))
+    ).toBe(true);
+  });
+
+  it('detects morphological leakage for confederation/confederated', () => {
+    const report = auditQuestionQuality([
+      {
+        id: 'morph2',
+        category: 'History',
+        difficulty: 'Medium',
+        question: 'When was Canada confederated into a single dominion?',
+        answer: 'Confederation',
+        explanation: 'Canadian Confederation occurred on July 1, 1867.',
+        tags: ['CA', 'History', 'TimeCapsule'],
+        sourceUrl: 'https://example.com/confederation',
+        sourceName: 'Canadian Encyclopedia',
+      },
+    ]);
+
+    const leakFindings = report.findings.filter((f) => f.rule === 'answer_leakage');
+    expect(leakFindings.length).toBeGreaterThanOrEqual(1);
+    expect(
+      leakFindings.some((f) => f.severity === 'low' && f.message.includes('shares a root'))
+    ).toBe(true);
+  });
+
+  it('does not flag stopwords as keyword leakage', () => {
+    const report = auditQuestionQuality([
+      {
+        id: 'stop1',
+        category: 'History',
+        difficulty: 'Medium',
+        question: 'What is the name of the ancient structure in China?',
+        answer: 'The Great Wall',
+        explanation: 'The Great Wall of China is over 13,000 miles long.',
+        tags: ['Global', 'History', 'TimeCapsule'],
+        sourceUrl: 'https://example.com/wall',
+        sourceName: 'Encyclopedia',
+      },
+    ]);
+
+    const leakFindings = report.findings.filter((f) => f.rule === 'answer_leakage');
+    expect(
+      leakFindings.some((f) => f.message.includes('"the"') || f.message.includes('"great"'))
+    ).toBe(false);
+  });
+
+  it('does not double-report keyword leakage when full answer already matches', () => {
+    const report = auditQuestionQuality([
+      {
+        id: 'dup1',
+        category: 'Music',
+        difficulty: 'Easy',
+        question: 'What Canadian musician is known as Oscar Peterson?',
+        answer: 'Oscar Peterson',
+        explanation: 'Oscar Peterson was a Canadian jazz pianist.',
+        tags: ['CA', 'Music', 'TimeCapsule'],
+        sourceUrl: 'https://example.com/oscar',
+        sourceName: 'Jazz Archive',
+      },
+    ]);
+
+    const leakFindings = report.findings.filter((f) => f.rule === 'answer_leakage');
+    expect(leakFindings.length).toBe(1);
+    expect(leakFindings[0].severity).toBe('high');
+  });
+
   it('returns a concise human-readable summary', () => {
     const report = auditQuestionQuality([
       {

--- a/server/lib/question-quality-audit.ts
+++ b/server/lib/question-quality-audit.ts
@@ -230,7 +230,6 @@ const STEM_RULES: [RegExp, string][] = [
   [/ed$/, ''],
   [/ly$/, ''],
   [/er$/, ''],
-  [/est$/, ''],
   [/es$/, ''],
   [/s$/, ''],
 ];

--- a/server/lib/question-quality-audit.ts
+++ b/server/lib/question-quality-audit.ts
@@ -104,6 +104,154 @@ function isLeakCandidate(candidate: string): boolean {
   return candidate.length >= 4;
 }
 
+const STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'and',
+  'or',
+  'but',
+  'in',
+  'on',
+  'at',
+  'to',
+  'for',
+  'of',
+  'with',
+  'by',
+  'from',
+  'is',
+  'it',
+  'its',
+  'was',
+  'are',
+  'were',
+  'be',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'do',
+  'does',
+  'did',
+  'will',
+  'would',
+  'could',
+  'should',
+  'may',
+  'might',
+  'shall',
+  'can',
+  'this',
+  'that',
+  'these',
+  'those',
+  'he',
+  'she',
+  'they',
+  'we',
+  'you',
+  'who',
+  'whom',
+  'which',
+  'what',
+  'where',
+  'when',
+  'why',
+  'how',
+  'not',
+  'no',
+  'nor',
+  'so',
+  'if',
+  'then',
+  'than',
+  'too',
+  'very',
+  'just',
+  'about',
+  'also',
+  'into',
+  'over',
+  'after',
+  'before',
+  'called',
+  'known',
+  'name',
+  'named',
+  'type',
+  'kind',
+  'form',
+  'first',
+  'last',
+  'most',
+  'many',
+  'much',
+  'more',
+  'some',
+  'new',
+  'old',
+  'great',
+  'big',
+  'small',
+  'long',
+  'short',
+  'world',
+  'country',
+  'city',
+  'state',
+  'part',
+]);
+
+const STEM_RULES: [RegExp, string][] = [
+  [/isation$/, 'ise'],
+  [/ization$/, 'ize'],
+  [/ically$/, 'ic'],
+  [/ation$/, ''],
+  [/ness$/, ''],
+  [/ment$/, ''],
+  [/ical$/, 'ic'],
+  [/ious$/, ''],
+  [/eous$/, ''],
+  [/ible$/, ''],
+  [/able$/, ''],
+  [/ting$/, 't'],
+  [/ling$/, 'l'],
+  [/ning$/, 'n'],
+  [/sis$/, ''],
+  [/tic$/, ''],
+  [/ing$/, ''],
+  [/ies$/, 'y'],
+  [/ied$/, 'y'],
+  [/ated$/, ''],
+  [/ted$/, 't'],
+  [/ded$/, 'd'],
+  [/ed$/, ''],
+  [/ly$/, ''],
+  [/er$/, ''],
+  [/est$/, ''],
+  [/es$/, ''],
+  [/s$/, ''],
+];
+
+function stemWord(word: string): string {
+  if (word.length < 5) return word;
+  for (const [suffix, replacement] of STEM_RULES) {
+    if (suffix.test(word)) {
+      const result = word.replace(suffix, replacement);
+      if (result.length >= 3) return result;
+    }
+  }
+  return word;
+}
+
+function extractKeywords(normalizedText: string): string[] {
+  return normalizedText
+    .split(/\s+/)
+    .filter((word) => isLeakCandidate(word) && !STOPWORDS.has(word));
+}
+
 function answerLooksNumeric(answer: string): boolean {
   const normalized = answer.toLowerCase();
   return /\d/.test(normalized) || NUMBER_WORD_PATTERN.test(normalized);
@@ -163,7 +311,14 @@ function pushFinding(
   message: string,
   proposedFix?: Record<string, unknown>
 ) {
-  findings.push({ questionId, questionIndex, severity, rule, message, ...(proposedFix ? { proposedFix } : {}) });
+  findings.push({
+    questionId,
+    questionIndex,
+    severity,
+    rule,
+    message,
+    ...(proposedFix ? { proposedFix } : {}),
+  });
 }
 
 export function auditQuestionQuality(questions: RawTriviaQuestion[]): QuestionQualityAuditReport {
@@ -294,6 +449,14 @@ export function auditQuestionQuality(questions: RawTriviaQuestion[]): QuestionQu
       .map((entry) => normalize(entry))
       .filter((entry) => isLeakCandidate(entry));
 
+    const questionWords = normalizedQuestion
+      ? normalizedQuestion.split(/\s+/).filter((w) => w.length >= 4)
+      : [];
+    const questionStemMap = new Map<string, string>();
+    for (const qw of questionWords) {
+      questionStemMap.set(stemWord(qw), qw);
+    }
+
     for (const candidate of answerCandidates) {
       if (normalizedQuestion && containsCandidate(normalizedQuestion, candidate)) {
         pushFinding(
@@ -304,6 +467,40 @@ export function auditQuestionQuality(questions: RawTriviaQuestion[]): QuestionQu
           'answer_leakage',
           `Answer candidate "${candidate}" appears in the question text.`
         );
+        continue;
+      }
+
+      const keywords = candidate.includes(' ')
+        ? extractKeywords(candidate)
+        : isLeakCandidate(candidate) && !STOPWORDS.has(candidate)
+          ? [candidate]
+          : [];
+
+      for (const keyword of keywords) {
+        if (candidate.includes(' ') && containsCandidate(normalizedQuestion, keyword)) {
+          pushFinding(
+            findings,
+            questionId,
+            questionIndex,
+            'medium',
+            'answer_leakage',
+            `Answer keyword "${keyword}" (from answer "${candidate}") appears in the question text.`
+          );
+          continue;
+        }
+
+        const keywordStem = stemWord(keyword);
+        const morphMatch = questionStemMap.get(keywordStem);
+        if (morphMatch && morphMatch !== keyword) {
+          pushFinding(
+            findings,
+            questionId,
+            questionIndex,
+            'low',
+            'answer_leakage',
+            `Question word "${morphMatch}" shares a root with answer keyword "${keyword}" (from answer "${candidate}").`
+          );
+        }
       }
     }
 
@@ -395,7 +592,9 @@ export function auditQuestionQuality(questions: RawTriviaQuestion[]): QuestionQu
     }
 
     if (!sourceUrl || !sourceName) {
-      const missingFieldsList = ([!sourceUrl && 'sourceUrl', !sourceName && 'sourceName'] as (string | false)[]).filter(Boolean) as string[];
+      const missingFieldsList = (
+        [!sourceUrl && 'sourceUrl', !sourceName && 'sourceName'] as (string | false)[]
+      ).filter(Boolean) as string[];
       pushFinding(
         findings,
         questionId,


### PR DESCRIPTION
## Summary

- Extends the `answer_leakage` check in `question-quality-audit.ts` to catch two previously-missed leakage patterns
- **Keyword overlap** (medium severity): individual significant words from a multi-word answer appearing in the question (e.g., answer "Mount Everest", question mentions "Everest")
- **Morphological closeness** (low severity): question word shares a root with an answer keyword via lightweight suffix-stripping stemmer — no new dependencies (e.g., "photosynthetic" in question when answer is "Photosynthesis")
- Existing full-string verbatim match stays at high severity, unchanged

## Test plan

- [ ] All 75 existing tests still pass (`npm test`)
- [ ] 5 new test cases added covering keyword leakage, morphological detection (2 cases), stopword false-positive prevention, and no-double-reporting

Fixes [STE-149](https://linear.app/stephs-vibe-coding/issue/STE-149) · Sub-issue of [STE-9](https://linear.app/stephs-vibe-coding/issue/STE-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)