### PR TITLE
feat(STE-153): Playwright smoke test — SETUP → QUESTION → REVEAL loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,72 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e-smoke:
+    name: E2E Smoke Tests
+    runs-on: ubuntu-latest
+    needs: quality-gates
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: trivia_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E smoke tests
+        run: npx playwright test
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/trivia_test
+          # SESSION_SECRET must be non-empty — getSession() throws otherwise.
+          # This is a CI-only placeholder; it is never used for real sessions
+          # because all API routes are intercepted by Playwright before hitting
+          # the server.
+          SESSION_SECRET: ci-e2e-placeholder-session-secret-not-for-production
+          # REPL_ID is the OIDC client identifier passed to openid-client
+          # discovery (https://replit.com/oidc). Discovery fetches the public
+          # OIDC metadata document and succeeds with any non-empty client ID;
+          # no real Replit app is needed since auth routes are never exercised
+          # during the smoke test.
+          REPL_ID: ci-playwright-smoke
+          CI: true
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,16 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
+      # OS-level packages (libgbm, libatk, etc.) are not stored in the
+      # ~/.cache/ms-playwright directory, so they must be installed on every
+      # run — even when the browser-binary cache is warm.
+      - name: Install Playwright OS dependencies
+        run: npx playwright install-deps chromium
+
+      # Browser binaries are large; restore them from cache when possible.
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Push database schema
         run: npm run db:push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,13 @@ jobs:
           # no real Replit app is needed since auth routes are never exercised
           # during the smoke test.
           REPL_ID: ci-playwright-smoke
+          # AI_INTEGRATIONS_OPENAI_API_KEY must be non-empty — several server
+          # modules (lib/ai, lib/guardian, lib/verifier, etc.) instantiate
+          # `new OpenAI({ apiKey: ... })` at import time, and the SDK throws
+          # "Missing credentials" when both this var and OPENAI_API_KEY are
+          # unset. This placeholder satisfies the constructor; no OpenAI
+          # request is made during the smoke test.
+          AI_INTEGRATIONS_OPENAI_API_KEY: sk-ci-placeholder-not-for-production
           CI: true
 
       - name: Upload Playwright report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,11 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
+      - name: Push database schema
+        run: npm run db:push
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/trivia_test
+
       - name: Run E2E smoke tests
         run: npx playwright test
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ vite.config.ts.*
 !.env.example
 # Local MCP Settings (Secrets)
 .vscode/mcp.json
+
+# Playwright
+playwright-report/
+test-results/
+playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Use Conventional Commits: `<type>(<scope>): <description>`
 - Test files: `*.test.ts` / `*.test.tsx`
 - Run `npm test` before marking work complete.
 - If tests fail: fix them. Do not skip, mock around, or ignore failures.
+- User-facing flow changes should add or update an E2E test in `e2e/`.
 
 ## Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Use Conventional Commits: `<type>(<scope>): <description>`
 - Test files: `*.test.ts` / `*.test.tsx`
 - Run `npm test` before marking work complete.
 - If tests fail: fix them. Do not skip, mock around, or ignore failures.
+- User-facing flow changes should add or update an E2E test in `e2e/`.
 
 ## Error Handling
 

--- a/docs/guides/e2e_testing.md
+++ b/docs/guides/e2e_testing.md
@@ -1,0 +1,56 @@
+# E2E Testing Guide
+
+## Overview
+
+End-to-end tests live in `e2e/` and use [Playwright](https://playwright.dev). They run against the production build on `http://localhost:5000`, covering the full SETUP → QUESTION → REVEAL → score-update loop and any other user-facing flows.
+
+## Running locally
+
+```bash
+# One-time browser install (only needed after first clone or Playwright version bump)
+npx playwright install --with-deps chromium
+
+# Run all E2E tests (starts the server automatically)
+npm run test:e2e
+
+# Run with the interactive UI
+npx playwright test --ui
+
+# Run a specific spec
+npx playwright test e2e/smoke.spec.ts
+
+# Debug a failing test (headed, with breakpoints)
+npx playwright test --debug
+```
+
+The `playwright.config.ts` `webServer` block automatically runs `npm run build && npm run start` before the suite, so the app is always tested against a real production build.
+
+### Environment variables
+
+The server requires `DATABASE_URL` at startup. Export it before running:
+
+```bash
+export DATABASE_URL=postgresql://user:password@localhost:5432/your_db
+npm run test:e2e
+```
+
+If the variable is absent the server may fail to start; tests will error at the connection step.
+
+## CI
+
+The `e2e-smoke` job in `.github/workflows/ci.yml` runs after `quality-gates` passes. It spins up a Postgres service container and sets `DATABASE_URL` automatically. Playwright browsers are cached per `package-lock.json` hash to keep the job fast.
+
+On failure, the HTML report is uploaded as the `playwright-report` artifact (retained 7 days) and is visible in the Actions summary.
+
+## Fixtures
+
+`e2e/fixtures/questions.json` contains 8 deterministic questions (Easy/Medium/Hard, Science/History). All `GET /api/questions*` requests are intercepted and fulfilled with this fixture so tests never hit a live database. `POST /api/questions/seen` is stubbed to return `{}`.
+
+## Adding new tests
+
+1. Create a new `e2e/*.spec.ts` file.
+2. Intercept `**/api/questions**` with fixture data (or a custom fixture for the feature under test).
+3. Follow the pattern in `e2e/smoke.spec.ts` for route setup and assertions.
+4. Add `data-testid` attributes to new UI elements so tests can target them without brittle CSS selectors.
+
+All user-facing flow changes should add or update an E2E test in `e2e/`.

--- a/e2e/fixtures/questions.json
+++ b/e2e/fixtures/questions.json
@@ -1,0 +1,105 @@
+{
+  "questions": [
+    {
+      "id": "smoke-q1",
+      "category": "Science",
+      "difficulty": "Easy",
+      "question": "What is the chemical formula for water?",
+      "answer": "H2O",
+      "explanation": "Water consists of two hydrogen atoms and one oxygen atom.",
+      "pillar": "Science",
+      "tags": ["Science"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/Water",
+      "sourceName": "Wikipedia"
+    },
+    {
+      "id": "smoke-q2",
+      "category": "Science",
+      "difficulty": "Medium",
+      "question": "What is the speed of light in a vacuum, approximately?",
+      "answer": "300000 km/s",
+      "acceptableAnswers": ["3x10^8 m/s", "299792 km/s", "299792458 m/s"],
+      "explanation": "The speed of light in a vacuum is approximately 299,792,458 metres per second.",
+      "pillar": "Science",
+      "tags": ["Science"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/Speed_of_light",
+      "sourceName": "Wikipedia"
+    },
+    {
+      "id": "smoke-q3",
+      "category": "Science",
+      "difficulty": "Hard",
+      "question": "What element has atomic number 79?",
+      "answer": "Gold",
+      "acceptableAnswers": ["Au"],
+      "explanation": "Gold (Au) is a chemical element with atomic number 79.",
+      "pillar": "Science",
+      "tags": ["Science"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/Gold",
+      "sourceName": "Wikipedia"
+    },
+    {
+      "id": "smoke-q4",
+      "category": "Science",
+      "difficulty": "Easy",
+      "question": "What gas do plants absorb from the air during photosynthesis?",
+      "answer": "Carbon dioxide",
+      "acceptableAnswers": ["CO2", "carbon dioxide"],
+      "explanation": "Plants absorb carbon dioxide (CO2) and release oxygen during photosynthesis.",
+      "pillar": "Science",
+      "tags": ["Science"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/Photosynthesis",
+      "sourceName": "Wikipedia"
+    },
+    {
+      "id": "smoke-q5",
+      "category": "History",
+      "difficulty": "Easy",
+      "question": "In what year did World War II end?",
+      "answer": "1945",
+      "explanation": "World War II ended in 1945 with the surrender of Germany in May and Japan in September.",
+      "pillar": "History",
+      "tags": ["History"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/World_War_II",
+      "sourceName": "Wikipedia"
+    },
+    {
+      "id": "smoke-q6",
+      "category": "History",
+      "difficulty": "Medium",
+      "question": "Who wrote the play Romeo and Juliet?",
+      "answer": "Shakespeare",
+      "acceptableAnswers": ["William Shakespeare"],
+      "explanation": "Romeo and Juliet is a tragedy written by William Shakespeare, believed to have been written between 1594 and 1596.",
+      "pillar": "History",
+      "tags": ["History"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/Romeo_and_Juliet",
+      "sourceName": "Wikipedia"
+    },
+    {
+      "id": "smoke-q7",
+      "category": "History",
+      "difficulty": "Hard",
+      "question": "In what year was the Magna Carta signed?",
+      "answer": "1215",
+      "explanation": "The Magna Carta was sealed by King John of England on June 15, 1215.",
+      "pillar": "History",
+      "tags": ["History"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/Magna_Carta",
+      "sourceName": "Wikipedia"
+    },
+    {
+      "id": "smoke-q8",
+      "category": "History",
+      "difficulty": "Medium",
+      "question": "Who was the first President of the United States?",
+      "answer": "George Washington",
+      "explanation": "George Washington served as the first President of the United States from 1789 to 1797.",
+      "pillar": "History",
+      "tags": ["History"],
+      "sourceUrl": "https://en.wikipedia.org/wiki/George_Washington",
+      "sourceName": "Wikipedia"
+    }
+  ],
+  "categories": ["Science", "History"]
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+import fixtureData from './fixtures/questions.json';
+
+const WRONG_ANSWER = 'definitely wrong answer';
+const CORRECT_ANSWER = 'H2O'; // smoke-q1 correct answer
+const EXPECTED_POINTS_DELTA = -1; // Easy wrong answer
+
+test.describe('SETUP → QUESTION → REVEAL loop', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept both the initial catalog load and startGame shuffle request
+    await page.route('**/api/questions**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(fixtureData),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Intercept the seen-questions POST (fired on GAME_OVER)
+    await page.route('**/api/questions/seen', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+  });
+
+  test('happy path: wrong answer decrements team score by expected delta', async ({ page }) => {
+    // ── 1. SETUP phase ──────────────────────────────────────────────────────
+    await page.goto('/');
+
+    // Assert SETUP UI is visible
+    await expect(page.getByRole('heading', { name: 'TRIVIA' })).toBeVisible();
+    await expect(page.getByText('Team Setup')).toBeVisible();
+
+    // Add TeamA
+    const teamInput = page.getByPlaceholder('Enter team name...');
+    await teamInput.fill('TeamA');
+    await teamInput.press('Enter');
+    await expect(page.getByText('TeamA')).toBeVisible();
+
+    // Add TeamB
+    await teamInput.fill('TeamB');
+    await teamInput.press('Enter');
+    await expect(page.getByText('TeamB')).toBeVisible();
+
+    // Select a category — wait for categories to load from the intercepted API
+    await expect(page.getByRole('button', { name: /Science/ })).toBeVisible();
+    await page.getByRole('button', { name: /Science/ }).click();
+
+    // Start the game
+    await page.getByTestId('button-start-game').click();
+    await page.waitForURL('**/game');
+
+    // ── 2. QUESTION phase ───────────────────────────────────────────────────
+    const answerInput = page.getByPlaceholder('Type answer here...');
+    await expect(answerInput).toBeVisible();
+
+    // Assert TeamA is the active team shown in the header area
+    await expect(page.getByText('TeamA').first()).toBeVisible();
+
+    // ── 3. Submit a known-wrong answer ──────────────────────────────────────
+    await answerInput.fill(WRONG_ANSWER);
+    await page.getByRole('button', { name: 'Submit Answer' }).click();
+
+    // ── 4. REVEAL phase ─────────────────────────────────────────────────────
+    // "They Answered" card shows the wrong submitted answer
+    await expect(page.getByText('They Answered')).toBeVisible();
+    await expect(page.getByText(WRONG_ANSWER)).toBeVisible();
+
+    // "Correct Answer" card shows the right answer
+    await expect(page.getByText('Correct Answer')).toBeVisible();
+    await expect(page.getByText(CORRECT_ANSWER)).toBeVisible();
+
+    // Verdict + points delta
+    const expectedVerdictText = `INCORRECT (${EXPECTED_POINTS_DELTA})`;
+    await expect(page.getByText(expectedVerdictText)).toBeVisible();
+
+    // ── 5. Advance to SCORE_UPDATE → QUESTION ───────────────────────────────
+    await page.getByRole('button', { name: /NEXT QUESTION/i }).click();
+
+    // Should now be in the next QUESTION phase — answer input re-appears
+    await expect(page.getByPlaceholder('Type answer here...')).toBeVisible();
+
+    // ── 6. Assert TeamA score decreased by expected delta ───────────────────
+    // Scoreboard strip at the bottom of the game screen renders each team as:
+    //   <span class="font-bold">{name}</span>
+    //   <span class="font-mono ...">{score}</span>
+    // Locate TeamA's score span via its sibling relationship.
+    const teamAScore = page
+      .locator('span.font-bold:text-is("TeamA")')
+      .locator('..')
+      .locator('span.font-mono');
+
+    await expect(teamAScore).toHaveText(String(EXPECTED_POINTS_DELTA));
+  });
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -62,8 +62,13 @@ test.describe('SETUP → QUESTION → REVEAL loop', () => {
     const answerInput = page.getByPlaceholder('Type answer here...');
     await expect(answerInput).toBeVisible();
 
-    // Assert TeamA is the active team shown in the header area
-    await expect(page.getByText('TeamA').first()).toBeVisible();
+    // Assert TeamA is the *active* team — the "Active Team" label in the
+    // question-phase header is only rendered for the current player, unlike
+    // the scoreboard strip which always lists all teams. Anchoring to this
+    // label means a rotation bug (wrong team shown as active) would fail here.
+    await expect(page.getByText('Active Team', { exact: true }).locator('..')).toContainText(
+      'TeamA'
+    );
 
     // ── 3. Submit a known-wrong answer ──────────────────────────────────────
     await answerInput.fill(WRONG_ANSWER);

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,5 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
-import fixtureData from './fixtures/questions.json';
+
+const fixtureData = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./fixtures/questions.json', import.meta.url)), 'utf8')
+);
 
 const WRONG_ANSWER = 'definitely wrong answer';
 const CORRECT_ANSWER = 'H2O'; // smoke-q1 correct answer

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "zod-validation-error": "^5.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@replit/vite-plugin-cartographer": "^0.4.4",
         "@replit/vite-plugin-dev-banner": "^0.1.2",
         "@replit/vite-plugin-runtime-error-modal": "^0.0.4",
@@ -1889,6 +1890,22 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -11644,6 +11661,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "CI=1 vitest run",
     "test:watch": "vitest",
     "test:coverage": "CI=1 vitest run --coverage",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "dependencies": {
@@ -104,6 +105,7 @@
     "zod-validation-error": "^5.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@replit/vite-plugin-cartographer": "^0.4.4",
     "@replit/vite-plugin-dev-banner": "^0.1.2",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html'], ['github']] : [['list']],
+  use: {
+    baseURL: 'http://localhost:5000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run build && npm run start',
+    url: 'http://localhost:5000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+    env: {
+      NODE_ENV: 'production',
+    },
+  },
+});

--- a/replit.md
+++ b/replit.md
@@ -81,6 +81,7 @@ Use Conventional Commits: `<type>(<scope>): <description>`
 - Test files: `*.test.ts` / `*.test.tsx`
 - Run `npm test` before marking work complete.
 - If tests fail: fix them. Do not skip, mock around, or ignore failures.
+- User-facing flow changes should add or update an E2E test in `e2e/`.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

- Installs `@playwright/test` and configures `playwright.config.ts` (chromium only, `webServer` via `npm run build && npm run start`, 30 s timeout)
- Adds `e2e/fixtures/questions.json` — 8 deterministic questions (Easy/Medium/Hard, Science/History) matching `/api/questions` response shape
- Adds `e2e/smoke.spec.ts` — happy-path test: intercepts `/api/questions*` and `/api/questions/seen`, adds TeamA + TeamB, selects Science, starts game, submits a known-wrong answer, asserts REVEAL shows correct answer + `INCORRECT (-1)` delta, clicks NEXT QUESTION, asserts TeamA score is `−1` in the scoreboard strip
- Wires `e2e-smoke` CI job (`needs: quality-gates`, postgres service, Playwright browser cache, uploads `playwright-report/` artifact on failure)
- Updates `.gitignore` with `playwright-report/`, `test-results/`, `playwright/.cache/`
- Creates `docs/guides/e2e_testing.md` with local-run instructions and extension guidance
- Adds `test:e2e` script to `package.json`
- Syncs rule _"User-facing flow changes should add or update an E2E test in `e2e/`"_ to `AGENTS.md`, `CLAUDE.md`, `replit.md` (byte-identical); bumps last-updated to 2026-04-18

Closes STE-153

## Test plan

- [ ] `npm run test:e2e` passes locally (requires `DATABASE_URL` + `npm run build`)
- [ ] CI `e2e-smoke` job green on this PR
- [ ] `cmp -s AGENTS.md CLAUDE.md && cmp -s AGENTS.md replit.md` passes (sync check in CI validates this)
- [ ] `playwright-report/` artifact uploads on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)