### PR TITLE
feat(client): add production error boundary [STE-48]

### DIFF
--- a/client/src/components/ErrorBoundary.test.tsx
+++ b/client/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function ThrowingChild() {
+  throw new Error('render failed');
+}
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <p>Game ready</p>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Game ready')).toBeDefined();
+  });
+
+  it('renders a reload fallback when a child throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Something went wrong' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeDefined();
+  });
+});

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error?: Error;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {};
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <main className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
+          <section className="w-full max-w-md space-y-4 text-center">
+            <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Modern Trivia
+            </p>
+            <h1 className="text-2xl font-bold">Something went wrong</h1>
+            <p className="text-sm text-muted-foreground">Reload the app to get back to the game.</p>
+            <Button type="button" onClick={() => window.location.reload()}>
+              Reload
+            </Button>
+          </section>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './index.css';
 
-createRoot(document.getElementById('root')!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary

Adds an app-level React error boundary so production render crashes show a recovery UI instead of a blank screen.

## Changes

- Added `client/src/components/ErrorBoundary.tsx` with a reload-capable fallback.
- Wrapped the app root in `client/src/main.tsx`.
- Added focused component coverage for normal rendering and fallback rendering.

## Validation

- `npm test -- client/src/components/ErrorBoundary.test.tsx`
- `npm run check`
- `npm test`
- `npm run lint` (existing warnings only)
- Prettier check for touched files

Linear: STE-48