### PR TITLE
fix(STE-151): enforce npm audit gate and add CI/branch protection guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Dependency audit
         run: npm audit --audit-level=high
-        continue-on-error: true
 
       - name: Build
         run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ When closing a sub-issue with a `parentId`, follow `.agent/workflows/linear-pare
 
 CI gates (`.github/workflows/ci.yml`) must pass before merge. Fix failures, don't bypass.
 
+- `docs/guides/ci_and_branch_protection.md` — required status-check name, all CI gates, and branch protection settings for `main`
+
 ## Documentation Confirmation
 
 When finishing any task, **always confirm to the user what documentation was updated**. Report:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ When closing a sub-issue with a `parentId`, follow `.agent/workflows/linear-pare
 
 CI gates (`.github/workflows/ci.yml`) must pass before merge. Fix failures, don't bypass.
 
+- `docs/guides/ci_and_branch_protection.md` — required status-check name, all CI gates, and branch protection settings for `main`
+
 ## Documentation Confirmation
 
 When finishing any task, **always confirm to the user what documentation was updated**. Report:

--- a/docs/guides/ci_and_branch_protection.md
+++ b/docs/guides/ci_and_branch_protection.md
@@ -15,14 +15,14 @@ This is the `jobs.quality-gates.name` value in `.github/workflows/ci.yml`.
 
 ## CI gates (all required, all blocking)
 
-| Step                    | Command                                | Notes                                         |
-| ----------------------- | -------------------------------------- | --------------------------------------------- |
-| Agent manual sync check | `cmp -s AGENTS.md CLAUDE.md replit.md` | Fails if the three shared agent files diverge |
-| TypeScript type-check   | `npm run check`                        | Runs `tsc` with no emit                       |
-| ESLint                  | `npm run lint`                         | Zero-warning policy                           |
-| Tests                   | `npm test`                             | Vitest suite                                  |
-| Dependency audit        | `npm audit --audit-level=high`         | Fails on any high or critical finding         |
-| Build                   | `npm run build`                        | Production bundle must compile clean          |
+| Step                    | Command                                | Notes                                                           |
+| ----------------------- | -------------------------------------- | --------------------------------------------------------------- |
+| Agent manual sync check | `cmp -s AGENTS.md CLAUDE.md replit.md` | Fails if the three shared agent files diverge                   |
+| TypeScript type-check   | `npm run check`                        | Runs `tsc` with no emit                                         |
+| ESLint                  | `npm run lint`                         | Fails on errors only; warnings are reported but do not block CI |
+| Tests                   | `npm test`                             | Vitest suite                                                    |
+| Dependency audit        | `npm audit --audit-level=high`         | Fails on any high or critical finding                           |
+| Build                   | `npm run build`                        | Production bundle must compile clean                            |
 
 All steps run in a single job named **Quality Gates** on `ubuntu-latest` with Node 20.
 

--- a/docs/guides/ci_and_branch_protection.md
+++ b/docs/guides/ci_and_branch_protection.md
@@ -1,0 +1,71 @@
+# CI Gates and Branch Protection
+
+**Last updated:** 2026-04-18
+**Owner:** Stephanie Figas
+
+## Required status-check name
+
+GitHub branch protection must reference the exact job name as it appears in the CI workflow:
+
+```
+Quality Gates
+```
+
+This is the `jobs.quality-gates.name` value in `.github/workflows/ci.yml`.
+
+## CI gates (all required, all blocking)
+
+| Step                    | Command                                | Notes                                         |
+| ----------------------- | -------------------------------------- | --------------------------------------------- |
+| Agent manual sync check | `cmp -s AGENTS.md CLAUDE.md replit.md` | Fails if the three shared agent files diverge |
+| TypeScript type-check   | `npm run check`                        | Runs `tsc` with no emit                       |
+| ESLint                  | `npm run lint`                         | Zero-warning policy                           |
+| Tests                   | `npm test`                             | Vitest suite                                  |
+| Dependency audit        | `npm audit --audit-level=high`         | Fails on any high or critical finding         |
+| Build                   | `npm run build`                        | Production bundle must compile clean          |
+
+All steps run in a single job named **Quality Gates** on `ubuntu-latest` with Node 20.
+
+## Dependency audit policy
+
+The audit gate uses `--audit-level=high`, meaning any vulnerability rated **high** or **critical** blocks the merge.
+
+**Moderate and lower findings** are logged but do not block CI. They should be triaged in follow-up issues.
+
+**Known exceptions as of 2026-04-18:**
+
+| Package                                                           | Advisory            | Severity | Reason not auto-fixed                                                        |
+| ----------------------------------------------------------------- | ------------------- | -------- | ---------------------------------------------------------------------------- |
+| `drizzle-kit` (via `@esbuild-kit/esm-loader` → `esbuild ≤0.24.2`) | GHSA-67mh-4wv8-2f99 | Moderate | Fix requires breaking `drizzle-kit` major version bump; tracked as follow-up |
+
+## Branch protection settings for `main`
+
+The following settings must be applied manually by the repo owner in **GitHub → Settings → Branches → Branch protection rules** for the `main` branch.
+
+> **Note:** Applying or changing these settings requires repo-owner access. Agents cannot apply branch protection via the API without explicit authorization.
+
+### Required settings
+
+| Setting                                                            | Value                    |
+| ------------------------------------------------------------------ | ------------------------ |
+| Require a pull request before merging                              | ✅ Enabled               |
+| — Required approving reviews                                       | 1 (minimum)              |
+| — Dismiss stale pull request approvals when new commits are pushed | ✅ Enabled               |
+| Require status checks to pass before merging                       | ✅ Enabled               |
+| — Required status check name                                       | `Quality Gates`          |
+| Require branches to be up to date before merging                   | ✅ Enabled               |
+| Require conversation resolution before merging                     | ✅ Enabled               |
+| Allow force pushes                                                 | ❌ Disabled              |
+| Allow deletions                                                    | ❌ Disabled              |
+| Include administrators                                             | ✅ Enabled (recommended) |
+
+### How to apply
+
+1. Go to the repository on GitHub.
+2. Navigate to **Settings → Branches**.
+3. Click **Add branch protection rule** (or edit the existing rule for `main`).
+4. Set **Branch name pattern** to `main`.
+5. Apply each setting from the table above.
+6. Click **Save changes**.
+
+Once enabled, every PR targeting `main` must have the `Quality Gates` job pass before it can be merged, and force-pushes and direct deletions of `main` are blocked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
-        "drizzle-orm": "^0.39.3",
+        "drizzle-orm": "^0.45.2",
         "drizzle-zod": "^0.7.1",
         "embla-carousel-react": "^8.6.0",
         "express": "^4.21.2",
@@ -5610,9 +5610,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6351,9 +6351,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7200,16 +7200,16 @@
       }
     },
     "node_modules/drizzle-kit": {
-      "version": "0.31.4",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.4.tgz",
-      "integrity": "sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==",
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@drizzle-team/brocli": "^0.10.2",
         "@esbuild-kit/esm-loader": "^2.5.5",
         "esbuild": "^0.25.4",
-        "esbuild-register": "^3.5.0"
+        "tsx": "^4.21.0"
       },
       "bin": {
         "drizzle-kit": "bin.cjs"
@@ -7700,9 +7700,9 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.39.3",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.39.3.tgz",
-      "integrity": "sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==",
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
@@ -7713,17 +7713,19 @@
         "@neondatabase/serverless": ">=0.10.0",
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1",
+        "@planetscale/database": ">=1.13",
         "@prisma/client": "*",
         "@tidbcloud/serverless": "*",
         "@types/better-sqlite3": "*",
         "@types/pg": "*",
         "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
         "@vercel/postgres": ">=0.8.0",
         "@xata.io/client": "*",
         "better-sqlite3": ">=7",
         "bun-types": "*",
         "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
         "knex": "*",
         "kysely": "*",
         "mysql2": ">=2",
@@ -7775,6 +7777,9 @@
         "@types/sql.js": {
           "optional": true
         },
+        "@upstash/redis": {
+          "optional": true
+        },
         "@vercel/postgres": {
           "optional": true
         },
@@ -7788,6 +7793,9 @@
           "optional": true
         },
         "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
           "optional": true
         },
         "knex": {
@@ -8209,19 +8217,6 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
-    "node_modules/esbuild-register": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
-      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -8630,12 +8625,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -8866,9 +8861,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -9504,9 +9499,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -10529,9 +10524,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -10768,9 +10763,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11440,9 +11435,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -11621,9 +11616,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13442,9 +13437,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13617,9 +13612,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14074,9 +14069,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
-    "drizzle-orm": "^0.39.3",
+    "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.7.1",
     "embla-carousel-react": "^8.6.0",
     "express": "^4.21.2",

--- a/replit.md
+++ b/replit.md
@@ -102,6 +102,8 @@ When closing a sub-issue with a `parentId`, follow `.agent/workflows/linear-pare
 
 CI gates (`.github/workflows/ci.yml`) must pass before merge. Fix failures, don't bypass.
 
+- `docs/guides/ci_and_branch_protection.md` — required status-check name, all CI gates, and branch protection settings for `main`
+
 ## Documentation Confirmation
 
 When finishing any task, **always confirm to the user what documentation was updated**. Report:


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the `Dependency audit` step in `.github/workflows/ci.yml` so any **high** or **critical** `npm audit` finding now blocks CI
- Updates `drizzle-orm` 0.39.3 → 0.45.2 to resolve GHSA-gpj5-g38j-94v9 (SQL injection, CVSS 7.5) — the only high-severity finding that remained after `npm audit fix`
- Applies `npm audit fix` for `vite` (path traversal/arbitrary file read) and `undici` (WebSocket/request-smuggling) vulnerabilities
- Adds `docs/guides/ci_and_branch_protection.md` documenting the required status-check name (`Quality Gates`), all CI gates, and the exact manual branch protection settings for `main`
- Adds one-line link to the new guide from the Quality Gates section in `AGENTS.md`, `CLAUDE.md`, and `replit.md` — all three remain byte-identical per sync contract

Closes STE-151.

## Remaining known findings (moderate, not blocking)

| Package | Advisory | Severity | Notes |
|---------|----------|----------|-------|
| `drizzle-kit` → `esbuild ≤0.24.2` | GHSA-67mh-4wv8-2f99 | Moderate | Fix requires breaking `drizzle-kit` major bump; follow-up needed |

## Test plan

- [ ] CI `Quality Gates` job passes on this PR
- [ ] `npm audit --audit-level=high` exits 0 locally (verified: 4 moderate, 0 high)
- [ ] `npm run check` (TypeScript) passes after `drizzle-orm` update (verified locally)
- [ ] `AGENTS.md`, `CLAUDE.md`, `replit.md` are byte-identical (`cmp -s` passes — verified locally)
- [ ] Repo owner manually applies branch protection settings from `docs/guides/ci_and_branch_protection.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)