### PR TITLE
chore(test): add API route integration coverage [STE-152]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Use Conventional Commits: `<type>(<scope>): <description>`
 - Run `npm test` before marking work complete.
 - If tests fail: fix them. Do not skip, mock around, or ignore failures.
 - User-facing flow changes should add or update an E2E test in `e2e/`.
+- When adding a new route in `server/routes.ts`, add or update a corresponding integration test.
 
 ## Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Use Conventional Commits: `<type>(<scope>): <description>`
 - Run `npm test` before marking work complete.
 - If tests fail: fix them. Do not skip, mock around, or ignore failures.
 - User-facing flow changes should add or update an E2E test in `e2e/`.
+- When adding a new route in `server/routes.ts`, add or update a corresponding integration test.
 
 ## Error Handling
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,44 @@
+# Testing Guide
+
+Modern Trivia uses Vitest for unit and integration tests. Test files should use
+`*.test.ts` or `*.test.tsx` and run through `npm test`.
+
+## API Route Integration Tests
+
+Route integration tests for `server/routes.ts` should build a fresh Express app,
+register the real route handlers, and drive requests with `supertest`.
+
+Use `server/test/testApp.ts`:
+
+```ts
+const app = await buildTestApp();
+await request(app).get('/api/questions').expect(200);
+```
+
+Mock process boundaries, not route behavior:
+
+- Mock `server/db.ts` with lightweight Drizzle-style chain objects.
+- Mock OpenAI-facing helpers such as `analyzeDispute`, `generateQuestions`,
+  `getAiFieldFix`, and fact-checking utilities.
+- Mock Replit auth so tests can attach a user from `x-test-user-id`.
+- Use real Zod schemas from `@shared/schema` whenever possible so validation
+  tests exercise the production request contract.
+- Keep Postgres, Replit Auth, and OpenAI out of the test path.
+
+Protected-route tests should include unauthenticated `401`, authenticated
+non-admin `403`, and admin happy-path coverage where relevant. Public routes
+should still test validation failures and database write/read behavior.
+
+## Verification
+
+Before marking test work complete, run:
+
+```bash
+npm run check
+npm run lint
+OPENAI_API_KEY=invalid npm test
+npm run build
+```
+
+For API route work, also confirm the relevant route test fails if the protected
+behavior is deliberately broken.

--- a/replit.md
+++ b/replit.md
@@ -82,6 +82,7 @@ Use Conventional Commits: `<type>(<scope>): <description>`
 - Run `npm test` before marking work complete.
 - If tests fail: fix them. Do not skip, mock around, or ignore failures.
 - User-facing flow changes should add or update an E2E test in `e2e/`.
+- When adding a new route in `server/routes.ts`, add or update a corresponding integration test.
 
 ## Error Handling
 

--- a/server/routes.ai-analyze.test.ts
+++ b/server/routes.ai-analyze.test.ts
@@ -1,0 +1,180 @@
+import type { Express, NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { analyzeDispute } from './lib/ai';
+import { createQueryMock } from './test/dbMock';
+import { buildTestApp } from './test/testApp';
+
+const dbMocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  insert: vi.fn(),
+  select: vi.fn(),
+  selectDistinct: vi.fn(),
+  update: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn((req: Request, res: Response, next: NextFunction) => {
+    const user = (req as Request & { user?: TestUser }).user;
+
+    if (!user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    next();
+  }),
+  registerAuthRoutes: vi.fn(),
+  setupAuth: vi.fn(async (app: Express) => {
+    app.use((req: Request, _res: Response, next: NextFunction) => {
+      const userId = req.header('x-test-user-id');
+
+      if (userId) {
+        (req as Request & { user?: TestUser }).user = {
+          claims: { sub: userId },
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+        };
+      }
+
+      next();
+    });
+  }),
+}));
+
+type TestUser = {
+  claims: { sub: string };
+  expires_at: number;
+};
+
+vi.mock('./db', () => ({
+  db: {
+    delete: dbMocks.delete,
+    insert: dbMocks.insert,
+    select: dbMocks.select,
+    selectDistinct: dbMocks.selectDistinct,
+    update: dbMocks.update,
+  },
+}));
+
+vi.mock('./replit_integrations/auth', () => authMocks);
+vi.mock('./lib/subjectivity-enricher', () => ({ enrichSubjectiveFindings: vi.fn() }));
+vi.mock('./lib/ai', () => ({ analyzeDispute: vi.fn() }));
+vi.mock('./lib/guardian', () => ({ generateQuestions: vi.fn() }));
+vi.mock('./lib/field-fix', () => ({ getAiFieldFix: vi.fn() }));
+vi.mock('./lib/question-quality-audit', () => ({ auditQuestionQuality: vi.fn() }));
+vi.mock('./lib/duplicate-detector', () => ({ detectDuplicates: vi.fn() }));
+vi.mock('./lib/verifier', () => ({ batchFactCheck: vi.fn() }));
+
+const adminRole = { userId: 'admin-user' };
+const disputeRow = {
+  id: 'dispute-1',
+  questionId: 'q-1',
+  questionText: 'What is the capital of Canada?',
+  correctAnswer: 'Ottawa',
+  teamName: 'Alpha',
+  submittedAnswer: 'Toronto',
+  teamExplanation: 'The clue seemed to ask for the biggest city.',
+  timestamp: new Date('2026-01-01T00:00:00Z'),
+  status: 'pending',
+  resolutionNote: null,
+  aiAnalysis: null,
+};
+const analysis = {
+  verdict: 'INCORRECT' as const,
+  confidence: 92,
+  reasoning: 'Ottawa is the capital of Canada.',
+  sources: ['canada.ca'],
+};
+
+describe('AI dispute analysis route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(analyzeDispute).mockResolvedValue(analysis);
+    dbMocks.update.mockReturnValue(createQueryMock(undefined));
+  });
+
+  it('requires authentication', async () => {
+    const app = await buildTestApp();
+
+    const response = await request(app).post('/api/disputes/dispute-1/analyze').expect(401);
+
+    expect(response.body).toEqual({ message: 'Unauthorized' });
+    expect(dbMocks.select).not.toHaveBeenCalled();
+    expect(analyzeDispute).not.toHaveBeenCalled();
+  });
+
+  it('requires admin access', async () => {
+    dbMocks.select.mockReturnValue(createQueryMock([]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/disputes/dispute-1/analyze')
+      .set('x-test-user-id', 'regular-user')
+      .expect(403);
+
+    expect(response.body).toEqual({ message: 'Forbidden: Admin access required' });
+    expect(analyzeDispute).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the dispute does not exist', async () => {
+    dbMocks.select
+      .mockReturnValueOnce(createQueryMock([adminRole]))
+      .mockReturnValueOnce(createQueryMock([]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/disputes/missing/analyze')
+      .set('x-test-user-id', 'admin-user')
+      .expect(404);
+
+    expect(response.body).toEqual({ message: 'Dispute not found' });
+    expect(analyzeDispute).not.toHaveBeenCalled();
+  });
+
+  it('runs analysis and stores the result for admins', async () => {
+    dbMocks.select
+      .mockReturnValueOnce(createQueryMock([adminRole]))
+      .mockReturnValueOnce(createQueryMock([disputeRow]));
+    const updateQuery = createQueryMock(undefined);
+    dbMocks.update.mockReturnValue(updateQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/disputes/dispute-1/analyze')
+      .set('x-test-user-id', 'admin-user')
+      .expect(200);
+
+    expect(analyzeDispute).toHaveBeenCalledWith(
+      disputeRow.questionText,
+      disputeRow.correctAnswer,
+      disputeRow.submittedAnswer,
+      disputeRow.teamExplanation
+    );
+    expect(updateQuery.set).toHaveBeenCalledWith({ aiAnalysis: analysis });
+    expect(response.body).toEqual(analysis);
+  });
+
+  it('passes through the AI rate limiter', async () => {
+    let selectCount = 0;
+    dbMocks.select.mockImplementation(() => {
+      selectCount += 1;
+      return createQueryMock(selectCount % 2 === 1 ? [adminRole] : [disputeRow]);
+    });
+    const app = await buildTestApp();
+    const headers = { 'x-test-user-id': 'rate-limit-admin-ste-152' };
+
+    for (let i = 0; i < 20; i++) {
+      await request(app).post('/api/disputes/dispute-1/analyze').set(headers).expect(200);
+    }
+
+    const response = await request(app)
+      .post('/api/disputes/dispute-1/analyze')
+      .set(headers)
+      .expect(429);
+
+    expect(response.body).toEqual({
+      message: 'AI analysis rate limit exceeded. Please wait before trying again.',
+    });
+    expect(analyzeDispute).toHaveBeenCalledTimes(20);
+  });
+});

--- a/server/routes.disputes.test.ts
+++ b/server/routes.disputes.test.ts
@@ -1,65 +1,58 @@
-import express, { type Express, type NextFunction, type Request, type Response } from 'express';
-import { createServer } from 'http';
+import type { Express, NextFunction, Request, Response } from 'express';
 import request from 'supertest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { z } from 'zod';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryMock } from './test/dbMock';
+import { buildTestApp } from './test/testApp';
 
 const dbMocks = vi.hoisted(() => ({
   delete: vi.fn(),
   insert: vi.fn(),
-  returning: vi.fn(),
   select: vi.fn(),
+  selectDistinct: vi.fn(),
   update: vi.fn(),
-  values: vi.fn(),
 }));
 
 const authMocks = vi.hoisted(() => ({
   isAuthenticated: vi.fn((req: Request, res: Response, next: NextFunction) => {
-    const userId = req.header('x-test-user-id');
+    const user = (req as Request & { user?: TestUser }).user;
 
-    if (!userId) {
+    if (!user) {
       return res.status(401).json({ message: 'Unauthorized' });
     }
 
-    (req as Request & { user?: { claims: { sub: string }; expires_at: number } }).user = {
-      claims: { sub: userId },
-      expires_at: Math.floor(Date.now() / 1000) + 60,
-    };
     next();
   }),
   registerAuthRoutes: vi.fn(),
-  setupAuth: vi.fn(async (_app: Express) => undefined),
+  setupAuth: vi.fn(async (app: Express) => {
+    app.use((req: Request, _res: Response, next: NextFunction) => {
+      const userId = req.header('x-test-user-id');
+
+      if (userId) {
+        (req as Request & { user?: TestUser }).user = {
+          claims: { sub: userId },
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+        };
+      }
+
+      next();
+    });
+  }),
 }));
 
-const schemaMocks = vi.hoisted(() => ({
-  insertDisputeParse: vi.fn((body) => body),
-  insertQuestionParse: vi.fn((body) => body),
-}));
+type TestUser = {
+  claims: { sub: string };
+  expires_at: number;
+};
 
 vi.mock('./db', () => ({
   db: {
     delete: dbMocks.delete,
     insert: dbMocks.insert,
     select: dbMocks.select,
+    selectDistinct: dbMocks.selectDistinct,
     update: dbMocks.update,
   },
-}));
-
-vi.mock('@shared/schema', () => ({
-  adminRoles: {},
-  appConfig: {},
-  disputes: {},
-  duplicatePairKey: vi.fn(),
-  insertDisputeSchema: {
-    parse: schemaMocks.insertDisputeParse,
-  },
-  insertQuestionSchema: {
-    parse: schemaMocks.insertQuestionParse,
-  },
-  questionEdits: {},
-  questionQualitySweepDismissals: {},
-  questions: {},
-  seenQuestions: {},
 }));
 
 vi.mock('./replit_integrations/auth', () => authMocks);
@@ -70,10 +63,8 @@ vi.mock('./lib/field-fix', () => ({ getAiFieldFix: vi.fn() }));
 vi.mock('./lib/question-quality-audit', () => ({ auditQuestionQuality: vi.fn() }));
 vi.mock('./lib/duplicate-detector', () => ({ detectDuplicates: vi.fn() }));
 vi.mock('./lib/verifier', () => ({ batchFactCheck: vi.fn() }));
-vi.mock('./middleware/rateLimiter', () => ({
-  aiLimiter: (_req: Request, _res: Response, next: NextFunction) => next(),
-}));
 
+const adminRole = { userId: 'admin-user' };
 const disputePayload = {
   questionId: 'q-1',
   questionText: 'What is the capital of Canada?',
@@ -82,44 +73,37 @@ const disputePayload = {
   submittedAnswer: 'Toronto',
   teamExplanation: 'We think Toronto should count because of the clue wording.',
 };
+const disputeRow = {
+  ...disputePayload,
+  id: 'dispute-1',
+  status: 'pending',
+  timestamp: new Date('2026-01-01T00:00:00Z'),
+  resolutionNote: null,
+  aiAnalysis: null,
+};
 
-async function buildApp() {
-  const app = express();
-  app.use(express.json());
-
-  const { registerRoutes } = await import('./routes');
-  await registerRoutes(createServer(app), app);
-
-  return app;
-}
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 describe('dispute routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dbMocks.returning.mockResolvedValue([
-      {
-        ...disputePayload,
-        id: 'dispute-1',
-        status: 'pending',
-        timestamp: new Date('2026-01-01T00:00:00Z'),
-        resolutionNote: null,
-        aiAnalysis: null,
-      },
-    ]);
-    dbMocks.values.mockReturnValue({ returning: dbMocks.returning });
-    dbMocks.insert.mockReturnValue({ values: dbMocks.values });
-    schemaMocks.insertDisputeParse.mockImplementation((body) => body);
-    schemaMocks.insertQuestionParse.mockImplementation((body) => body);
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('allows unauthenticated players to submit disputes', async () => {
-    const app = await buildApp();
+    const insertQuery = createQueryMock([disputeRow]);
+    dbMocks.insert.mockReturnValue(insertQuery);
+    const app = await buildTestApp();
 
     const response = await request(app).post('/api/disputes').send(disputePayload).expect(201);
 
     expect(authMocks.isAuthenticated).not.toHaveBeenCalled();
     expect(dbMocks.insert).toHaveBeenCalledOnce();
-    expect(dbMocks.values).toHaveBeenCalledWith(disputePayload);
+    expect(insertQuery.values).toHaveBeenCalledWith(disputePayload);
     expect(response.body).toMatchObject({
       id: 'dispute-1',
       status: 'pending',
@@ -129,30 +113,29 @@ describe('dispute routes', () => {
   });
 
   it('returns 422 without writing when dispute validation fails', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const app = await buildTestApp();
+    const { teamExplanation: _teamExplanation, ...invalidPayload } = disputePayload;
 
-    schemaMocks.insertDisputeParse.mockImplementationOnce(() => {
-      throw new z.ZodError([
-        {
-          code: 'invalid_type',
-          expected: 'string',
-          received: 'undefined',
-          path: ['teamExplanation'],
-          message: 'Required',
-        },
-      ]);
-    });
+    const response = await request(app).post('/api/disputes').send(invalidPayload).expect(422);
 
-    const app = await buildApp();
-
-    const response = await request(app)
-      .post('/api/disputes')
-      .send({ ...disputePayload, teamExplanation: undefined })
-      .expect(422);
-
-    expect(dbMocks.insert).not.toHaveBeenCalled();
-    expect(consoleError).toHaveBeenCalledWith('Error creating dispute:', expect.any(z.ZodError));
     expect(response.body).toEqual({ message: 'Invalid dispute data' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error creating dispute:', expect.any(Error));
+  });
+
+  it('accepts long dispute explanations that stay within the JSON body limit', async () => {
+    const longPayload = {
+      ...disputePayload,
+      teamExplanation: 'This should count. '.repeat(3_000),
+    };
+    const insertQuery = createQueryMock([{ ...disputeRow, ...longPayload }]);
+    dbMocks.insert.mockReturnValue(insertQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app).post('/api/disputes').send(longPayload).expect(201);
+
+    expect(insertQuery.values).toHaveBeenCalledWith(longPayload);
+    expect(response.body.teamExplanation).toBe(longPayload.teamExplanation);
   });
 
   it.each([
@@ -161,7 +144,7 @@ describe('dispute routes', () => {
     ['DELETE', '/api/disputes'],
     ['POST', '/api/disputes/dispute-1/analyze'],
   ])('keeps %s %s protected without a session', async (method, path) => {
-    const app = await buildApp();
+    const app = await buildTestApp();
     let response: request.Response;
 
     switch (method) {
@@ -181,5 +164,98 @@ describe('dispute routes', () => {
 
     expect(response.status).toBe(401);
     expect(response.body).toEqual({ message: 'Unauthorized' });
+  });
+
+  it.each([
+    ['GET', '/api/disputes'],
+    ['PATCH', '/api/disputes/dispute-1'],
+    ['DELETE', '/api/disputes'],
+    ['POST', '/api/disputes/dispute-1/analyze'],
+  ])('rejects non-admin sessions for %s %s', async (method, path) => {
+    dbMocks.select.mockReturnValue(createQueryMock([]));
+    const app = await buildTestApp();
+    let response: request.Response;
+
+    switch (method) {
+      case 'GET':
+        response = await request(app).get(path).set('x-test-user-id', 'regular-user');
+        break;
+      case 'PATCH':
+        response = await request(app)
+          .patch(path)
+          .set('x-test-user-id', 'regular-user')
+          .send({ status: 'resolved' });
+        break;
+      case 'DELETE':
+        response = await request(app).delete(path).set('x-test-user-id', 'regular-user');
+        break;
+      default:
+        response = await request(app).post(path).set('x-test-user-id', 'regular-user');
+        break;
+    }
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ message: 'Forbidden: Admin access required' });
+  });
+
+  it('lists disputes for admins', async () => {
+    dbMocks.select
+      .mockReturnValueOnce(createQueryMock([adminRole]))
+      .mockReturnValueOnce(createQueryMock([disputeRow]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/disputes')
+      .set('x-test-user-id', 'admin-user')
+      .expect(200);
+
+    expect(response.body).toMatchObject([{ id: 'dispute-1', teamName: 'Alpha' }]);
+  });
+
+  it.each(['resolved', 'rejected'])('updates disputes to %s for admins', async (status) => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const updateQuery = createQueryMock([{ ...disputeRow, status, resolutionNote: 'Reviewed' }]);
+    dbMocks.update.mockReturnValue(updateQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/disputes/dispute-1')
+      .set('x-test-user-id', 'admin-user')
+      .send({ status, resolutionNote: 'Reviewed' })
+      .expect(200);
+
+    expect(updateQuery.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status, resolutionNote: 'Reviewed' })
+    );
+    expect(response.body).toMatchObject({ id: 'dispute-1', status, resolutionNote: 'Reviewed' });
+  });
+
+  it('rejects invalid dispute statuses before updating', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/disputes/dispute-1')
+      .set('x-test-user-id', 'admin-user')
+      .send({ status: 'closed' })
+      .expect(400);
+
+    expect(response.body).toEqual({ message: 'Invalid status' });
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it('clears disputes for admins', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const deleteQuery = createQueryMock(undefined);
+    dbMocks.delete.mockReturnValue(deleteQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .delete('/api/disputes')
+      .set('x-test-user-id', 'admin-user')
+      .expect(200);
+
+    expect(dbMocks.delete).toHaveBeenCalledOnce();
+    expect(response.body).toEqual({ message: 'All disputes cleared' });
   });
 });

--- a/server/routes.questions.test.ts
+++ b/server/routes.questions.test.ts
@@ -1,0 +1,260 @@
+import type { Express, NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryMock } from './test/dbMock';
+import { buildTestApp } from './test/testApp';
+
+const dbMocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  insert: vi.fn(),
+  select: vi.fn(),
+  selectDistinct: vi.fn(),
+  update: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn((req: Request, res: Response, next: NextFunction) => {
+    const user = (req as Request & { user?: TestUser }).user;
+
+    if (!user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    next();
+  }),
+  registerAuthRoutes: vi.fn(),
+  setupAuth: vi.fn(async (app: Express) => {
+    app.use((req: Request, _res: Response, next: NextFunction) => {
+      const userId = req.header('x-test-user-id');
+
+      if (userId) {
+        (req as Request & { user?: TestUser }).user = {
+          claims: { sub: userId },
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+        };
+      }
+
+      next();
+    });
+  }),
+}));
+
+type TestUser = {
+  claims: { sub: string };
+  expires_at: number;
+};
+
+vi.mock('./db', () => ({
+  db: {
+    delete: dbMocks.delete,
+    insert: dbMocks.insert,
+    select: dbMocks.select,
+    selectDistinct: dbMocks.selectDistinct,
+    update: dbMocks.update,
+  },
+}));
+
+vi.mock('./replit_integrations/auth', () => authMocks);
+vi.mock('./lib/subjectivity-enricher', () => ({ enrichSubjectiveFindings: vi.fn() }));
+vi.mock('./lib/ai', () => ({ analyzeDispute: vi.fn() }));
+vi.mock('./lib/guardian', () => ({ generateQuestions: vi.fn() }));
+vi.mock('./lib/field-fix', () => ({ getAiFieldFix: vi.fn() }));
+vi.mock('./lib/question-quality-audit', () => ({ auditQuestionQuality: vi.fn() }));
+vi.mock('./lib/duplicate-detector', () => ({ detectDuplicates: vi.fn() }));
+vi.mock('./lib/verifier', () => ({ batchFactCheck: vi.fn() }));
+
+const adminRole = { userId: 'admin-user' };
+const questionPayload = {
+  id: 'q-1',
+  category: 'Geography',
+  difficulty: 'Easy',
+  question: 'What is the capital of Canada?',
+  answer: 'Ottawa',
+  acceptableAnswers: ['Ottawa, Ontario'],
+  explanation: 'Ottawa is the federal capital of Canada.',
+  pillar: 'GlobalEh',
+  tags: ['CA', 'GlobalEh', 'Geography'],
+  sourceUrl: 'https://www.canada.ca/en/canadian-heritage/services/crown-canada/about.html',
+  sourceName: 'Government of Canada',
+  status: 'approved',
+};
+const questionRow = {
+  ...questionPayload,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  aiAnalysis: null,
+};
+
+function mockQuestionMetadata() {
+  dbMocks.selectDistinct
+    .mockReturnValueOnce(createQueryMock([{ category: questionPayload.category }]))
+    .mockReturnValueOnce(createQueryMock([{ pillar: questionPayload.pillar }]));
+}
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+describe('question routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns approved questions with filters, shuffle, and limit metadata', async () => {
+    const questionQuery = createQueryMock([questionRow]);
+    dbMocks.select.mockReturnValueOnce(questionQuery);
+    mockQuestionMetadata();
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/questions?category=Geography&difficulty=Easy&pillar=GlobalEh&shuffle=true&limit=1')
+      .expect(200);
+
+    expect(questionQuery.where).toHaveBeenCalledOnce();
+    expect(questionQuery.orderBy).toHaveBeenCalledOnce();
+    expect(questionQuery.limit).toHaveBeenCalledWith(1);
+    expect(response.body).toMatchObject({
+      total: 1,
+      categories: ['Geography'],
+      pillars: ['GlobalEh'],
+      questions: [{ id: 'q-1', question: questionPayload.question }],
+    });
+  });
+
+  it('can exclude recently seen questions for authenticated users', async () => {
+    const questionQuery = createQueryMock([questionRow]);
+    dbMocks.select.mockReturnValueOnce(questionQuery);
+    mockQuestionMetadata();
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/questions?excludeSeen=true&shuffle=true&limit=2')
+      .set('x-test-user-id', 'player-1')
+      .expect(200);
+
+    expect(questionQuery.leftJoin).toHaveBeenCalledOnce();
+    expect(questionQuery.where).toHaveBeenCalledOnce();
+    expect(questionQuery.orderBy).toHaveBeenCalledTimes(1);
+    expect(questionQuery.limit).toHaveBeenCalledWith(2);
+    expect(response.body.questions).toHaveLength(1);
+  });
+
+  it('requires authentication to create questions', async () => {
+    const app = await buildTestApp();
+
+    const response = await request(app).post('/api/questions').send(questionPayload).expect(401);
+
+    expect(response.body).toEqual({ message: 'Unauthorized' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('requires admin access to create questions', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/questions')
+      .set('x-test-user-id', 'regular-user')
+      .send(questionPayload)
+      .expect(403);
+
+    expect(response.body).toEqual({ message: 'Forbidden: Admin access required' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('creates questions for admins', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const insertQuery = createQueryMock([questionRow]);
+    dbMocks.insert.mockReturnValue(insertQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/questions')
+      .set('x-test-user-id', 'admin-user')
+      .send(questionPayload)
+      .expect(201);
+
+    expect(insertQuery.values).toHaveBeenCalledWith(questionPayload);
+    expect(response.body).toMatchObject({ id: 'q-1', question: questionPayload.question });
+  });
+
+  it('updates questions for admins', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const updateQuery = createQueryMock([{ ...questionRow, answer: 'Ottawa' }]);
+    dbMocks.update.mockReturnValue(updateQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/questions/q-1')
+      .set('x-test-user-id', 'admin-user')
+      .send({ answer: 'Ottawa' })
+      .expect(200);
+
+    expect(updateQuery.set).toHaveBeenCalledWith(
+      expect.objectContaining({ answer: 'Ottawa', updatedAt: expect.any(Date) })
+    );
+    expect(response.body).toMatchObject({ id: 'q-1', answer: 'Ottawa' });
+  });
+
+  it('returns 404 when admins update a missing question', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    dbMocks.update.mockReturnValue(createQueryMock([]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/questions/missing')
+      .set('x-test-user-id', 'admin-user')
+      .send({ answer: 'Ottawa' })
+      .expect(404);
+
+    expect(response.body).toEqual({ message: 'Question not found' });
+  });
+
+  it('requires authentication to mark questions as seen', async () => {
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/questions/seen')
+      .send({ questionIds: ['q-1'] })
+      .expect(401);
+
+    expect(response.body).toEqual({ message: 'Unauthorized' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('validates seen-question payloads', async () => {
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/questions/seen')
+      .set('x-test-user-id', 'player-1')
+      .send({ questionIds: [] })
+      .expect(400);
+
+    expect(response.body).toEqual({ message: 'questionIds array is required' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('upserts seen-question rows for authenticated users', async () => {
+    const insertQuery = createQueryMock(undefined);
+    dbMocks.insert.mockReturnValue(insertQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/questions/seen')
+      .set('x-test-user-id', 'player-1')
+      .send({ questionIds: ['q-1', 'q-2'] })
+      .expect(200);
+
+    expect(insertQuery.values).toHaveBeenCalledWith([
+      { userId: 'player-1', questionId: 'q-1' },
+      { userId: 'player-1', questionId: 'q-2' },
+    ]);
+    expect(insertQuery.onConflictDoUpdate).toHaveBeenCalledOnce();
+    expect(response.body).toEqual({ message: 'Questions marked as seen', count: 2 });
+  });
+});

--- a/server/test/dbMock.ts
+++ b/server/test/dbMock.ts
@@ -1,0 +1,35 @@
+import { vi, type Mock } from 'vitest';
+
+export type QueryMock<T> = PromiseLike<T> & {
+  from: Mock;
+  leftJoin: Mock;
+  limit: Mock;
+  offset: Mock;
+  onConflictDoNothing: Mock;
+  onConflictDoUpdate: Mock;
+  orderBy: Mock;
+  returning: Mock;
+  set: Mock;
+  values: Mock;
+  where: Mock;
+};
+
+export function createQueryMock<T>(result: T): QueryMock<T> {
+  const promise = Promise.resolve(result);
+  const query = {
+    from: vi.fn(() => query),
+    leftJoin: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    offset: vi.fn(() => query),
+    onConflictDoNothing: vi.fn(() => query),
+    onConflictDoUpdate: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    returning: vi.fn(() => Promise.resolve(result)),
+    set: vi.fn(() => query),
+    then: promise.then.bind(promise),
+    values: vi.fn(() => query),
+    where: vi.fn(() => query),
+  };
+
+  return query;
+}

--- a/server/test/testApp.ts
+++ b/server/test/testApp.ts
@@ -1,0 +1,12 @@
+import express, { type Express } from 'express';
+import { createServer } from 'http';
+
+export async function buildTestApp(): Promise<Express> {
+  const app = express();
+  app.use(express.json());
+
+  const { registerRoutes } = await import('../routes');
+  await registerRoutes(createServer(app), app);
+
+  return app;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
           environment: "node",
           include: ["server/**/*.test.ts", "shared/**/*.test.ts"],
         },
+        resolve: {
+          alias: {
+            "@shared": path.resolve(import.meta.dirname, "shared"),
+          },
+        },
       },
       {
         plugins: [react()],


### PR DESCRIPTION
## Summary

Closes STE-152 by adding integration coverage around the critical `server/routes.ts` API surface.

## What changed

- Added a shared Express route test harness in `server/test/testApp.ts` plus a lightweight Drizzle-style query mock helper in `server/test/dbMock.ts`.
- Expanded dispute route integration coverage for public submit behavior, invalid payloads, long payloads, admin auth gates, admin list/update/delete, and invalid status handling.
- Added AI dispute analysis route tests for 401, 403, 404, mocked analysis success, DB persistence, and real `aiLimiter` 429 behavior.
- Added questions route tests for public listing filters, `excludeSeen`, admin create/update, and seen-question upserts.
- Added server Vitest `@shared` alias support so route tests can exercise the real shared schemas.
- Documented the API route integration test pattern and synced the agent-manual route-test rule across `AGENTS.md`, `CLAUDE.md`, and `replit.md`.

## Validation

- `npm run check`
- `npm run lint` (passes with existing warnings)
- `OPENAI_API_KEY=invalid npm test` (128 tests passing)
- `/usr/bin/time npm test` (2.82s real)
- `npm run build`

## Documentation updated

- `docs/guides/testing.md` documents the route integration test pattern.
- `AGENTS.md`, `CLAUDE.md`, and `replit.md` now require integration tests when adding or updating `server/routes.ts` routes.
- Linear STE-152 has an implementation/verification progress comment.