### PR TITLE
feat(api): add quality control prompt for sweep [STE-29]

### DIFF
--- a/server/lib/quality-control-prompt.test.ts
+++ b/server/lib/quality-control-prompt.test.ts
@@ -37,6 +37,20 @@ describe('buildQualityControlPrompt', () => {
     expect(prompt).toContain('FreshPrints');
   });
 
+  it('clamps the FreshPrints cutoff to the target month instead of rolling over', () => {
+    const mayPrompt = buildQualityControlPrompt(
+      [makeQuestion({ id: 'may-end', question: 'What is the capital of France?' })],
+      new Date('2026-05-31T00:00:00.000Z')
+    );
+    const decemberPrompt = buildQualityControlPrompt(
+      [makeQuestion({ id: 'december-end', question: 'What is the capital of France?' })],
+      new Date('2026-12-31T00:00:00.000Z')
+    );
+
+    expect(mayPrompt).toContain('FreshPrints freshness cutoff: 2026-02-28');
+    expect(decemberPrompt).toContain('FreshPrints freshness cutoff: 2026-09-30');
+  });
+
   it('serializes the expanded question metadata needed for semantic QA', () => {
     const prompt = buildQualityControlPrompt([
       makeQuestion({

--- a/server/lib/quality-control-prompt.test.ts
+++ b/server/lib/quality-control-prompt.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Question } from '@shared/models/questions';
+import { buildQualityControlPrompt } from './quality-control-prompt';
+
+function makeQuestion(overrides: Partial<Question> & { id: string; question: string }): Question {
+  return {
+    category: 'General Knowledge',
+    difficulty: 'Medium',
+    answer: 'Test answer',
+    explanation: 'Test explanation.',
+    pillar: 'GlobalEh',
+    tags: ['Global', 'General Knowledge', 'GlobalEh'],
+    acceptableAnswers: [],
+    sourceUrl: 'https://example.com/source',
+    sourceName: 'Example Source',
+    status: 'approved',
+    aiAnalysis: null,
+    createdAt: new Date('2026-04-25T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-25T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('buildQualityControlPrompt', () => {
+  it('includes the Modern Trivia editorial rubric and review freshness window', () => {
+    const prompt = buildQualityControlPrompt(
+      [makeQuestion({ id: 'q1', question: 'What is the capital of France?' })],
+      new Date('2026-04-25T00:00:00.000Z')
+    );
+
+    expect(prompt).toContain('Modern Trivia Quality Control reviewer');
+    expect(prompt).toContain('Review date: 2026-04-25');
+    expect(prompt).toContain('FreshPrints freshness cutoff: 2026-01-25');
+    expect(prompt).toContain('Answer leakage');
+    expect(prompt).toContain('GlobalEh');
+    expect(prompt).toContain('FreshPrints');
+  });
+
+  it('serializes the expanded question metadata needed for semantic QA', () => {
+    const prompt = buildQualityControlPrompt([
+      makeQuestion({
+        id: 'metadata-1',
+        category: 'Geography',
+        difficulty: 'Easy',
+        question: 'Which Canadian city hosts the Calgary Stampede?',
+        answer: 'Calgary',
+        explanation: 'The Calgary Stampede is hosted in Calgary.',
+        pillar: 'GreatOutdoors',
+        tags: ['CA', 'Geography', 'GreatOutdoors'],
+        sourceUrl: 'https://www.thecanadianencyclopedia.ca/en/article/calgary-stampede',
+        sourceName: 'The Canadian Encyclopedia',
+      }),
+    ]);
+
+    expect(prompt).toContain('"category": "Geography"');
+    expect(prompt).toContain('"difficulty": "Easy"');
+    expect(prompt).toContain('"pillar": "GreatOutdoors"');
+    expect(prompt).toContain('"tags"');
+    expect(prompt).toContain('"sourceUrl"');
+    expect(prompt).toContain('"sourceName"');
+  });
+
+  it('covers the five STE-29 known-bad prompt scenarios', () => {
+    const prompt = buildQualityControlPrompt(
+      [
+        makeQuestion({
+          id: 'embedded-answer',
+          question: 'What city, Calgary, hosts the Calgary Stampede?',
+          answer: 'Calgary',
+        }),
+        makeQuestion({
+          id: 'us-centric-globaleh',
+          category: 'Geography',
+          question: 'What is the capital of Iowa?',
+          answer: 'Des Moines',
+          pillar: 'GlobalEh',
+          tags: ['US', 'Geography', 'GlobalEh'],
+        }),
+        makeQuestion({
+          id: 'wrong-difficulty',
+          difficulty: 'Easy',
+          question: 'Which enzyme catalyzes the rate-limiting step of glycolysis?',
+          answer: 'Phosphofructokinase-1',
+        }),
+        makeQuestion({
+          id: 'typo',
+          question: 'Which planett is known as the Red Planet?',
+          answer: 'Mars',
+        }),
+        makeQuestion({
+          id: 'stale-freshprints',
+          question: 'Which app topped download charts during the 2020 lockdowns?',
+          answer: 'Zoom',
+          pillar: 'FreshPrints',
+          tags: ['Global', 'Technology', 'FreshPrints'],
+        }),
+      ],
+      new Date('2026-04-25T00:00:00.000Z')
+    );
+
+    expect(prompt).toContain('embedded-answer');
+    expect(prompt).toContain('us-centric-globaleh');
+    expect(prompt).toContain('wrong-difficulty');
+    expect(prompt).toContain('typo');
+    expect(prompt).toContain('stale-freshprints');
+    expect(prompt).toContain('answer or a distinctive answer keyword');
+    expect(prompt).toContain('not US-centric');
+    expect(prompt).toContain('Difficulty');
+    expect(prompt).toContain('misspellings');
+    expect(prompt).toContain('older than the cutoff');
+  });
+});

--- a/server/lib/quality-control-prompt.ts
+++ b/server/lib/quality-control-prompt.ts
@@ -1,0 +1,80 @@
+import type { Question } from '@shared/models/questions';
+
+type QualityControlQuestionPayload = Pick<
+  Question,
+  | 'id'
+  | 'category'
+  | 'difficulty'
+  | 'question'
+  | 'answer'
+  | 'explanation'
+  | 'pillar'
+  | 'tags'
+  | 'sourceUrl'
+  | 'sourceName'
+>;
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function threeMonthsBefore(date: Date): Date {
+  const result = new Date(date);
+  result.setMonth(result.getMonth() - 3);
+  return result;
+}
+
+function toQualityControlPayload(question: Question): QualityControlQuestionPayload {
+  return {
+    id: question.id,
+    category: question.category,
+    difficulty: question.difficulty,
+    question: question.question,
+    answer: question.answer,
+    explanation: question.explanation,
+    pillar: question.pillar,
+    tags: question.tags ?? [],
+    sourceUrl: question.sourceUrl ?? null,
+    sourceName: question.sourceName ?? null,
+  };
+}
+
+export function buildQualityControlPrompt(questions: Question[], reviewDate = new Date()): string {
+  const staleFreshPrintsCutoff = threeMonthsBefore(reviewDate);
+
+  return `You are the Modern Trivia Quality Control reviewer. Review each trivia item against factual accuracy and the game's editorial standards.
+
+Review date: ${formatDate(reviewDate)}
+FreshPrints freshness cutoff: ${formatDate(staleFreshPrintsCutoff)}
+
+For each question return one of:
+- "pass"  — question, answer, explanation, tags, pillar, and difficulty are suitable
+- "flag"  — likely usable, but has an editorial concern, minor typo, weak source, stale clue, possible tag issue, or uncertain fact
+- "fail"  — factually wrong, misleading, answer leaks into the prompt, circular wording, clearly wrong tag/pillar/difficulty, or unusable as trivia
+
+Evaluate these Modern Trivia quality rules:
+- Factual correctness: question, answer, and explanation must agree and be verifiable.
+- Answer leakage: the answer or a distinctive answer keyword must not appear in the question text.
+- Circular wording: do not ask who/what something is while naming the answer in the question.
+- Clarity and typos: flag misspellings, awkward wording, unclear references, and prompts without one best answer.
+- Category and tags: tags should include a correct region tag (CA, US, or Global), category tag, and pillar tag.
+- Difficulty: Easy should be broadly accessible, Medium should require some knowledge, and Hard should require specialized knowledge.
+- GlobalEh: this pillar must be globally relevant and not US-centric unless the US topic has clear worldwide significance.
+- FreshPrints: this pillar should reflect recent culture, news, or trends from roughly the last 3 months. Flag stale items older than the cutoff.
+- Sources: use sourceUrl/sourceName when present; flag missing, vague, or irrelevant sources if they weaken verification.
+
+Return valid JSON:
+{
+  "results": [
+    {
+      "id": "<question id>",
+      "verdict": "pass" | "flag" | "fail",
+      "confidence": 0-100,
+      "reason": "one sentence naming the main factual or editorial reason"
+    }
+  ]
+}
+
+Questions to review:
+${JSON.stringify(questions.map(toQualityControlPayload), null, 2)}`;
+}

--- a/server/lib/quality-control-prompt.ts
+++ b/server/lib/quality-control-prompt.ts
@@ -19,9 +19,12 @@ function formatDate(date: Date): string {
 }
 
 function threeMonthsBefore(date: Date): Date {
-  const result = new Date(date);
-  result.setMonth(result.getMonth() - 3);
-  return result;
+  const year = date.getUTCFullYear();
+  const targetMonth = date.getUTCMonth() - 3;
+  const targetMonthLastDay = new Date(Date.UTC(year, targetMonth + 1, 0)).getUTCDate();
+  const targetDay = Math.min(date.getUTCDate(), targetMonthLastDay);
+
+  return new Date(Date.UTC(year, targetMonth, targetDay));
 }
 
 function toQualityControlPayload(question: Question): QualityControlQuestionPayload {

--- a/server/lib/verifier.test.ts
+++ b/server/lib/verifier.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Question } from '@shared/models/questions';
+import { batchFactCheck } from './verifier';
+
+const mockCreate = vi.hoisted(() => vi.fn());
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockCreate } };
+  },
+}));
+
+function makeQuestion(overrides: Partial<Question> & { id: string; question: string }): Question {
+  return {
+    category: 'General Knowledge',
+    difficulty: 'Medium',
+    answer: 'Test answer',
+    explanation: 'Test explanation.',
+    pillar: 'GlobalEh',
+    tags: ['Global', 'General Knowledge', 'GlobalEh'],
+    acceptableAnswers: [],
+    sourceUrl: 'https://example.com/source',
+    sourceName: 'Example Source',
+    status: 'approved',
+    aiAnalysis: null,
+    createdAt: new Date('2026-04-25T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-25T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockCreate.mockReset();
+});
+
+describe('batchFactCheck', () => {
+  it('sends the expanded quality-control prompt payload to OpenAI', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              results: [{ id: 'q1', verdict: 'pass', confidence: 96, reason: 'Looks good.' }],
+            }),
+          },
+        },
+      ],
+    });
+
+    await batchFactCheck([
+      makeQuestion({
+        id: 'q1',
+        category: 'Geography',
+        difficulty: 'Hard',
+        question: 'What is the capital of Kazakhstan?',
+        answer: 'Astana',
+        explanation: 'Astana is the capital of Kazakhstan.',
+        pillar: 'GlobalEh',
+        tags: ['Global', 'Geography', 'GlobalEh'],
+        sourceUrl: 'https://www.britannica.com/place/Astana',
+        sourceName: 'Britannica',
+      }),
+    ]);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const request = mockCreate.mock.calls[0][0];
+    expect(request.model).toBe('gpt-4o');
+    expect(request.response_format).toEqual({ type: 'json_object' });
+    expect(request.messages[0].content).toContain('quality-control assistant');
+    expect(request.messages[1].content).toContain('Modern Trivia Quality Control reviewer');
+    expect(request.messages[1].content).toContain('"category": "Geography"');
+    expect(request.messages[1].content).toContain('"difficulty": "Hard"');
+    expect(request.messages[1].content).toContain('"pillar": "GlobalEh"');
+    expect(request.messages[1].content).toContain('"sourceName": "Britannica"');
+  });
+
+  it('preserves parsed verdicts from the existing fact-check report contract', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              results: [
+                {
+                  id: 'q1',
+                  verdict: 'fail',
+                  confidence: 88,
+                  reason: 'Answer leaks into the prompt.',
+                },
+              ],
+            }),
+          },
+        },
+      ],
+    });
+
+    const report = await batchFactCheck([
+      makeQuestion({
+        id: 'q1',
+        question: 'Which planet, Mars, is the Red Planet?',
+        answer: 'Mars',
+      }),
+    ]);
+
+    expect(report).toEqual({
+      totalChecked: 1,
+      results: [
+        {
+          questionId: 'q1',
+          verdict: 'fail',
+          confidence: 88,
+          reason: 'Answer leaks into the prompt.',
+        },
+      ],
+    });
+  });
+
+  it('keeps the missing-model-result fallback as a low-confidence flag', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ results: [] }) } }],
+    });
+
+    const report = await batchFactCheck([
+      makeQuestion({ id: 'q1', question: 'What is the capital of France?', answer: 'Paris' }),
+    ]);
+
+    expect(report.results).toEqual([
+      {
+        questionId: 'q1',
+        verdict: 'flag',
+        confidence: 0,
+        reason: 'No verdict returned by fact-checker.',
+      },
+    ]);
+  });
+});

--- a/server/lib/verifier.test.ts
+++ b/server/lib/verifier.test.ts
@@ -134,4 +134,33 @@ describe('batchFactCheck', () => {
       },
     ]);
   });
+
+  it('uses one captured review date across all batches', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-31T23:59:59.000Z'));
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ results: [] }) } }],
+    });
+
+    try {
+      const questions = Array.from({ length: 51 }, (_, index) =>
+        makeQuestion({
+          id: `q${index + 1}`,
+          question: `Question ${index + 1}?`,
+          answer: `Answer ${index + 1}`,
+        })
+      );
+
+      await batchFactCheck(questions);
+
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+      for (const call of mockCreate.mock.calls) {
+        const prompt = call[0].messages[1].content as string;
+        expect(prompt).toContain('Review date: 2026-05-31');
+        expect(prompt).toContain('FreshPrints freshness cutoff: 2026-02-28');
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/server/lib/verifier.ts
+++ b/server/lib/verifier.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 
 import type { Question } from '@shared/models/questions';
+import { buildQualityControlPrompt } from './quality-control-prompt';
 
 const openai = new OpenAI({
   apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY,
@@ -31,36 +32,7 @@ const BATCH_SIZE = 50;
 async function factCheckBatch(batch: Question[]): Promise<FactCheckVerdict[]> {
   if (batch.length === 0) return [];
 
-  const prompt = `You are a trivia fact-checker. Review each question and verify factual accuracy.
-
-For each question return one of:
-- "pass"  — question, answer, and explanation are all factually correct and unambiguous
-- "flag"  — likely correct but uncertain, minor wording concern, or hard to verify
-- "fail"  — factually wrong, misleading, or the answer is clearly incorrect
-
-Return valid JSON:
-{
-  "results": [
-    {
-      "id": "<question id>",
-      "verdict": "pass" | "flag" | "fail",
-      "confidence": 0-100,
-      "reason": "one sentence explaining the verdict"
-    }
-  ]
-}
-
-Questions to review:
-${JSON.stringify(
-  batch.map((q) => ({
-    id: q.id,
-    question: q.question,
-    answer: q.answer,
-    explanation: q.explanation,
-  })),
-  null,
-  2
-)}`;
+  const prompt = buildQualityControlPrompt(batch);
 
   const startedAt = Date.now();
   console.info('[verifier] Fact-checking batch', { count: batch.length });
@@ -72,7 +44,7 @@ ${JSON.stringify(
         {
           role: 'system',
           content:
-            'You are a trivia fact-checking assistant. Always respond with valid JSON that matches the requested schema exactly.',
+            'You are a trivia quality-control assistant. Always respond with valid JSON that matches the requested schema exactly.',
         },
         { role: 'user', content: prompt },
       ],
@@ -88,13 +60,16 @@ ${JSON.stringify(
     for (const raw of rawResults) {
       const id = typeof raw.id === 'string' ? raw.id : '';
       if (!id) continue;
-      const verdict = (['pass', 'flag', 'fail'] as const).includes(raw.verdict as 'pass' | 'flag' | 'fail')
+      const verdict = (['pass', 'flag', 'fail'] as const).includes(
+        raw.verdict as 'pass' | 'flag' | 'fail'
+      )
         ? (raw.verdict as 'pass' | 'flag' | 'fail')
         : 'flag';
       resultMap.set(id, {
         questionId: id,
         verdict,
-        confidence: typeof raw.confidence === 'number' ? Math.min(100, Math.max(0, raw.confidence)) : 50,
+        confidence:
+          typeof raw.confidence === 'number' ? Math.min(100, Math.max(0, raw.confidence)) : 50,
         reason: typeof raw.reason === 'string' ? raw.reason : 'No reason provided.',
       });
     }

--- a/server/lib/verifier.ts
+++ b/server/lib/verifier.ts
@@ -29,10 +29,10 @@ interface RawVerdict {
 
 const BATCH_SIZE = 50;
 
-async function factCheckBatch(batch: Question[]): Promise<FactCheckVerdict[]> {
+async function factCheckBatch(batch: Question[], reviewDate: Date): Promise<FactCheckVerdict[]> {
   if (batch.length === 0) return [];
 
-  const prompt = buildQualityControlPrompt(batch);
+  const prompt = buildQualityControlPrompt(batch, reviewDate);
 
   const startedAt = Date.now();
   console.info('[verifier] Fact-checking batch', { count: batch.length });
@@ -107,6 +107,7 @@ export async function batchFactCheck(questions: Question[]): Promise<FactCheckRe
   }
 
   console.info('[verifier] Running batch fact-check', { count: questions.length });
+  const reviewDate = new Date();
 
   // Split into chunks and process each with a single GPT-4o call
   const chunks: Question[][] = [];
@@ -117,7 +118,7 @@ export async function batchFactCheck(questions: Question[]): Promise<FactCheckRe
   // Process chunks sequentially to avoid rate limits
   const allResults: FactCheckVerdict[] = [];
   for (const chunk of chunks) {
-    const chunkResults = await factCheckBatch(chunk);
+    const chunkResults = await factCheckBatch(chunk, reviewDate);
     allResults.push(...chunkResults);
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated Modern Trivia quality-control prompt for sweep fact-checking
- include category, difficulty, pillar, tags, and source metadata in the AI review payload
- preserve the existing factCheck report contract

## Verification
- npm test
- npm run check
- npm run lint

## Notes
- Optional sweep smoke was skipped locally because DATABASE_URL and AI_INTEGRATIONS_OPENAI_API_KEY were missing.