### PR TITLE
[codex] fix STE-75 unauthenticated disputes and group awards

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Additionally, Claude Code on web was used to update and enhance the README conte
 ### Authentication & Admin Features
 
 - **Replit Authentication**: Secure OpenID Connect-based login
-- **Dispute System**: Challenge question answers with explanations (requires authentication)
+- **Dispute System**: Challenge question answers with explanations during gameplay
 - **Admin Panel**:
   - Add, edit, and delete custom questions (stored in local storage)
   - View and manage dispute logs (requires admin role)
@@ -242,7 +242,7 @@ To grant admin access to users:
 
 ### Disputes
 
-- `POST /api/disputes` - Submit question dispute (requires authentication)
+- `POST /api/disputes` - Submit question dispute (public gameplay endpoint)
 - `GET /api/disputes` - View all disputes (requires admin)
 - `DELETE /api/disputes` - Clear all disputes (requires admin)
 
@@ -281,7 +281,7 @@ The Replit configuration is defined in `.replit`.
 ## Notes
 
 - Custom questions added in the Admin panel are saved in browser local storage
-- The dispute system requires user authentication via Replit Auth
+- Players can submit disputes without signing in; dispute review and management require admin access
 - Admin roles are managed in the PostgreSQL database
 - Answer verification uses fuzzy matching with an 80% similarity threshold to handle minor typos and formatting differences
 - `DATABASE_URL` and `SESSION_SECRET` are required to start the server

--- a/client/src/components/DisputeModal.tsx
+++ b/client/src/components/DisputeModal.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,6 +11,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { saveDispute } from '@/lib/disputes';
+import { useGame } from '@/lib/store';
 import { useToast } from '@/hooks/use-toast';
 
 interface DisputeModalProps {
@@ -36,6 +35,7 @@ export function DisputeModal({
 }: DisputeModalProps) {
   const [explanation, setExplanation] = useState('');
   const { toast } = useToast();
+  const { markDisputeSubmitted } = useGame();
 
   const handleSubmit = async () => {
     if (!explanation.trim()) {
@@ -56,18 +56,6 @@ export function DisputeModal({
       teamExplanation: explanation,
     });
 
-    if (result.needsAuth) {
-      toast({
-        title: 'Authentication Required',
-        description: 'Please sign in to submit disputes. Redirecting to login...',
-        variant: 'destructive',
-      });
-      setTimeout(() => {
-        window.location.href = '/api/login';
-      }, 1500);
-      return;
-    }
-
     if (!result.success) {
       toast({
         title: 'Error',
@@ -76,6 +64,8 @@ export function DisputeModal({
       });
       return;
     }
+
+    markDisputeSubmitted();
 
     toast({
       title: 'Dispute Submitted',

--- a/client/src/lib/disputes.ts
+++ b/client/src/lib/disputes.ts
@@ -9,7 +9,7 @@ export async function saveDispute(dispute: {
   teamName: string;
   submittedAnswer: string | null;
   teamExplanation: string;
-}): Promise<{ success: boolean; needsAuth: boolean; message?: string }> {
+}): Promise<{ success: boolean; message?: string }> {
   try {
     const response = await fetch('/api/disputes', {
       method: 'POST',
@@ -18,20 +18,15 @@ export async function saveDispute(dispute: {
       body: JSON.stringify(dispute),
     });
 
-    if (response.status === 401) {
-      console.warn('User not authenticated - dispute not saved');
-      return { success: false, needsAuth: true, message: 'Please sign in to submit disputes' };
-    }
-
     if (!response.ok) {
       console.error('Failed to save dispute:', response.statusText);
-      return { success: false, needsAuth: false, message: 'Failed to save dispute' };
+      return { success: false, message: 'Failed to save dispute' };
     }
 
     console.log('QA Dispute saved to database');
-    return { success: true, needsAuth: false };
+    return { success: true };
   } catch (error) {
     console.error('Error saving dispute:', error);
-    return { success: false, needsAuth: false, message: 'Network error' };
+    return { success: false, message: 'Network error' };
   }
 }

--- a/client/src/lib/store.test.tsx
+++ b/client/src/lib/store.test.tsx
@@ -160,6 +160,20 @@ function passAndAdvance(result: { current: ReturnType<typeof useGame> }) {
   act(() => result.current.advanceToScoreUpdate());
 }
 
+function getCorrectPoints(difficulty: Question['difficulty']) {
+  return difficulty === 'Easy' ? 1 : difficulty === 'Medium' ? 2 : 3;
+}
+
+function submitIncorrectAnswer(result: { current: ReturnType<typeof useGame> }) {
+  const question = result.current.state.questions[result.current.state.currentQuestionIndex];
+
+  act(() => result.current.setTypedAnswer('zzzzzzzzzzzz'));
+  act(() => result.current.submitAnswer());
+
+  expect(result.current.state.currentAttempt?.verdict).toBe('INCORRECT');
+  return question;
+}
+
 function finishGame(result: { current: ReturnType<typeof useGame> }) {
   let questionsAnswered = 0;
   let roundBreaks = 0;
@@ -379,6 +393,104 @@ describe('GameProvider state machine', () => {
     expect(activeTeam?.questionCount).toBe(1);
     expect(result.current.state.currentQuestionIndex).toBe(1);
     expect(result.current.state.phase).toBe('QUESTION');
+  });
+
+  it('marks the current reveal attempt after a dispute is submitted', async () => {
+    const { result } = await setupAndStart();
+
+    submitIncorrectAnswer(result);
+    expect(result.current.state.currentAttempt?.disputeSubmitted).toBeUndefined();
+
+    act(() => result.current.markDisputeSubmitted());
+
+    expect(result.current.state.currentAttempt?.disputeSubmitted).toBe(true);
+  });
+
+  it('awards disputed points immediately and flips the attempt to correct', async () => {
+    const { result } = await setupAndStart();
+    const activeTeamId = result.current.state.activeTeamId!;
+    const startingScore = result.current.state.teams.find((team) => team.id === activeTeamId)!
+      .score;
+    const question = submitIncorrectAnswer(result);
+    const correctPoints = getCorrectPoints(question.difficulty);
+
+    act(() => result.current.markDisputeSubmitted());
+    act(() => result.current.awardDisputedPoints());
+
+    const activeTeam = result.current.state.teams.find((team) => team.id === activeTeamId);
+    expect(activeTeam?.score).toBe(startingScore + correctPoints);
+    expect(activeTeam?.questionCount).toBe(0);
+    expect(result.current.state.currentAttempt).toMatchObject({
+      verdict: 'CORRECT',
+      pointsDelta: correctPoints,
+      processed: true,
+      disputeSubmitted: true,
+      pointsAwarded: true,
+    });
+  });
+
+  it('advances an awarded attempt without applying points a second time', async () => {
+    const { result } = await setupAndStart();
+    const activeTeamId = result.current.state.activeTeamId!;
+
+    submitIncorrectAnswer(result);
+    act(() => result.current.markDisputeSubmitted());
+    act(() => result.current.awardDisputedPoints());
+
+    const scoreAfterAward = result.current.state.teams.find((team) => team.id === activeTeamId)!
+      .score;
+
+    act(() => result.current.advanceToScoreUpdate());
+
+    const activeTeam = result.current.state.teams.find((team) => team.id === activeTeamId);
+    expect(activeTeam?.score).toBe(scoreAfterAward);
+    expect(activeTeam?.questionCount).toBe(1);
+    expect(result.current.state.currentQuestionIndex).toBe(1);
+    expect(result.current.state.phase).toBe('QUESTION');
+  });
+
+  it('prevents re-awarding points for the same dispute attempt', async () => {
+    const { result } = await setupAndStart();
+    const activeTeamId = result.current.state.activeTeamId!;
+
+    submitIncorrectAnswer(result);
+    act(() => result.current.markDisputeSubmitted());
+    act(() => result.current.awardDisputedPoints());
+
+    const scoreAfterAward = result.current.state.teams.find((team) => team.id === activeTeamId)!
+      .score;
+
+    act(() => result.current.awardDisputedPoints());
+
+    expect(result.current.state.teams.find((team) => team.id === activeTeamId)?.score).toBe(
+      scoreAfterAward
+    );
+  });
+
+  it('does not award points for pass, correct, or undisputed incorrect attempts', async () => {
+    const passHook = await setupAndStart();
+    act(() => passHook.result.current.passQuestion());
+    act(() => passHook.result.current.markDisputeSubmitted());
+    act(() => passHook.result.current.awardDisputedPoints());
+    expect(passHook.result.current.state.teams[0].score).toBe(0);
+    expect(passHook.result.current.state.currentAttempt?.verdict).toBe('PASS');
+    passHook.unmount();
+
+    const correctHook = await setupAndStart();
+    const correctAnswer = correctHook.result.current.state.questions[0].answer;
+    act(() => correctHook.result.current.setTypedAnswer(correctAnswer));
+    act(() => correctHook.result.current.submitAnswer());
+    act(() => correctHook.result.current.markDisputeSubmitted());
+    act(() => correctHook.result.current.awardDisputedPoints());
+    expect(correctHook.result.current.state.teams[0].score).toBe(0);
+    expect(correctHook.result.current.state.currentAttempt?.verdict).toBe('CORRECT');
+    correctHook.unmount();
+
+    const undisputedHook = await setupAndStart();
+    submitIncorrectAnswer(undisputedHook.result);
+    act(() => undisputedHook.result.current.awardDisputedPoints());
+    expect(undisputedHook.result.current.state.teams[0].score).toBe(0);
+    expect(undisputedHook.result.current.state.currentAttempt?.verdict).toBe('INCORRECT');
   });
 
   it('rotates active team after QUESTIONS_PER_TEAM_ROTATION (4) questions', async () => {

--- a/client/src/lib/store.tsx
+++ b/client/src/lib/store.tsx
@@ -41,6 +41,8 @@ export interface Attempt {
   verdict: Verdict;
   pointsDelta: number;
   processed: boolean;
+  disputeSubmitted?: boolean;
+  pointsAwarded?: boolean;
 }
 
 export interface GameState {
@@ -66,6 +68,8 @@ interface GameContextType {
   setTypedAnswer: (text: string) => void;
   submitAnswer: () => void;
   passQuestion: () => void;
+  markDisputeSubmitted: () => void;
+  awardDisputedPoints: () => void;
   advanceToScoreUpdate: () => void;
   continueToNextRound: () => void;
   endGame: () => void;
@@ -131,6 +135,10 @@ export const verifyAttempt = (input: string, q: Question): { verdict: Verdict; p
     const p = q.difficulty === 'Easy' ? -1 : q.difficulty === 'Medium' ? -2 : -3;
     return { verdict: 'INCORRECT', points: p };
   }
+};
+
+const getCorrectPoints = (difficulty: Difficulty): number => {
+  return difficulty === 'Easy' ? 1 : difficulty === 'Medium' ? 2 : 3;
 };
 
 export function GameProvider({ children }: { children: React.ReactNode }) {
@@ -301,17 +309,74 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     });
   };
 
+  const markDisputeSubmitted = () => {
+    setState((prev) => {
+      if (prev.phase !== 'REVEAL' || !prev.currentAttempt) return prev;
+
+      return {
+        ...prev,
+        currentAttempt: {
+          ...prev.currentAttempt,
+          disputeSubmitted: true,
+        },
+      };
+    });
+  };
+
+  const awardDisputedPoints = () => {
+    setState((prev) => {
+      const attempt = prev.currentAttempt;
+      const currentQ = prev.questions[prev.currentQuestionIndex];
+
+      if (
+        prev.phase !== 'REVEAL' ||
+        !attempt ||
+        !currentQ ||
+        attempt.verdict !== 'INCORRECT' ||
+        attempt.disputeSubmitted !== true ||
+        attempt.pointsAwarded === true
+      ) {
+        return prev;
+      }
+
+      const correctPoints = getCorrectPoints(currentQ.difficulty);
+      const scoreAdjustment = attempt.processed
+        ? correctPoints - attempt.pointsDelta
+        : correctPoints;
+
+      return {
+        ...prev,
+        teams: prev.teams.map((team) => {
+          if (team.id !== attempt.teamId) return team;
+
+          return {
+            ...team,
+            score: team.score + scoreAdjustment,
+            lastRoundDelta: correctPoints,
+          };
+        }),
+        currentAttempt: {
+          ...attempt,
+          verdict: 'CORRECT',
+          pointsDelta: correctPoints,
+          processed: true,
+          pointsAwarded: true,
+        },
+      };
+    });
+  };
+
   const advanceToScoreUpdate = () => {
     setState((prev) => {
-      if (prev.phase !== 'REVEAL' || !prev.currentAttempt || prev.currentAttempt.processed)
-        return prev;
+      if (prev.phase !== 'REVEAL' || !prev.currentAttempt) return prev;
 
       const attempt = prev.currentAttempt;
+      const shouldApplyScore = !attempt.processed;
       const updatedTeams = prev.teams.map((t) => {
         if (t.id === attempt.teamId) {
           return {
             ...t,
-            score: t.score + attempt.pointsDelta,
+            score: shouldApplyScore ? t.score + attempt.pointsDelta : t.score,
             questionCount: t.questionCount + 1,
             lastRoundDelta: attempt.pointsDelta,
           };
@@ -471,6 +536,8 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         setTypedAnswer,
         submitAnswer,
         passQuestion,
+        markDisputeSubmitted,
+        awardDisputedPoints,
         advanceToScoreUpdate,
         continueToNextRound,
         endGame,

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'wouter';
-import { useGame, Team } from '@/lib/store';
+import { useGame } from '@/lib/store';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Check, X, Minus, ArrowRight, Trophy, Flag, ExternalLink, LogOut } from 'lucide-react';
+import { ArrowRight, Trophy, Flag, ExternalLink, LogOut } from 'lucide-react';
 import { DisputeModal } from '@/components/DisputeModal';
+import { useToast } from '@/hooks/use-toast';
 
 const QUESTIONS_PER_TEAM_ROTATION = 4;
 
@@ -15,11 +16,13 @@ export default function Game() {
   const [_, setLocation] = useLocation();
   const [disputeOpen, setDisputeOpen] = useState(false);
   const [showQuitConfirm, setShowQuitConfirm] = useState(false);
+  const { toast } = useToast();
   const {
     state,
     setTypedAnswer,
     submitAnswer,
     passQuestion,
+    awardDisputedPoints,
     advanceToScoreUpdate,
     continueToNextRound,
     endGame,
@@ -168,6 +171,14 @@ export default function Game() {
   const completedRounds =
     questionsPerRound > 0 ? Math.floor(state.currentQuestionIndex / questionsPerRound) : 0;
   const rankedTeams = [...state.teams].sort((a, b) => b.score - a.score);
+  const canDisputeAttempt =
+    isReveal &&
+    state.currentAttempt?.verdict === 'INCORRECT' &&
+    state.currentAttempt.pointsAwarded !== true;
+  const canAwardDisputedPoints =
+    canDisputeAttempt &&
+    state.currentAttempt?.disputeSubmitted === true &&
+    state.currentAttempt.pointsAwarded !== true;
 
   const getDifficultyColor = (d: string) => {
     switch (d) {
@@ -180,6 +191,14 @@ export default function Game() {
       default:
         return 'bg-primary';
     }
+  };
+
+  const handleAwardDisputedPoints = () => {
+    awardDisputedPoints();
+    toast({
+      title: 'Points Awarded',
+      description: `Points awarded to ${activeTeam?.name || 'team'}.`,
+    });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -353,14 +372,25 @@ export default function Game() {
                     >
                       NEXT QUESTION <ArrowRight className="ml-2 w-6 h-6" />
                     </Button>
-                    <Button
-                      onClick={() => setDisputeOpen(true)}
-                      variant="outline"
-                      className="h-16 px-6 border-white/20 hover:bg-red-500/10 hover:text-red-500 transition-colors"
-                    >
-                      <Flag className="w-5 h-5" />
-                      <span className="hidden sm:inline ml-2">Dispute</span>
-                    </Button>
+                    {canAwardDisputedPoints && (
+                      <Button
+                        onClick={handleAwardDisputedPoints}
+                        variant="secondary"
+                        className="h-16 px-6 font-bold"
+                      >
+                        Group agreed — award points
+                      </Button>
+                    )}
+                    {canDisputeAttempt && (
+                      <Button
+                        onClick={() => setDisputeOpen(true)}
+                        variant="outline"
+                        className="h-16 px-6 border-white/20 hover:bg-red-500/10 hover:text-red-500 transition-colors"
+                      >
+                        <Flag className="w-5 h-5" />
+                        <span className="hidden sm:inline ml-2">Dispute</span>
+                      </Button>
+                    )}
                   </div>
 
                   <DisputeModal

--- a/docs/guides/admin_setup.md
+++ b/docs/guides/admin_setup.md
@@ -71,5 +71,5 @@ Once granted admin access, users can:
 
 - Admin access is stored in a separate `admin_roles` table
 - All admin routes require both authentication AND admin role verification
-- Regular users can still submit disputes (requires authentication)
+- Players can submit disputes without authentication during gameplay
 - Only admins can view and manage disputes

--- a/docs/guides/game_state_machine.md
+++ b/docs/guides/game_state_machine.md
@@ -27,15 +27,16 @@ The game uses a linear state machine to ensure data integrity and a consistent g
    - **Next State**: `REVEAL` (Immediate transition).
 
 4. **REVEAL**
-   - **Description**: Read-only view showing the question, user's answer, correct answer, explanation, and the verdict/points result.
-   - **Allowed Actions**: `advanceToScoreUpdate`.
+   - **Description**: View showing the question, user's answer, correct answer, explanation, and the verdict/points result.
+   - **Allowed Actions**: `advanceToScoreUpdate`, `markDisputeSubmitted`, and `awardDisputedPoints` for disputed incorrect answers.
+   - **Dispute Award Logic**: If a dispute is submitted for an `INCORRECT` attempt and the group agrees, `awardDisputedPoints` immediately flips the attempt to `CORRECT`, applies the correct-answer score once, and marks the attempt as processed.
    - **Next State**: `SCORE_UPDATE`.
 
 5. **SCORE_UPDATE** (Transient)
    - **Description**: System applies the `pointsDelta` to the `activeTeam`'s score.
-   - **Guards**: Checks `attemptId` or similar to ensure points are applied exactly once.
+   - **Guards**: Checks `processed` to ensure points are applied exactly once.
    - **Logic**:
-     - Update Team Score.
+     - Update Team Score if the attempt has not already been processed by a dispute award.
      - Increment `teamQuestionCount`.
      - Rotate `activeTeamId` if `teamQuestionCount` % 4 == 0.
      - Increment `currentQuestionIndex`.
@@ -66,5 +67,7 @@ interface Attempt {
   verdict: 'CORRECT' | 'INCORRECT' | 'PASS';
   pointsDelta: number;
   processed: boolean; // Guard for score application
+  disputeSubmitted?: boolean;
+  pointsAwarded?: boolean;
 }
 ```

--- a/server/routes.disputes.test.ts
+++ b/server/routes.disputes.test.ts
@@ -1,0 +1,150 @@
+import express, { type Express, type NextFunction, type Request, type Response } from 'express';
+import { createServer } from 'http';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  insert: vi.fn(),
+  returning: vi.fn(),
+  select: vi.fn(),
+  update: vi.fn(),
+  values: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn((req: Request, res: Response, next: NextFunction) => {
+    const userId = req.header('x-test-user-id');
+
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    (req as Request & { user?: { claims: { sub: string }; expires_at: number } }).user = {
+      claims: { sub: userId },
+      expires_at: Math.floor(Date.now() / 1000) + 60,
+    };
+    next();
+  }),
+  registerAuthRoutes: vi.fn(),
+  setupAuth: vi.fn(async (_app: Express) => undefined),
+}));
+
+vi.mock('./db', () => ({
+  db: {
+    delete: dbMocks.delete,
+    insert: dbMocks.insert,
+    select: dbMocks.select,
+    update: dbMocks.update,
+  },
+}));
+
+vi.mock('@shared/schema', () => ({
+  adminRoles: {},
+  appConfig: {},
+  disputes: {},
+  duplicatePairKey: vi.fn(),
+  insertDisputeSchema: {
+    parse: vi.fn((body) => body),
+  },
+  insertQuestionSchema: {
+    parse: vi.fn((body) => body),
+  },
+  questionEdits: {},
+  questionQualitySweepDismissals: {},
+  questions: {},
+  seenQuestions: {},
+}));
+
+vi.mock('./replit_integrations/auth', () => authMocks);
+vi.mock('./lib/subjectivity-enricher', () => ({ enrichSubjectiveFindings: vi.fn() }));
+vi.mock('./lib/ai', () => ({ analyzeDispute: vi.fn() }));
+vi.mock('./lib/guardian', () => ({ generateQuestions: vi.fn() }));
+vi.mock('./lib/field-fix', () => ({ getAiFieldFix: vi.fn() }));
+vi.mock('./lib/question-quality-audit', () => ({ auditQuestionQuality: vi.fn() }));
+vi.mock('./lib/duplicate-detector', () => ({ detectDuplicates: vi.fn() }));
+vi.mock('./lib/verifier', () => ({ batchFactCheck: vi.fn() }));
+vi.mock('./middleware/rateLimiter', () => ({
+  aiLimiter: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+const disputePayload = {
+  questionId: 'q-1',
+  questionText: 'What is the capital of Canada?',
+  correctAnswer: 'Ottawa',
+  teamName: 'Alpha',
+  submittedAnswer: 'Toronto',
+  teamExplanation: 'We think Toronto should count because of the clue wording.',
+};
+
+async function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  const { registerRoutes } = await import('./routes');
+  await registerRoutes(createServer(app), app);
+
+  return app;
+}
+
+describe('dispute routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.returning.mockResolvedValue([
+      {
+        ...disputePayload,
+        id: 'dispute-1',
+        status: 'pending',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        resolutionNote: null,
+        aiAnalysis: null,
+      },
+    ]);
+    dbMocks.values.mockReturnValue({ returning: dbMocks.returning });
+    dbMocks.insert.mockReturnValue({ values: dbMocks.values });
+  });
+
+  it('allows unauthenticated players to submit disputes', async () => {
+    const app = await buildApp();
+
+    const response = await request(app).post('/api/disputes').send(disputePayload).expect(201);
+
+    expect(authMocks.isAuthenticated).not.toHaveBeenCalled();
+    expect(dbMocks.insert).toHaveBeenCalledOnce();
+    expect(dbMocks.values).toHaveBeenCalledWith(disputePayload);
+    expect(response.body).toMatchObject({
+      id: 'dispute-1',
+      status: 'pending',
+      teamName: 'Alpha',
+      teamExplanation: disputePayload.teamExplanation,
+    });
+  });
+
+  it.each([
+    ['GET', '/api/disputes'],
+    ['PATCH', '/api/disputes/dispute-1'],
+    ['DELETE', '/api/disputes'],
+    ['POST', '/api/disputes/dispute-1/analyze'],
+  ])('keeps %s %s protected without a session', async (method, path) => {
+    const app = await buildApp();
+    let response: request.Response;
+
+    switch (method) {
+      case 'GET':
+        response = await request(app).get(path);
+        break;
+      case 'PATCH':
+        response = await request(app).patch(path).send({ status: 'resolved' });
+        break;
+      case 'DELETE':
+        response = await request(app).delete(path);
+        break;
+      default:
+        response = await request(app).post(path);
+        break;
+    }
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: 'Unauthorized' });
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,6 @@
 import type { Express, Request, Response, NextFunction } from 'express';
 import { enrichSubjectiveFindings } from './lib/subjectivity-enricher';
-import { createServer, type Server } from 'http';
+import type { Server } from 'http';
 import { setupAuth, registerAuthRoutes, isAuthenticated } from './replit_integrations/auth';
 import { db } from './db';
 import {
@@ -28,6 +28,13 @@ import { aiLimiter } from './middleware/rateLimiter';
 
 const VALID_PILLARS = ['GlobalEh', 'FreshPrints', 'TimeCapsule', 'GreatOutdoors'] as const;
 type SinglePillar = (typeof VALID_PILLARS)[number];
+type RequestWithClaims = Request & {
+  user?: {
+    claims?: {
+      sub?: string;
+    };
+  };
+};
 
 const PILLAR_MIX: { pillar: SinglePillar; pct: number }[] = [
   { pillar: 'TimeCapsule', pct: 0.3 },
@@ -56,7 +63,7 @@ const stagingGenerateSchema = z.object({
 });
 
 function getUserId(req: Request): string | undefined {
-  return (req as any).user?.claims?.sub;
+  return (req as RequestWithClaims).user?.claims?.sub;
 }
 
 async function isAdmin(req: Request, res: Response, next: NextFunction) {
@@ -84,7 +91,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   await setupAuth(app);
   registerAuthRoutes(app);
 
-  // Disputes API - protected by admin middleware
+  // Disputes API - admin review routes are protected; player submissions are public.
   app.get('/api/disputes', isAuthenticated, isAdmin, async (req, res) => {
     try {
       const allDisputes = await db.select().from(disputes);
@@ -95,7 +102,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     }
   });
 
-  app.post('/api/disputes', isAuthenticated, async (req, res) => {
+  app.post('/api/disputes', async (req, res) => {
     try {
       const parsed = insertDisputeSchema.parse(req.body);
       const [newDispute] = await db.insert(disputes).values(parsed).returning();


### PR DESCRIPTION
## Summary
- Allow anonymous players to submit `POST /api/disputes` while keeping dispute review/manage routes admin-protected.
- Remove the client login redirect from dispute submission and mark the current reveal attempt as disputed after a successful save.
- Add immediate group-award scoring for disputed incorrect answers, with once-only score application through the existing `processed` guard.
- Update dispute docs and add regression coverage for store behavior and dispute route auth boundaries.

## Validation
- `npm run check`
- `npm run lint` (passes with existing warnings)
- `npm test` (11 files, 88 tests)
- `npm run build` verified from a `/tmp` copy of the exact worktree source because the hidden `.codex` worktree path blocked local `dist/public` creation with `EPERM`; client and server bundles completed successfully there.