### PR TITLE
fix(admin): make static quality sweep keys unique [STE-154]

### DIFF
--- a/client/src/pages/admin-quality-sweep.tsx
+++ b/client/src/pages/admin-quality-sweep.tsx
@@ -41,8 +41,10 @@ import { useAuth } from '@/hooks/use-auth';
 import { useAdmin } from '@/hooks/use-admin';
 import { useGame, type Question } from '@/lib/store';
 import {
+  buildStaticFindingKey,
   duplicatePairKey,
   FACT_CHECK_FINDING_KEY,
+  isStaticFindingDismissed,
   type DismissFindingRequest,
   type DuplicateMatch,
   type FactCheckVerdict,
@@ -645,8 +647,7 @@ function buildDefaultFilter(report: QualitySweepReport): IssueTypeFilter {
 function filterStaticFindings(findings: QuestionQualityFinding[], removed: RemovedFindings) {
   return findings.filter(
     (f) =>
-      !removed.deletedQuestionIds.has(f.questionId) &&
-      !removed.static.has(`${f.questionId}::${f.rule}`)
+      !removed.deletedQuestionIds.has(f.questionId) && !isStaticFindingDismissed(removed.static, f)
   );
 }
 
@@ -951,7 +952,8 @@ function AuditFindingsSection({
               </h4>
               <div className="space-y-2">
                 {group.map((finding) => {
-                  const editKey = `static::${finding.questionId}::${finding.rule}`;
+                  const findingKey = buildStaticFindingKey(finding);
+                  const editKey = `static::${finding.questionId}::${findingKey}`;
                   const snapshot = questionsById?.[finding.questionId];
                   return (
                     <FindingRow
@@ -959,7 +961,7 @@ function AuditFindingsSection({
                       editKey={editKey}
                       questionId={finding.questionId}
                       findingType="static"
-                      findingKey={finding.rule}
+                      findingKey={findingKey}
                       actions={actions}
                       proposedFix={finding.proposedFix}
                       rule={finding.rule}

--- a/server/lib/question-quality-audit.test.ts
+++ b/server/lib/question-quality-audit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { buildStaticFindingKey, isStaticFindingDismissed } from '../../shared/models/quality-sweep';
 import { auditQuestionQuality, formatQuestionQualitySummary } from './question-quality-audit';
 
 describe('auditQuestionQuality', () => {
@@ -38,6 +39,63 @@ describe('auditQuestionQuality', () => {
       )
     ).toBe(true);
     expect(report.findingsBySeverity.high).toBeGreaterThan(0);
+  });
+
+  it('builds unique static finding keys for repeated rules on the same question', () => {
+    const report = auditQuestionQuality([
+      {
+        id: 'required-fields-1',
+        category: '',
+        difficulty: '',
+        question: 'Which Canadian city hosts the Calgary Stampede?',
+        answer: '',
+        explanation: '',
+        tags: ['CA', 'General Knowledge', 'GlobalEh'],
+        sourceUrl: 'https://example.com/source',
+        sourceName: 'Example Source',
+      },
+    ]);
+
+    const missingRequiredFindings = report.findings.filter(
+      (finding) =>
+        finding.questionId === 'required-fields-1' && finding.rule === 'missing_required_field'
+    );
+    const keys = missingRequiredFindings.map(buildStaticFindingKey);
+
+    expect(missingRequiredFindings.length).toBeGreaterThan(1);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toContain('missing_required_field::Missing required field: answer.');
+  });
+
+  it('still recognizes legacy rule-only static dismissal keys', () => {
+    const report = auditQuestionQuality([
+      {
+        id: 'legacy-dismissal-1',
+        category: '',
+        difficulty: 'Easy',
+        question: 'Which Canadian city hosts the Calgary Stampede?',
+        answer: '',
+        explanation: 'The Calgary Stampede is hosted in Calgary.',
+        tags: ['CA', 'General Knowledge', 'GlobalEh'],
+        sourceUrl: 'https://example.com/source',
+        sourceName: 'Example Source',
+      },
+    ]);
+
+    const finding = report.findings.find(
+      (candidate) =>
+        candidate.questionId === 'legacy-dismissal-1' &&
+        candidate.rule === 'missing_required_field' &&
+        candidate.message === 'Missing required field: answer.'
+    );
+
+    expect(finding).toBeDefined();
+    if (!finding) {
+      throw new Error('Expected missing required answer finding');
+    }
+    expect(
+      isStaticFindingDismissed(new Set(['legacy-dismissal-1::missing_required_field']), finding)
+    ).toBe(true);
   });
 
   it('flags ambiguous prompts and answer-type mismatches as medium severity', () => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -14,6 +14,7 @@ import {
   questionEdits,
   questionQualitySweepDismissals,
   duplicatePairKey,
+  isStaticFindingDismissed,
   type QuestionSnapshot,
 } from '@shared/schema';
 import { eq, and, sql } from 'drizzle-orm';
@@ -873,7 +874,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       );
 
       const filteredFindings = auditRaw.findings.filter(
-        (f) => !dismissedStatic.has(`${f.questionId}::${f.rule}`)
+        (f) => !isStaticFindingDismissed(dismissedStatic, f)
       );
       const recountedSeverity: Record<'high' | 'medium' | 'low', number> = {
         high: 0,

--- a/shared/models/quality-sweep-dismissals.ts
+++ b/shared/models/quality-sweep-dismissals.ts
@@ -18,7 +18,7 @@ export const questionQualitySweepDismissals = pgTable(
       .references(() => questions.id, { onDelete: 'cascade' }),
     // 'static' | 'duplicate' | 'fact_check'
     findingType: varchar('finding_type', { length: 20 }).notNull(),
-    // For static: the rule name. For duplicate: sorted "{minId}::{maxId}".
+    // For static: stable rule+message finding key. For duplicate: sorted "{minId}::{maxId}".
     // For fact_check: the literal "fact_check".
     findingKey: text('finding_key').notNull(),
     dismissedAt: timestamp('dismissed_at').notNull().defaultNow(),

--- a/shared/models/quality-sweep.ts
+++ b/shared/models/quality-sweep.ts
@@ -116,6 +116,25 @@ export interface DismissFindingResponse {
   id: string;
 }
 
+type StaticFindingKeySource = Pick<QuestionQualityFinding, 'questionId' | 'rule' | 'message'>;
+
+// Build the stable per-finding key used for static audit dismissals.
+// Include the message so repeated rules on the same question stay distinct.
+export function buildStaticFindingKey(
+  finding: Pick<QuestionQualityFinding, 'rule' | 'message'>
+): string {
+  return `${finding.rule}::${finding.message}`;
+}
+
+export function isStaticFindingDismissed(
+  dismissedKeys: ReadonlySet<string>,
+  finding: StaticFindingKeySource
+): boolean {
+  const currentKey = `${finding.questionId}::${buildStaticFindingKey(finding)}`;
+  const legacyKey = `${finding.questionId}::${finding.rule}`;
+  return dismissedKeys.has(currentKey) || dismissedKeys.has(legacyKey);
+}
+
 // Build the stable per-pair key used for duplicate dismissals.
 // Sorting ensures the same key regardless of (A, B) order.
 export function duplicatePairKey(idA: string, idB: string): string {


### PR DESCRIPTION
Fixes non-unique React keys on static quality sweep findings that caused incorrect dismissal behavior. Keys now use buildStaticFindingKey() instead of rule name alone, and the dismissal check uses isStaticFindingDismissed(). Includes regression tests.

Closes STE-154