### PR TITLE
fix(api): validate mutating request payloads [STE-47]

### DIFF
--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -1,5 +1,6 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import type { Request } from 'express';
+import type { AuthenticatedRequest } from '../types';
 
 export const generalLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -19,7 +20,7 @@ export const aiLimiter = rateLimit({
     message: 'AI analysis rate limit exceeded. Please wait before trying again.',
   },
   keyGenerator: (req: Request) => {
-    const userId = (req as any).user?.claims?.sub;
+    const userId = (req as AuthenticatedRequest).user?.claims?.sub;
     if (userId) return userId;
     return ipKeyGenerator(req.ip ?? 'unknown');
   },

--- a/server/replit_integrations/audio/routes.ts
+++ b/server/replit_integrations/audio/routes.ts
@@ -1,7 +1,25 @@
 import type { Express, Request, Response } from 'express';
+import { z } from 'zod';
 import { aiLimiter } from '../../middleware/rateLimiter';
 import { chatStorage } from '../chat/storage';
 import { openai, speechToText, voiceChatWithTextModel, convertWebmToWav } from './client';
+
+const voiceSchema = z.enum(['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer']);
+const audioRequestSchema = z
+  .object({
+    audio: z.string().min(1).max(10_000_000),
+    voice: voiceSchema.optional().default('alloy'),
+    inputFormat: z.enum(['wav', 'mp3']).optional().default('wav'),
+  })
+  .strict();
+
+const voiceStreamRequestSchema = audioRequestSchema.extend({
+  locale: z.string().trim().min(2).max(12).optional().default('en'),
+});
+
+function sendValidationError(res: Response, message: string, error: z.ZodError) {
+  return res.status(422).json({ error: message, details: error.errors });
+}
 
 // Note: Set express.json({ limit: "50mb" }) for audio payloads.
 // Note: Use convertWebmToWav() to convert browser WebM to WAV before API calls.
@@ -65,11 +83,7 @@ export function registerAudioRoutes(app: Express): void {
   app.post('/api/conversations/:id/messages', aiLimiter, async (req: Request, res: Response) => {
     try {
       const conversationId = parseInt(req.params.id);
-      const { audio, voice = 'alloy', inputFormat = 'wav' } = req.body;
-
-      if (!audio) {
-        return res.status(400).json({ error: 'Audio data (base64) is required' });
-      }
+      const { audio, voice, inputFormat } = audioRequestSchema.parse(req.body);
 
       // 1. Transcribe user audio
       const audioBuffer = Buffer.from(audio, 'base64');
@@ -126,6 +140,9 @@ export function registerAudioRoutes(app: Express): void {
       res.end();
     } catch (error) {
       console.error('Error processing voice message:', error);
+      if (error instanceof z.ZodError && !res.headersSent) {
+        return sendValidationError(res, 'Invalid voice message request', error);
+      }
       if (res.headersSent) {
         res.write(
           `data: ${JSON.stringify({ type: 'error', error: 'Failed to process voice message' })}\n\n`
@@ -143,11 +160,7 @@ export function registerAudioRoutes(app: Express): void {
   app.post(voiceStreamRoute, aiLimiter, async (req: Request, res: Response) => {
     try {
       const conversationId = parseInt(req.params.id);
-      const { audio, voice = 'alloy', inputFormat = 'wav', locale = 'en' } = req.body;
-
-      if (!audio) {
-        return res.status(400).json({ error: 'Audio data (base64) is required' });
-      }
+      const { audio, voice, inputFormat, locale } = voiceStreamRequestSchema.parse(req.body);
 
       // Get conversation history
       const existingMessages = await chatStorage.getMessagesByConversation(conversationId);
@@ -188,6 +201,9 @@ export function registerAudioRoutes(app: Express): void {
       res.end();
     } catch (error) {
       console.error('Error in voice stream:', error);
+      if (error instanceof z.ZodError && !res.headersSent) {
+        return sendValidationError(res, 'Invalid voice stream request', error);
+      }
       if (res.headersSent) {
         res.write(`data: ${JSON.stringify({ type: 'error', error: 'Voice stream failed' })}\n\n`);
         res.end();

--- a/server/replit_integrations/chat/routes.ts
+++ b/server/replit_integrations/chat/routes.ts
@@ -1,5 +1,6 @@
 import type { Express, Request, Response } from 'express';
 import OpenAI from 'openai';
+import { z } from 'zod';
 import { aiLimiter } from '../../middleware/rateLimiter';
 import { chatStorage } from './storage';
 
@@ -7,6 +8,22 @@ const openai = new OpenAI({
   apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY,
   baseURL: process.env.AI_INTEGRATIONS_OPENAI_BASE_URL,
 });
+
+const createConversationSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200).optional(),
+  })
+  .strict();
+
+const sendMessageSchema = z
+  .object({
+    content: z.string().trim().min(1).max(10000),
+  })
+  .strict();
+
+function sendValidationError(res: Response, message: string, error: z.ZodError) {
+  return res.status(422).json({ error: message, details: error.errors });
+}
 
 export function registerChatRoutes(app: Express): void {
   // Get all conversations
@@ -39,11 +56,14 @@ export function registerChatRoutes(app: Express): void {
   // Create new conversation
   app.post('/api/conversations', async (req: Request, res: Response) => {
     try {
-      const { title } = req.body;
+      const { title } = createConversationSchema.parse(req.body);
       const conversation = await chatStorage.createConversation(title || 'New Chat');
       res.status(201).json(conversation);
     } catch (error) {
       console.error('Error creating conversation:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid conversation request', error);
+      }
       res.status(500).json({ error: 'Failed to create conversation' });
     }
   });
@@ -64,7 +84,7 @@ export function registerChatRoutes(app: Express): void {
   app.post('/api/conversations/:id/messages', aiLimiter, async (req: Request, res: Response) => {
     try {
       const conversationId = parseInt(req.params.id);
-      const { content } = req.body;
+      const { content } = sendMessageSchema.parse(req.body);
 
       // Save user message
       await chatStorage.createMessage(conversationId, 'user', content);
@@ -106,6 +126,9 @@ export function registerChatRoutes(app: Express): void {
       res.end();
     } catch (error) {
       console.error('Error sending message:', error);
+      if (error instanceof z.ZodError && !res.headersSent) {
+        return sendValidationError(res, 'Invalid message request', error);
+      }
       // Check if headers already sent (SSE streaming started)
       if (res.headersSent) {
         res.write(`data: ${JSON.stringify({ error: 'Failed to send message' })}\n\n`);

--- a/server/replit_integrations/image/routes.ts
+++ b/server/replit_integrations/image/routes.ts
@@ -1,15 +1,19 @@
 import type { Express, Request, Response } from 'express';
+import { z } from 'zod';
 import { aiLimiter } from '../../middleware/rateLimiter';
 import { openai } from './client';
+
+const generateImageSchema = z
+  .object({
+    prompt: z.string().trim().min(1).max(1000),
+    size: z.enum(['1024x1024', '512x512', '256x256']).optional().default('1024x1024'),
+  })
+  .strict();
 
 export function registerImageRoutes(app: Express): void {
   app.post('/api/generate-image', aiLimiter, async (req: Request, res: Response) => {
     try {
-      const { prompt, size = '1024x1024' } = req.body;
-
-      if (!prompt) {
-        return res.status(400).json({ error: 'Prompt is required' });
-      }
+      const { prompt, size } = generateImageSchema.parse(req.body);
 
       const response = await openai.images.generate({
         model: 'gpt-image-1',
@@ -29,6 +33,9 @@ export function registerImageRoutes(app: Express): void {
       });
     } catch (error) {
       console.error('Error generating image:', error);
+      if (error instanceof z.ZodError) {
+        return res.status(422).json({ error: 'Invalid image request', details: error.errors });
+      }
       res.status(500).json({ error: 'Failed to generate image' });
     }
   });

--- a/server/routes.admin-validation.test.ts
+++ b/server/routes.admin-validation.test.ts
@@ -1,0 +1,119 @@
+import type { Express, NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQueryMock } from './test/dbMock';
+import { buildTestApp } from './test/testApp';
+
+const dbMocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  insert: vi.fn(),
+  select: vi.fn(),
+  selectDistinct: vi.fn(),
+  update: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn((req: Request, res: Response, next: NextFunction) => {
+    const user = (req as Request & { user?: TestUser }).user;
+
+    if (!user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    next();
+  }),
+  registerAuthRoutes: vi.fn(),
+  setupAuth: vi.fn(async (app: Express) => {
+    app.use((req: Request, _res: Response, next: NextFunction) => {
+      const userId = req.header('x-test-user-id');
+
+      if (userId) {
+        (req as Request & { user?: TestUser }).user = {
+          claims: { sub: userId },
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+        };
+      }
+
+      next();
+    });
+  }),
+}));
+
+type TestUser = {
+  claims: { sub: string };
+  expires_at: number;
+};
+
+vi.mock('./db', () => ({
+  db: {
+    delete: dbMocks.delete,
+    insert: dbMocks.insert,
+    select: dbMocks.select,
+    selectDistinct: dbMocks.selectDistinct,
+    update: dbMocks.update,
+  },
+}));
+
+vi.mock('./replit_integrations/auth', () => authMocks);
+vi.mock('./lib/subjectivity-enricher', () => ({ enrichSubjectiveFindings: vi.fn() }));
+vi.mock('./lib/ai', () => ({ analyzeDispute: vi.fn() }));
+vi.mock('./lib/guardian', () => ({ generateQuestions: vi.fn() }));
+vi.mock('./lib/field-fix', () => ({ getAiFieldFix: vi.fn() }));
+vi.mock('./lib/question-quality-audit', () => ({ auditQuestionQuality: vi.fn() }));
+vi.mock('./lib/duplicate-detector', () => ({ detectDuplicates: vi.fn() }));
+vi.mock('./lib/verifier', () => ({ batchFactCheck: vi.fn() }));
+
+const adminRole = { userId: 'admin-user' };
+
+describe('admin route validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('rejects malformed admin grant requests before writing', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/admin/grant')
+      .set('x-test-user-id', 'admin-user')
+      .send({ userId: '' })
+      .expect(422);
+
+    expect(response.body).toMatchObject({ message: 'Invalid admin grant request' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects unapproved config keys before writing', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/admin/config')
+      .set('x-test-user-id', 'admin-user')
+      .send({ key: 'unexpected_key', value: 'secret' })
+      .expect(422);
+
+    expect(response.body).toMatchObject({ message: 'Invalid configuration request' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('saves approved config keys for admins', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const insertQuery = createQueryMock([{ key: 'openai_api_key', value: 'secret' }]);
+    dbMocks.insert.mockReturnValue(insertQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/admin/config')
+      .set('x-test-user-id', 'admin-user')
+      .send({ key: 'openai_api_key', value: 'secret' })
+      .expect(200);
+
+    expect(insertQuery.values).toHaveBeenCalledWith({ key: 'openai_api_key', value: 'secret' });
+    expect(insertQuery.onConflictDoUpdate).toHaveBeenCalledOnce();
+    expect(response.body).toEqual({ message: 'Configuration saved', key: 'openai_api_key' });
+  });
+});

--- a/server/routes.disputes.test.ts
+++ b/server/routes.disputes.test.ts
@@ -238,9 +238,9 @@ describe('dispute routes', () => {
       .patch('/api/disputes/dispute-1')
       .set('x-test-user-id', 'admin-user')
       .send({ status: 'closed' })
-      .expect(400);
+      .expect(422);
 
-    expect(response.body).toEqual({ message: 'Invalid status' });
+    expect(response.body).toMatchObject({ message: 'Invalid dispute update' });
     expect(dbMocks.update).not.toHaveBeenCalled();
   });
 

--- a/server/routes.questions.test.ts
+++ b/server/routes.questions.test.ts
@@ -214,6 +214,20 @@ describe('question routes', () => {
     expect(response.body).toEqual({ message: 'Question not found' });
   });
 
+  it('rejects unsafe question update fields before writing', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/questions/q-1')
+      .set('x-test-user-id', 'admin-user')
+      .send({ id: 'different-id', answer: 'Ottawa' })
+      .expect(422);
+
+    expect(response.body).toMatchObject({ message: 'Invalid question update' });
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
   it('requires authentication to mark questions as seen', async () => {
     const app = await buildTestApp();
 
@@ -233,9 +247,9 @@ describe('question routes', () => {
       .post('/api/questions/seen')
       .set('x-test-user-id', 'player-1')
       .send({ questionIds: [] })
-      .expect(400);
+      .expect(422);
 
-    expect(response.body).toEqual({ message: 'questionIds array is required' });
+    expect(response.body).toMatchObject({ message: 'Invalid seen-question request' });
     expect(dbMocks.insert).not.toHaveBeenCalled();
   });
 

--- a/server/routes.questions.test.ts
+++ b/server/routes.questions.test.ts
@@ -253,6 +253,38 @@ describe('question routes', () => {
     expect(dbMocks.insert).not.toHaveBeenCalled();
   });
 
+  it('accepts the largest normal game seen-question payload', async () => {
+    const insertQuery = createQueryMock(undefined);
+    dbMocks.insert.mockReturnValue(insertQuery);
+    const app = await buildTestApp();
+    const questionIds = Array.from({ length: 480 }, (_, index) => `q-${index + 1}`);
+
+    const response = await request(app)
+      .post('/api/questions/seen')
+      .set('x-test-user-id', 'player-1')
+      .send({ questionIds })
+      .expect(200);
+
+    expect(insertQuery.values).toHaveBeenCalledWith(
+      questionIds.map((questionId) => ({ userId: 'player-1', questionId }))
+    );
+    expect(response.body).toEqual({ message: 'Questions marked as seen', count: 480 });
+  });
+
+  it('rejects excessive seen-question payloads', async () => {
+    const app = await buildTestApp();
+    const questionIds = Array.from({ length: 501 }, (_, index) => `q-${index + 1}`);
+
+    const response = await request(app)
+      .post('/api/questions/seen')
+      .set('x-test-user-id', 'player-1')
+      .send({ questionIds })
+      .expect(422);
+
+    expect(response.body).toMatchObject({ message: 'Invalid seen-question request' });
+    expect(dbMocks.insert).not.toHaveBeenCalled();
+  });
+
   it('upserts seen-question rows for authenticated users', async () => {
     const insertQuery = createQueryMock(undefined);
     dbMocks.insert.mockReturnValue(insertQuery);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -78,9 +78,11 @@ const appConfigUpdateSchema = z
   })
   .strict();
 
+const MAX_SEEN_QUESTION_IDS_PER_REQUEST = 500;
+
 const seenQuestionsRequestSchema = z
   .object({
-    questionIds: z.array(z.string().trim().min(1)).min(1).max(200),
+    questionIds: z.array(z.string().trim().min(1)).min(1).max(MAX_SEEN_QUESTION_IDS_PER_REQUEST),
   })
   .strict();
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,17 +26,10 @@ import { detectDuplicates } from './lib/duplicate-detector';
 import { batchFactCheck } from './lib/verifier';
 import { z } from 'zod';
 import { aiLimiter } from './middleware/rateLimiter';
+import type { AuthenticatedRequest } from './types';
 
 const VALID_PILLARS = ['GlobalEh', 'FreshPrints', 'TimeCapsule', 'GreatOutdoors'] as const;
 type SinglePillar = (typeof VALID_PILLARS)[number];
-type RequestWithClaims = Request & {
-  user?: {
-    claims?: {
-      sub?: string;
-    };
-  };
-};
-
 const PILLAR_MIX: { pillar: SinglePillar; pct: number }[] = [
   { pillar: 'TimeCapsule', pct: 0.3 },
   { pillar: 'GlobalEh', pct: 0.3 },
@@ -63,8 +56,81 @@ const stagingGenerateSchema = z.object({
   pillar: z.union([z.enum(VALID_PILLARS), z.literal('Mixed')]),
 });
 
+const disputeUpdateSchema = z
+  .object({
+    status: z.enum(['pending', 'resolved', 'rejected']).optional(),
+    resolutionNote: z.string().max(2000).nullable().optional(),
+    aiAnalysis: z.unknown().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, 'At least one update field is required');
+
+const adminGrantSchema = z
+  .object({
+    userId: z.string().trim().min(1).max(255),
+  })
+  .strict();
+
+const appConfigUpdateSchema = z
+  .object({
+    key: z.enum(['openai_api_key', 'llm_provider']),
+    value: z.string().trim().min(1).max(10000),
+  })
+  .strict();
+
+const seenQuestionsRequestSchema = z
+  .object({
+    questionIds: z.array(z.string().trim().min(1)).min(1).max(200),
+  })
+  .strict();
+
+const questionEditableFieldsSchema = insertQuestionSchema
+  .omit({ id: true, aiAnalysis: true })
+  .partial()
+  .strict();
+
+const questionPatchSchema = questionEditableFieldsSchema.refine(
+  (value) => Object.keys(value).length > 0,
+  'At least one update field is required'
+);
+
+const questionFieldPatchSchema = z
+  .object({
+    field: questionEditableFieldsSchema.keyof(),
+    value: z.unknown(),
+    aiSuggested: z.boolean().optional().default(false),
+  })
+  .strict();
+
+const aiFixRequestSchema = z
+  .object({
+    field: z.enum([
+      'sourceUrl',
+      'sourceName',
+      'explanation',
+      'tags',
+      'answer',
+      'question',
+      'acceptableAnswers',
+    ]),
+  })
+  .strict();
+
+function sendValidationError(res: Response, message: string, error: z.ZodError) {
+  return res.status(422).json({ message, errors: error.errors });
+}
+
+function parseQuestionFieldPatch(body: unknown) {
+  const parsed = questionFieldPatchSchema.parse(body);
+  const fieldSchema = questionEditableFieldsSchema.shape[parsed.field];
+  return {
+    ...parsed,
+    value: fieldSchema.parse(parsed.value),
+  };
+}
+
 function getUserId(req: Request): string | undefined {
-  return (req as RequestWithClaims).user?.claims?.sub;
+  return (req as AuthenticatedRequest).user?.claims?.sub;
 }
 
 async function isAdmin(req: Request, res: Response, next: NextFunction) {
@@ -147,19 +213,12 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   app.patch('/api/disputes/:id', isAuthenticated, isAdmin, async (req, res) => {
     try {
       const { id } = req.params;
-      const { status, resolutionNote, aiAnalysis } = req.body;
-
-      // Validate status enum
-      if (status && !['pending', 'resolved', 'rejected'].includes(status)) {
-        return res.status(400).json({ message: 'Invalid status' });
-      }
+      const parsed = disputeUpdateSchema.parse(req.body);
 
       const [updated] = await db
         .update(disputes)
         .set({
-          status,
-          resolutionNote,
-          aiAnalysis,
+          ...parsed,
         })
         .where(eq(disputes.id, id))
         .returning();
@@ -171,6 +230,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       res.json(updated);
     } catch (error) {
       console.error('Error updating dispute:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid dispute update', error);
+      }
       res.status(500).json({ message: 'Failed to update dispute' });
     }
   });
@@ -188,12 +250,8 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   // Admin management routes
   app.post('/api/admin/grant', isAuthenticated, isAdmin, async (req: Request, res: Response) => {
     try {
-      const { userId } = req.body;
+      const { userId } = adminGrantSchema.parse(req.body);
       const grantedBy = getUserId(req);
-
-      if (!userId) {
-        return res.status(400).json({ message: 'userId is required' });
-      }
 
       await db.insert(adminRoles).values({
         userId,
@@ -203,6 +261,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       res.json({ message: 'Admin access granted' });
     } catch (error) {
       console.error('Error granting admin:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid admin grant request', error);
+      }
       res.status(500).json({ message: 'Failed to grant admin access' });
     }
   });
@@ -227,10 +288,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
 
   app.post('/api/admin/config', isAuthenticated, isAdmin, async (req, res) => {
     try {
-      const { key, value } = req.body;
-      if (!key || !value) {
-        return res.status(400).json({ message: 'Key and value are required' });
-      }
+      const { key, value } = appConfigUpdateSchema.parse(req.body);
 
       // Upsert configuration
       const [updated] = await db
@@ -245,6 +303,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       res.json({ message: 'Configuration saved', key: updated.key });
     } catch (error) {
       console.error('Error saving config:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid configuration request', error);
+      }
       res.status(500).json({ message: 'Failed to save configuration' });
     }
   });
@@ -401,10 +462,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       const userId = getUserId(req);
       if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
-      const { questionIds } = req.body;
-      if (!Array.isArray(questionIds) || questionIds.length === 0) {
-        return res.status(400).json({ message: 'questionIds array is required' });
-      }
+      const { questionIds } = seenQuestionsRequestSchema.parse(req.body);
 
       // Upsert with replay guard: only bump seen_count if the last
       // seen_at is more than 24 hours ago. This prevents duplicate
@@ -432,6 +490,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       res.json({ message: 'Questions marked as seen', count: questionIds.length });
     } catch (error) {
       console.error('Error marking questions as seen:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid seen-question request', error);
+      }
       res.status(500).json({ message: 'Failed to mark questions as seen' });
     }
   });
@@ -459,10 +520,11 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   app.patch('/api/questions/:id', isAuthenticated, isAdmin, async (req, res) => {
     try {
       const { id } = req.params;
+      const parsed = questionPatchSchema.parse(req.body);
 
       const [updated] = await db
         .update(questions)
-        .set({ ...req.body, updatedAt: new Date() })
+        .set({ ...parsed, updatedAt: new Date() })
         .where(eq(questions.id, id))
         .returning();
 
@@ -473,6 +535,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       res.json(updated);
     } catch (error) {
       console.error('Error updating question:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid question update', error);
+      }
       res.status(500).json({ message: 'Failed to update question' });
     }
   });
@@ -545,17 +610,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       const userId = getUserId(req);
       if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
-      const {
-        field,
-        value,
-        aiSuggested = false,
-      } = req.body as {
-        field: string;
-        value: unknown;
-        aiSuggested?: boolean;
-      };
-
-      if (!field) return res.status(400).json({ message: 'field is required' });
+      const { field, value, aiSuggested } = parseQuestionFieldPatch(req.body);
 
       // Fetch the current row to capture the old value
       const [current] = await db.select().from(questions).where(eq(questions.id, id)).limit(1);
@@ -587,6 +642,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       res.json(updated);
     } catch (error) {
       console.error('Error patching question field:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid question field update', error);
+      }
       res.status(500).json({ message: 'Failed to update field' });
     }
   });
@@ -600,20 +658,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     async (req, res) => {
       try {
         const { id } = req.params;
-        const { field } = req.body as { field: string };
-
-        const FIXABLE = [
-          'sourceUrl',
-          'sourceName',
-          'explanation',
-          'tags',
-          'answer',
-          'question',
-          'acceptableAnswers',
-        ];
-        if (!field || !FIXABLE.includes(field)) {
-          return res.status(400).json({ message: `field must be one of: ${FIXABLE.join(', ')}` });
-        }
+        const { field } = aiFixRequestSchema.parse(req.body);
 
         const [q] = await db.select().from(questions).where(eq(questions.id, id)).limit(1);
         if (!q) return res.status(404).json({ message: 'Question not found' });
@@ -637,6 +682,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
         res.json({ suggestion });
       } catch (error) {
         console.error('Error getting AI field fix:', error);
+        if (error instanceof z.ZodError) {
+          return sendValidationError(res, 'Invalid AI fix request', error);
+        }
         res.status(500).json({ message: 'Failed to get AI suggestion' });
       }
     }
@@ -711,7 +759,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
     try {
       const parsed = stagingGenerateSchema.safeParse(req.body);
       if (!parsed.success) {
-        return res.status(400).json({
+        return res.status(422).json({
           message: 'Invalid generation parameters',
           errors: parsed.error.errors,
         });
@@ -1045,6 +1093,9 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
       });
     } catch (error) {
       console.error('Error running quality sweep:', error);
+      if (error instanceof z.ZodError) {
+        return sendValidationError(res, 'Invalid quality sweep request', error);
+      }
       res.status(500).json({ message: 'Quality sweep failed' });
     }
   });


### PR DESCRIPTION
## Summary

Hardens high-risk mutating API routes with Zod validation and tightens authenticated request typing around `req.user`/`claims`. This folds the useful part of STE-35 into STE-47.

## Changes

- Added Zod validation for mutating payloads in main server routes and Replit chat/image/audio integration routes.
- Prevented `PATCH /api/questions/:id` from spreading arbitrary request body fields into DB updates.
- Reused `AuthenticatedRequest` typing in route/rate-limit code.
- Added representative route tests for invalid admin config/grant, dispute update, seen questions, and unsafe question patch payloads.

## Validation

- `npm test -- server/routes.disputes.test.ts server/routes.questions.test.ts server/routes.admin-validation.test.ts`
- `npm run check`
- `npm test`
- `npm run lint` (existing warnings only)
- Prettier check for touched files

Linear: STE-47