### PR TITLE
fix(test): close STE-67 coverage gaps [STE-67]

### DIFF
--- a/client/src/lib/questions.json
+++ b/client/src/lib/questions.json
@@ -978,11 +978,12 @@
     "id": "q89",
     "category": "History",
     "difficulty": "Medium",
-    "question": "In which year did the Titanic sink?",
-    "answer": "1912",
-    "explanation": "Over 1,500 people died when RMS Titanic sank on April 15, 1912 after hitting an iceberg.",
-    "tags": ["Global", "History", "GlobalEh"],
-    "sourceUrl": "https://en.wikipedia.org/wiki/Titanic",
+    "question": "Which civilization built Machu Picchu?",
+    "answer": "Inca Empire",
+    "acceptableAnswers": ["Inca", "Incas"],
+    "explanation": "Machu Picchu was built by the Inca Empire in the 15th century and later became one of Peru's most famous archaeological sites.",
+    "tags": ["Global", "History", "TimeCapsule"],
+    "sourceUrl": "https://en.wikipedia.org/wiki/Machu_Picchu",
     "sourceName": "Wikipedia"
   },
   {

--- a/client/src/lib/questions.test.ts
+++ b/client/src/lib/questions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import questions from './questions.json';
+
+type QuestionRecord = {
+  id: string;
+  category: string;
+  difficulty: string;
+  question: string;
+  answer: string;
+  explanation: string;
+  tags: string[];
+};
+
+const questionList = questions as QuestionRecord[];
+const requiredTextFields = ['id', 'category', 'difficulty', 'question', 'answer', 'explanation'];
+const validDifficulties = new Set(['Easy', 'Medium', 'Hard']);
+const regionTags = new Set(['CA', 'US', 'Global']);
+const pillarTags = new Set(['GlobalEh', 'FreshPrints', 'TimeCapsule', 'GreatOutdoors']);
+
+function compactText(value: string) {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+describe('questions.json data integrity', () => {
+  it('contains at least one question', () => {
+    expect(questionList.length).toBeGreaterThan(0);
+  });
+
+  it('has required non-empty fields and tags for every question', () => {
+    const violations = questionList.flatMap((question) => {
+      const missingFields = requiredTextFields
+        .filter((field) => {
+          const value = question[field as keyof QuestionRecord];
+          return typeof value !== 'string' || value.trim().length === 0;
+        })
+        .map((field) => `${question.id || '<missing id>'}: ${field}`);
+
+      if (!Array.isArray(question.tags) || question.tags.length === 0) {
+        missingFields.push(`${question.id || '<missing id>'}: tags`);
+      }
+
+      return missingFields;
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('uses supported difficulty values', () => {
+    const invalidDifficulties = questionList
+      .filter((question) => !validDifficulties.has(question.difficulty))
+      .map((question) => `${question.id}: ${question.difficulty}`);
+
+    expect(invalidDifficulties).toEqual([]);
+  });
+
+  it('normalizes category, region, and pillar tags', () => {
+    const invalidTags = questionList.flatMap((question) => {
+      const tags = new Set(question.tags);
+      const violations: string[] = [];
+
+      if (!tags.has(question.category)) {
+        violations.push(`${question.id}: missing category tag ${question.category}`);
+      }
+
+      if (!question.tags.some((tag) => regionTags.has(tag))) {
+        violations.push(`${question.id}: missing region tag`);
+      }
+
+      if (!question.tags.some((tag) => pillarTags.has(tag))) {
+        violations.push(`${question.id}: missing pillar tag`);
+      }
+
+      return violations;
+    });
+
+    expect(invalidTags).toEqual([]);
+  });
+
+  it('has unique ids', () => {
+    const seen = new Set<string>();
+    const duplicates = questionList
+      .filter((question) => {
+        if (seen.has(question.id)) {
+          return true;
+        }
+
+        seen.add(question.id);
+        return false;
+      })
+      .map((question) => question.id);
+
+    expect(duplicates).toEqual([]);
+  });
+
+  it('has unique normalized question and answer pairs', () => {
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+
+    for (const question of questionList) {
+      const key = `${compactText(question.question)}::${compactText(question.answer)}`;
+      const existingId = seen.get(key);
+
+      if (existingId) {
+        duplicates.push(`${existingId} / ${question.id}`);
+        continue;
+      }
+
+      seen.set(key, question.id);
+    }
+
+    expect(duplicates).toEqual([]);
+  });
+});

--- a/server/routes.disputes.test.ts
+++ b/server/routes.disputes.test.ts
@@ -2,6 +2,7 @@ import express, { type Express, type NextFunction, type Request, type Response }
 import { createServer } from 'http';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
 const dbMocks = vi.hoisted(() => ({
   delete: vi.fn(),
@@ -30,6 +31,11 @@ const authMocks = vi.hoisted(() => ({
   setupAuth: vi.fn(async (_app: Express) => undefined),
 }));
 
+const schemaMocks = vi.hoisted(() => ({
+  insertDisputeParse: vi.fn((body) => body),
+  insertQuestionParse: vi.fn((body) => body),
+}));
+
 vi.mock('./db', () => ({
   db: {
     delete: dbMocks.delete,
@@ -45,10 +51,10 @@ vi.mock('@shared/schema', () => ({
   disputes: {},
   duplicatePairKey: vi.fn(),
   insertDisputeSchema: {
-    parse: vi.fn((body) => body),
+    parse: schemaMocks.insertDisputeParse,
   },
   insertQuestionSchema: {
-    parse: vi.fn((body) => body),
+    parse: schemaMocks.insertQuestionParse,
   },
   questionEdits: {},
   questionQualitySweepDismissals: {},
@@ -102,6 +108,8 @@ describe('dispute routes', () => {
     ]);
     dbMocks.values.mockReturnValue({ returning: dbMocks.returning });
     dbMocks.insert.mockReturnValue({ values: dbMocks.values });
+    schemaMocks.insertDisputeParse.mockImplementation((body) => body);
+    schemaMocks.insertQuestionParse.mockImplementation((body) => body);
   });
 
   it('allows unauthenticated players to submit disputes', async () => {
@@ -118,6 +126,33 @@ describe('dispute routes', () => {
       teamName: 'Alpha',
       teamExplanation: disputePayload.teamExplanation,
     });
+  });
+
+  it('returns 422 without writing when dispute validation fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    schemaMocks.insertDisputeParse.mockImplementationOnce(() => {
+      throw new z.ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['teamExplanation'],
+          message: 'Required',
+        },
+      ]);
+    });
+
+    const app = await buildApp();
+
+    const response = await request(app)
+      .post('/api/disputes')
+      .send({ ...disputePayload, teamExplanation: undefined })
+      .expect(422);
+
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith('Error creating dispute:', expect.any(z.ZodError));
+    expect(response.body).toEqual({ message: 'Invalid dispute data' });
   });
 
   it.each([

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -109,7 +109,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       res.status(201).json(newDispute);
     } catch (error) {
       console.error('Error creating dispute:', error);
-      const statusCode = error instanceof Error && error.message.includes('validation') ? 422 : 400;
+      const statusCode = error instanceof z.ZodError ? 422 : 400;
       res.status(statusCode).json({ message: 'Invalid dispute data' });
     }
   });

--- a/server/seed-data.json
+++ b/server/seed-data.json
@@ -1784,16 +1784,19 @@
     "id": "q89",
     "category": "History",
     "difficulty": "Medium",
-    "question": "In which year did the Titanic sink?",
-    "answer": "1912",
-    "acceptableAnswers": [],
-    "explanation": "Over 1,500 people died when RMS Titanic sank on April 15, 1912 after hitting an iceberg.",
-    "pillar": "GlobalEh",
+    "question": "Which civilization built Machu Picchu?",
+    "answer": "Inca Empire",
+    "acceptableAnswers": [
+      "Inca",
+      "Incas"
+    ],
+    "explanation": "Machu Picchu was built by the Inca Empire in the 15th century and later became one of Peru's most famous archaeological sites.",
+    "pillar": "TimeCapsule",
     "tags": [
       "Global",
       "History"
     ],
-    "sourceUrl": "https://en.wikipedia.org/wiki/Titanic",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Machu_Picchu",
     "sourceName": "Wikipedia",
     "status": "approved",
     "aiAnalysis": null,

--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { insertDisputeSchema, insertQuestionSchema } from './schema';
+
+const validDisputePayload = {
+  questionId: 'q-1',
+  questionText: 'What is the capital of Canada?',
+  correctAnswer: 'Ottawa',
+  teamName: 'Alpha',
+  submittedAnswer: 'Toronto',
+  teamExplanation: 'The clue made Toronto sound acceptable.',
+};
+
+const validQuestionPayload = {
+  id: 'q-test',
+  category: 'History',
+  difficulty: 'Medium',
+  question: 'Which civilization built Machu Picchu?',
+  answer: 'Inca Empire',
+  explanation: 'Machu Picchu was built by the Inca Empire in the 15th century.',
+  pillar: 'TimeCapsule',
+};
+
+describe('insertDisputeSchema', () => {
+  it('accepts a valid dispute payload', () => {
+    expect(insertDisputeSchema.parse(validDisputePayload)).toEqual(validDisputePayload);
+  });
+
+  it('rejects a payload missing a required field', () => {
+    const result = insertDisputeSchema.safeParse({
+      ...validDisputePayload,
+      teamExplanation: undefined,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((issue) => issue.path.join('.') === 'teamExplanation')).toBe(
+      true
+    );
+  });
+});
+
+describe('insertQuestionSchema', () => {
+  it('accepts a valid question and applies insert defaults', () => {
+    expect(insertQuestionSchema.parse(validQuestionPayload)).toMatchObject({
+      ...validQuestionPayload,
+      acceptableAnswers: [],
+      status: 'approved',
+      tags: [],
+    });
+  });
+
+  it.each([
+    ['difficulty', 'Impossible'],
+    ['pillar', 'WrongPillar'],
+    ['status', 'archived'],
+  ])('rejects an invalid %s value', (field, value) => {
+    const result = insertQuestionSchema.safeParse({
+      ...validQuestionPayload,
+      [field]: value,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((issue) => issue.path.join('.') === field)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared schema validation tests for dispute and question insert contracts
- Add deterministic question data-integrity tests for required fields, normalized tags, unique IDs, and unique question/answer pairs
- Return 422 for Zod dispute validation failures and cover that API path
- Replace duplicate q89 Titanic content with a sourced Machu Picchu question, mirrored in seed data

## Why
STE-67 tracks the remaining STE-55 test-gap scope: API route behavior, shared schema coverage, and trivia data integrity. This PR closes those gaps and fixes the duplicate question discovered while adding the integrity guard.

## Validation
- npm test
- npm run test:coverage
- npm run check
- npm run lint (existing warnings only, no errors)
- git diff --check

Linear: STE-67