### PR TITLE
Validate `status` on question PATCH and add tests for status handling

### DIFF
--- a/server/routes.questions.test.ts
+++ b/server/routes.questions.test.ts
@@ -200,6 +200,24 @@ describe('question routes', () => {
     expect(response.body).toMatchObject({ id: 'q-1', answer: 'Ottawa' });
   });
 
+  it('updates question status for admins when status is valid', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const updateQuery = createQueryMock([{ ...questionRow, status: 'rejected' }]);
+    dbMocks.update.mockReturnValue(updateQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/questions/q-1')
+      .set('x-test-user-id', 'admin-user')
+      .send({ status: 'rejected' })
+      .expect(200);
+
+    expect(updateQuery.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'rejected', updatedAt: expect.any(Date) })
+    );
+    expect(response.body).toMatchObject({ id: 'q-1', status: 'rejected' });
+  });
+
   it('returns 404 when admins update a missing question', async () => {
     dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
     dbMocks.update.mockReturnValue(createQueryMock([]));
@@ -222,6 +240,20 @@ describe('question routes', () => {
       .patch('/api/questions/q-1')
       .set('x-test-user-id', 'admin-user')
       .send({ id: 'different-id', answer: 'Ottawa' })
+      .expect(422);
+
+    expect(response.body).toMatchObject({ message: 'Invalid question update' });
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid question status values before writing', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/questions/q-1')
+      .set('x-test-user-id', 'admin-user')
+      .send({ status: 'whatever' })
       .expect(422);
 
     expect(response.body).toMatchObject({ message: 'Invalid question update' });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -88,6 +88,11 @@ const seenQuestionsRequestSchema = z
 
 const questionEditableFieldsSchema = insertQuestionSchema
   .omit({ id: true, aiAnalysis: true })
+  .extend({
+    // Keep status validation explicit on PATCH payloads so invalid values are rejected
+    // before hitting the database update.
+    status: z.enum(['draft', 'pending', 'approved', 'rejected']).optional(),
+  })
   .partial()
   .strict();
 


### PR DESCRIPTION
### Motivation
- Prevent invalid `status` values from reaching the database by validating them at the PATCH payload level.
- Ensure admins can update a question's `status` to allowed states and that invalid values are rejected.
- Add test coverage for both successful and failing `status` updates.

### Description
- Extend `questionEditableFieldsSchema` to include an optional `status` field with `z.enum(['draft','pending','approved','rejected'])` so invalid statuses are rejected before DB operations.
- Add test `updates question status for admins when status is valid` to `server/routes.questions.test.ts` to verify successful admin status updates.
- Add test `rejects invalid question status values before writing` to `server/routes.questions.test.ts` to verify that invalid `status` values produce a `422` and prevent DB updates.

### Testing
- Ran unit tests with `yarn test`, and the full test suite passed.
- Executed the question routes test file `server/routes.questions.test.ts`, and the two new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeab1c41c8832092b88fa7ddc105e5)