### PR TITLE
chore(data): migrate categories to 6 canonical values and enforce via schema [STE-142, STE-141]

### DIFF
--- a/client/src/lib/questions.json
+++ b/client/src/lib/questions.json
@@ -1,70 +1,102 @@
 [
   {
     "id": "q1",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital city of Canada?",
     "answer": "Ottawa",
     "explanation": "Ottawa was chosen as the capital on December 31, 1857 by Queen Victoria.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ottawa",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q2",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which US state is known as the 'Sunshine State'?",
     "answer": "Florida",
-    "acceptableAnswers": ["FL"],
+    "acceptableAnswers": [
+      "FL"
+    ],
     "explanation": "Florida officially adopted 'The Sunshine State' nickname in 1970 when the state legislature included it on license plates.",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Florida",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q3",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What represents the 'K' in the periodic table?",
     "answer": "Potassium",
-    "acceptableAnswers": ["K"],
+    "acceptableAnswers": [
+      "K"
+    ],
     "explanation": "The symbol K comes from the Latin word 'Kalium'.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Potassium",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q4",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Who was the first Prime Minister of Canada?",
     "answer": "Sir John A. Macdonald",
-    "acceptableAnswers": ["John A Macdonald", "Macdonald", "John Macdonald"],
+    "acceptableAnswers": [
+      "John A Macdonald",
+      "Macdonald",
+      "John Macdonald"
+    ],
     "explanation": "He served as the first Prime Minister of Canada from 1867 to 1873.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/John_A._Macdonald",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q5",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "In which year was the Declaration of Independence signed?",
     "answer": "1776",
     "explanation": "The Declaration of Independence was ADOPTED on July 4, 1776, declaring the 13 colonies independent from Britain. The actual signing began on August 2, 1776, when delegates started signing the engrossed parchment copy.",
-    "tags": ["US", "History", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://www.archives.gov/milestone-documents/declaration-of-independence",
     "sourceName": "National Archives"
   },
   {
     "id": "q6",
-    "category": "Pop Culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian rapper released the album 'Views'?",
     "answer": "Drake",
     "explanation": "Drake released Views in April 2016. 'Hotline Bling' was released earlier as a single on July 31, 2015, and is credited as a bonus track on the physical album. Major album tracks include 'One Dance' and 'Controlla'.",
-    "tags": ["CA", "Pop Culture", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Views_(album)",
     "sourceName": "Wikipedia"
   },
@@ -75,7 +107,11 @@
     "question": "Which city hosted the 2010 Winter Olympics?",
     "answer": "Vancouver",
     "explanation": "Vancouver, Canada hosted the XXI Olympic Winter Games.",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/2010_Winter_Olympics",
     "sourceName": "Wikipedia"
   },
@@ -86,162 +122,225 @@
     "question": "What is the national summer sport of Canada?",
     "answer": "Lacrosse",
     "explanation": "While Hockey is the national winter sport, Lacrosse is the official national summer sport of Canada.",
-    "tags": ["CA", "Sports", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/National_Sports_of_Canada_Act",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q9",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the longest river in the United States?",
     "answer": "Missouri River",
     "explanation": "The Missouri River is about 2,341 miles long, slightly longer than the Mississippi River at 2,340 miles.",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Missouri_River",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q10",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which TV show is set in the fictional city of Springfield?",
     "answer": "The Simpsons",
     "explanation": "The Simpsons is the longest-running American animated series and longest-running American sitcom.",
-    "tags": ["US", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Simpsons",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q11",
-    "category": "General Knowledge",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the currency of Japan?",
     "answer": "Yen",
     "explanation": "The Japanese Yen is the third most traded currency in the foreign exchange market.",
-    "tags": ["Global", "General Knowledge", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Japanese_yen",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q12",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the hardest natural substance on Earth?",
     "answer": "Diamond",
     "explanation": "Diamonds are formed deep within the Earth under extreme heat and pressure. They rank 10 on the Mohs hardness scale.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Diamond",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q13",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which province joined Canada last?",
     "answer": "Newfoundland and Labrador",
     "explanation": "They joined Confederation on March 31, 1949, becoming Canada's tenth province.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Newfoundland_and_Labrador",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q14",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which U.S. president who served four terms is not depicted on Mount Rushmore?",
     "answer": "Franklin D. Roosevelt",
-    "acceptableAnswers": ["FDR", "Franklin Roosevelt"],
+    "acceptableAnswers": [
+      "FDR",
+      "Franklin Roosevelt"
+    ],
     "explanation": "The four presidents on Mount Rushmore are George Washington, Thomas Jefferson, Theodore Roosevelt, and Abraham Lincoln. Franklin D. Roosevelt is not depicted.",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mount_Rushmore",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q15",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Poutine originated in which Canadian province?",
     "answer": "Quebec",
     "explanation": "It emerged in the late 1950s in the Centre-du-Qu\u00e9bec area.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Poutine",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q17",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "How many time zones does Canada have?",
     "answer": "Six",
     "explanation": "Pacific, Mountain, Central, Eastern, Atlantic, and Newfoundland.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Time_in_Canada",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q18",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Who was the 16th President of the United States?",
     "answer": "Abraham Lincoln",
     "explanation": "He served from 1861 to 1865 during the American Civil War.",
-    "tags": ["US", "History", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Abraham_Lincoln",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q19",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the national animal of the United States?",
     "answer": "Bald Eagle",
     "explanation": "The Bald Eagle was adopted as the national bird in 1782.",
-    "tags": ["US", "Nature", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bald_eagle",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q20",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the national animal of Canada?",
     "answer": "Beaver",
     "explanation": "The North American Beaver became an official symbol of Canada in 1975.",
-    "tags": ["CA", "Nature", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/North_American_beaver",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q21",
-    "category": "Space",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "Which planet is known as the Red Planet?",
     "answer": "Mars",
     "explanation": "Iron oxide prevalent on its surface gives it a reddish appearance.",
-    "tags": ["Global", "Space", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mars",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q22",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'The Handmaid's Tale'?",
     "answer": "Margaret Atwood",
     "explanation": "Margaret Atwood is a celebrated Canadian author. The novel was published in 1985.",
-    "tags": ["CA", "Literature", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Handmaid%27s_Tale",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q23",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which city is known as the 'Big Apple'?",
     "answer": "New York City",
     "explanation": "The nickname was popularized in the 1920s by sports writer John J. Fitz Gerald.",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Big_Apple",
     "sourceName": "Wikipedia"
   },
@@ -252,73 +351,102 @@
     "question": "In which sport would you perform a 'slam dunk'?",
     "answer": "Basketball",
     "explanation": "Basketball was invented by Canadian James Naismith in 1891.",
-    "tags": ["US", "Sports", "TimeCapsule"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Slam_dunk",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q25",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Ryan Reynolds was born in which Canadian city?",
     "answer": "Vancouver",
     "explanation": "He was born in Vancouver, British Columbia on October 23, 1976.",
-    "tags": ["CA", "Entertainment", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ryan_Reynolds",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q26",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the smallest US state by area?",
     "answer": "Rhode Island",
     "explanation": "Rhode Island is about 1,545 square miles. Despite its name, it is not an island.",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rhode_Island",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q27",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "H2O is the chemical formula for what?",
     "answer": "Water",
     "explanation": "Two hydrogen atoms and one oxygen atom.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Water",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q28",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which American singer is known as the 'King of Pop'?",
     "answer": "Michael Jackson",
     "explanation": "He is regarded as one of the most significant cultural figures of the 20th century.",
-    "tags": ["US", "Music", "TimeCapsule"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Michael_Jackson",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q29",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the largest province in Canada by area?",
     "answer": "Quebec",
     "explanation": "Quebec covers about 1.5 million km\u00b2. Nunavut is larger, but it is a territory, not a province.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Quebec",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q30",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did the War of 1812 end?",
     "answer": "1815",
     "explanation": "The Treaty of Ghent was signed December 24, 1814, but fighting continued into 1815, including the Battle of New Orleans.",
-    "tags": ["US", "History", "CA", "TimeCapsule"],
+    "tags": [
+      "US",
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/War_of_1812",
     "sourceName": "Wikipedia"
   },
@@ -329,73 +457,101 @@
     "question": "Which company was founded by Bill Gates and Paul Allen?",
     "answer": "Microsoft",
     "explanation": "Founded on April 4, 1975 in Albuquerque, New Mexico.",
-    "tags": ["US", "Technology", "TimeCapsule"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Microsoft",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q32",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Celine Dion is from which Canadian province?",
     "answer": "Quebec",
     "explanation": "She was born on March 30, 1968 in Charlemagne, Quebec.",
-    "tags": ["CA", "Music", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Celine_Dion",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q33",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the capital of California?",
     "answer": "Sacramento",
     "explanation": "Sacramento became California's state capital in 1854. It's not Los Angeles or San Francisco!",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sacramento,_California",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q34",
-    "category": "General Knowledge",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many sides does a hexagon have?",
     "answer": "Six",
     "explanation": "From the Greek 'hex' meaning six.",
-    "tags": ["Global", "General Knowledge", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hexagon",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q35",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is the main ingredient in Guacamole?",
     "answer": "Avocado",
     "explanation": "It's an avocado-based dip, spread, or salad originating from Mexico.",
-    "tags": ["Global", "Food", "GreatOutdoors"],
+    "tags": [
+      "Global",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Guacamole",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q36",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "The CN Tower is located in which city?",
     "answer": "Toronto",
     "explanation": "It held the record for the world's tallest free-standing structure for 32 years (1975-2007).",
-    "tags": ["CA", "Geography", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/CN_Tower",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q37",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which ocean is on the West Coast of the US and Canada?",
     "answer": "Pacific Ocean",
     "explanation": "It is the largest and deepest of Earth's oceanic divisions, covering about 63 million square miles.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pacific_Ocean",
     "sourceName": "Wikipedia"
   },
@@ -406,84 +562,116 @@
     "question": "Which team won the first ever Super Bowl?",
     "answer": "Green Bay Packers",
     "explanation": "They defeated the Kansas City Chiefs 35-10 on January 15, 1967.",
-    "tags": ["US", "Sports", "TimeCapsule"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Super_Bowl_I",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q39",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the largest mammal in the world?",
     "answer": "Blue Whale",
     "explanation": "They can grow up to 100 feet long and weigh as much as 200 tons.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Blue_whale",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q40",
-    "category": "Culture",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Tim Hortons is famous for what two items?",
     "answer": "Coffee and Donuts",
     "explanation": "Founded in 1964 in Hamilton, Ontario by Canadian hockey player Tim Horton.",
-    "tags": ["CA", "Culture", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tim_Hortons",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q41",
-    "category": "Government",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "How many senators are in the US Senate?",
     "answer": "100",
     "explanation": "Two for each of the 50 states, serving six-year terms.",
-    "tags": ["US", "Government", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/United_States_Senate",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q42",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the speed of light approximately?",
     "answer": "299,792 km/s",
     "explanation": "Often approximated as 300,000 km/s. Light travels at exactly 299,792,458 meters per second in a vacuum.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Speed_of_light",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q43",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What are the two official languages of Canada?",
     "answer": "English and French",
     "explanation": "Canada became officially bilingual at the federal level with the Official Languages Act of 1969.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Official_Languages_Act_(Canada)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q44",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which Great Lake is the only one located entirely within the US?",
     "answer": "Lake Michigan",
     "explanation": "The other four Great Lakes (Superior, Huron, Erie, Ontario) are shared with Canada.",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Lake_Michigan",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q45",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Who played Iron Man in the Marvel Cinematic Universe?",
     "answer": "Robert Downey Jr.",
     "explanation": "He kicked off the MCU in Iron Man (2008) and played Tony Stark until Avengers: Endgame (2019).",
-    "tags": ["US", "Entertainment", "FreshPrints"],
+    "tags": [
+      "US",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Robert_Downey_Jr.",
     "sourceName": "Wikipedia"
   },
@@ -494,73 +682,101 @@
     "question": "Which Canadian hockey player is known as 'The Great One'?",
     "answer": "Wayne Gretzky",
     "explanation": "He holds over 60 NHL records including most career goals (894) and assists (1,963).",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Wayne_Gretzky",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q47",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the powerhouse of the cell?",
     "answer": "Mitochondria",
     "explanation": "They generate most of the cell's supply of adenosine triphosphate (ATP) through cellular respiration.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mitochondrion",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q48",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the capital of Texas?",
     "answer": "Austin",
     "explanation": "Austin has been the state capital since 1839. 'Keep Austin Weird' is the city's unofficial slogan.",
-    "tags": ["US", "Geography", "GlobalEh"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Austin,_Texas",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q49",
-    "category": "General Knowledge",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What color do you get when you mix Red and Blue?",
     "answer": "Purple",
     "explanation": "Purple is a secondary color in the traditional RYB color model used in painting.",
-    "tags": ["Global", "General Knowledge", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Purple",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q50",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the northernmost permanent settlement in the world?",
     "answer": "Alert, Nunavut",
     "explanation": "Alert is located at 82\u00b030'N in the Qikiqtaaluk Region of Nunavut, Canada, just 817 km from the North Pole.",
-    "tags": ["CA", "Geography", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Alert,_Nunavut",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q51",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "In what year did Canada become a nation?",
     "answer": "1867",
     "explanation": "Confederation occurred on July 1, 1867, now celebrated as Canada Day.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_Confederation",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q52",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian artist performed the halftime show at Super Bowl LV?",
     "answer": "The Weeknd",
     "explanation": "The Weeknd performed at Super Bowl LV (55) on February 7, 2021 in Tampa, Florida. Super Bowl LIV (54) in 2020 featured Shakira and Jennifer Lopez.",
-    "tags": ["CA", "Music", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Super_Bowl_LV_halftime_show",
     "sourceName": "Wikipedia"
   },
@@ -571,108 +787,154 @@
     "question": "How many Stanley Cups has Canada's Toronto Maple Leafs won?",
     "answer": "13",
     "explanation": "Their last championship was in 1967, the longest active drought in the NHL.",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Toronto_Maple_Leafs",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q54",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the chemical symbol for Gold?",
     "answer": "Au",
     "explanation": "Au comes from the Latin word 'aurum', meaning 'shining dawn'.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Gold",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q55",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the tallest mountain in North America?",
     "answer": "Denali",
-    "acceptableAnswers": ["Mount Denali", "Mt. Denali"],
+    "acceptableAnswers": [
+      "Mount Denali",
+      "Mt. Denali"
+    ],
     "explanation": "Denali in Alaska stands at 20,310 feet (6,190 meters). It was formerly known as Mount McKinley.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Denali",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q56",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Maple syrup comes from which tree?",
     "answer": "Sugar Maple",
     "explanation": "The sugar maple (Acer saccharum) is the primary source of maple syrup and is Canada's national tree.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sugar_maple",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q57",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which British actor stars as Batman in 'The Batman' (2022)?",
     "answer": "Robert Pattinson",
     "explanation": "Robert Pattinson was born on May 13, 1986 in Barnes, London, England. He is British and starred in 'The Batman' (2022).",
-    "tags": ["CA", "Entertainment", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.britannica.com/facts/Robert-Pattinson",
     "sourceName": "Britannica"
   },
   {
     "id": "q58",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Who discovered insulin and won a Nobel Prize for Medicine?",
     "answer": "Frederick Banting",
     "explanation": "Sir Frederick Banting was a Canadian physician who shared the 1923 Nobel Prize with John Macleod for the discovery of insulin.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Frederick_Banting",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q59",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the world's largest freshwater lake?",
     "answer": "Lake Superior",
     "explanation": "Lake Superior is the largest freshwater lake by surface area (31,700 sq mi), shared between Canada and the United States.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Lake_Superior",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q60",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'Anne of Green Gables'?",
     "answer": "Lucy Maud Montgomery",
     "explanation": "L.M. Montgomery was a Canadian author born in Clifton, Prince Edward Island. The novel was published in 1908.",
-    "tags": ["CA", "Literature", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Anne_of_Green_Gables",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q61",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which Canadian city is known as the 'City of Festivals'?",
     "answer": "Montreal",
     "explanation": "Montreal hosts over 100 festivals annually including the Montreal Jazz Festival and Just for Laughs.",
-    "tags": ["CA", "Geography", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Montreal",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q62",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What gas do plants absorb for photosynthesis?",
     "answer": "Carbon Dioxide",
-    "acceptableAnswers": ["CO2", "CO2"],
+    "acceptableAnswers": [
+      "CO2",
+      "CO2"
+    ],
     "explanation": "Plants use CO2 and sunlight to create glucose and release oxygen.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Photosynthesis",
     "sourceName": "Wikipedia"
   },
@@ -683,84 +945,116 @@
     "question": "Which Canadian tennis player won the US Open in 2019?",
     "answer": "Bianca Andreescu",
     "explanation": "Andreescu defeated Serena Williams 6\u20133, 7\u20135 in the final, becoming the first Canadian to win a Grand Slam singles title.",
-    "tags": ["CA", "Sports", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bianca_Andreescu",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q64",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian actor is known for the TV series 'Schitt's Creek'?",
     "answer": "Dan Levy",
     "explanation": "Dan Levy co-created the show with his father Eugene Levy. It won 9 Emmy Awards in 2020.",
-    "tags": ["CA", "Entertainment", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Schitt%27s_Creek",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q65",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "In which year did the Titanic sink?",
     "answer": "1912",
     "explanation": "RMS Titanic struck an iceberg on April 14, 1912 and sank in the early morning of April 15. Over 1,500 people died.",
-    "tags": ["Global", "History", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sinking_of_the_Titanic",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q66",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the capital of Australia?",
     "answer": "Canberra",
     "explanation": "Canberra was chosen in 1908 as a compromise between Sydney and Melbourne, and became the capital in 1927.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canberra",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q67",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian singer-songwriter wrote 'Hallelujah'?",
     "answer": "Leonard Cohen",
     "explanation": "Leonard Cohen was born in Montreal and originally released 'Hallelujah' on his 1984 album 'Various Positions'.",
-    "tags": ["CA", "Music", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hallelujah_(Leonard_Cohen_song)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q68",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is the national dish of Canada?",
     "answer": "Poutine",
     "explanation": "Poutine consists of French fries topped with cheese curds and brown gravy. It originated in Quebec in the late 1950s.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Poutine",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q69",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many bones does an adult human have?",
     "answer": "206",
     "explanation": "Babies are born with about 270 bones, but some fuse together as they grow into adults.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Human_skeleton",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q70",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian comedy troupe created 'Kids in the Hall'?",
     "answer": "The Kids in the Hall",
     "explanation": "The Kids in the Hall is a Canadian sketch comedy group formed in 1984. Their TV series aired from 1988-1995.",
-    "tags": ["CA", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Kids_in_the_Hall",
     "sourceName": "Wikipedia"
   },
@@ -771,62 +1065,86 @@
     "question": "What year did Canada first win an Olympic gold medal?",
     "answer": "1904",
     "explanation": "\u00c9tienne Desmarteau and George Lyon won Canada's first official Olympic gold medals at the 1904 St. Louis Games. Gold, silver, and bronze medals were first awarded at the 1904 Olympics.",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canada_at_the_1904_Summer_Olympics",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q72",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Who was the first European to reach North America?",
     "answer": "Leif Erikson",
     "explanation": "The Viking explorer reached North America around 1000 AD, establishing a settlement at L'Anse aux Meadows in Newfoundland.",
-    "tags": ["Global", "History", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Leif_Erikson",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q73",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the capital of France?",
     "answer": "Paris",
     "explanation": "Paris is located on the Seine River and has been France's capital since 987 AD.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Paris",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q74",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the largest land animal on Earth?",
     "answer": "African Elephant",
     "explanation": "Adult male African bush elephants can weigh up to 14,000 pounds (6,350 kg) and stand up to 13 feet tall.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/African_elephant",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q75",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote the Harry Potter series?",
     "answer": "J.K. Rowling",
     "explanation": "J.K. Rowling is a British author who published the first Harry Potter book in 1997.",
-    "tags": ["Global", "Literature", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Harry_Potter",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q77",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which British rock band released the iconic album 'The Wall' in 1979?",
     "answer": "Pink Floyd",
     "explanation": "Pink Floyd is a British rock band formed in London in 1965. 'The Wall' is one of rock's most acclaimed concept albums.",
-    "tags": ["Global", "Music", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pink_Floyd",
     "sourceName": "Wikipedia"
   },
@@ -837,74 +1155,105 @@
     "question": "How many Olympic sports are there in the Summer Olympics?",
     "answer": "32",
     "explanation": "The 2024 Paris Olympics featured 32 sports. The number of sports varies with each Olympic Games.",
-    "tags": ["Global", "Sports", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Summer_Olympic_Games",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q79",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which Canadian province has the highest population?",
     "answer": "Ontario",
     "explanation": "Ontario is home to over 15 million people, about 38% of Canada's total population.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ontario",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q80",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the largest organ in the human body?",
     "answer": "Skin",
     "explanation": "The skin covers about 20 square feet in adults and weighs about 8 pounds.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Human_skin",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q81",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which American actress plays Black Widow in Marvel films?",
     "answer": "Scarlett Johansson",
     "explanation": "Scarlett Johansson is an American actress born in New York City. She has played Natasha Romanoff/Black Widow since 2010.",
-    "tags": ["Global", "Entertainment", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Scarlett_Johansson",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q82",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What year did the Berlin Wall fall?",
     "answer": "1989",
     "explanation": "The Berlin Wall fell on November 9, 1989, symbolizing the end of the Cold War division of Europe.",
-    "tags": ["Global", "History", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Fall_of_the_Berlin_Wall",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q83",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "What is a Nanaimo bar?",
     "answer": "A chocolate dessert",
-    "acceptableAnswers": ["Chocolate bar", "Canadian candy"],
+    "acceptableAnswers": [
+      "Chocolate bar",
+      "Canadian candy"
+    ],
     "explanation": "It's a no-bake three-layer dessert bar originating from Nanaimo, British Columbia with a custard-flavored middle layer.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nanaimo_bar",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q84",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the smallest independent country in the world?",
     "answer": "Vatican City",
     "explanation": "Vatican City is about 0.44 square kilometers (110 acres), entirely surrounded by Rome, Italy.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Vatican_City",
     "sourceName": "Wikipedia"
   },
@@ -915,74 +1264,105 @@
     "question": "Which NHL team is known as the Maple Leafs?",
     "answer": "Toronto",
     "explanation": "The Toronto Maple Leafs were founded in 1917 and play in the Atlantic Division of the Eastern Conference.",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Toronto_Maple_Leafs",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q86",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'One Hundred Years of Solitude'?",
     "answer": "Gabriel Garc\u00eda M\u00e1rquez",
     "explanation": "Garc\u00eda M\u00e1rquez was a Colombian author who won the 1982 Nobel Prize in Literature.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/One_Hundred_Years_of_Solitude",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q87",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What element has the atomic number 1?",
     "answer": "Hydrogen",
     "explanation": "Hydrogen is the lightest element and makes up about 75% of all matter in the universe.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hydrogen",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q88",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which British artist sings 'Watermelon Sugar'?",
     "answer": "Harry Styles",
     "explanation": "Harry Styles is a British singer born in Redditch, England. 'Watermelon Sugar' was released in 2019 from his album 'Fine Line'.",
-    "tags": ["Global", "Music", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Harry_Styles",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q89",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which civilization built Machu Picchu?",
     "answer": "Inca Empire",
-    "acceptableAnswers": ["Inca", "Incas"],
+    "acceptableAnswers": [
+      "Inca",
+      "Incas"
+    ],
     "explanation": "Machu Picchu was built by the Inca Empire in the 15th century and later became one of Peru's most famous archaeological sites.",
-    "tags": ["Global", "History", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Machu_Picchu",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q90",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Italy?",
     "answer": "Rome",
     "explanation": "Rome has been Italy's capital since 1871. It's known as the 'Eternal City' (La Citt\u00e0 Eterna).",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rome",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q91",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Australian actor played Wolverine in the X-Men films?",
     "answer": "Hugh Jackman",
     "explanation": "Hugh Jackman is an Australian actor born in Sydney. He played Wolverine in nine X-Men films from 2000-2024.",
-    "tags": ["Global", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hugh_Jackman",
     "sourceName": "Wikipedia"
   },
@@ -993,85 +1373,120 @@
     "question": "How many gold medals did Canadian sprinter Andre De Grasse win at the 2016 Olympics?",
     "answer": "0",
     "explanation": "De Grasse won three medals: 1 silver and 2 bronze.",
-    "tags": ["CA", "Sports", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Andre_De_Grasse",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q93",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many legs does a spider have?",
     "answer": "8",
     "explanation": "All spiders are arachnids with eight legs.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Spider",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q94",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What is a Buxton cake?",
     "answer": "A Canadian pastry",
-    "acceptableAnswers": ["Pastry", "Dessert"],
+    "acceptableAnswers": [
+      "Pastry",
+      "Dessert"
+    ],
     "explanation": "A traditional Canadian dessert from the early 20th century.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_cuisine",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q95",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the rarest blood type?",
     "answer": "Rh-null",
     "explanation": "Only a handful of people worldwide have this blood type.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rh_blood_group_system",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q96",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did Canada get its own flag?",
     "answer": "1965",
     "explanation": "The Maple Leaf flag was officially adopted on February 15, 1965.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Flag_of_Canada",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q97",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the capital of Brazil?",
     "answer": "Bras\u00edlia",
     "explanation": "Bras\u00edlia replaced Rio de Janeiro as the capital in 1960.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bras%C3%ADlia",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q98",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Scottish artist sings 'Someone You Loved'?",
     "answer": "Lewis Capaldi",
     "explanation": "Lewis Capaldi is a Scottish singer-songwriter from Whitburn, West Lothian. 'Someone You Loved' reached #1 in the UK and US in 2019.",
-    "tags": ["Global", "Music", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Lewis_Capaldi",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q99",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "What streaming service did Netflix originate as?",
     "answer": "DVD rental by mail",
     "explanation": "Netflix started in 1997 as a mail-based DVD rental service.",
-    "tags": ["Global", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Netflix",
     "sourceName": "Wikipedia"
   },
@@ -1082,62 +1497,86 @@
     "question": "How many players are on a Canadian hockey team on the ice?",
     "answer": "6",
     "explanation": "Five skaters and one goaltender.",
-    "tags": ["CA", "Sports", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ice_hockey",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q102",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What gas makes up most of Earth's atmosphere?",
     "answer": "Nitrogen",
     "explanation": "Nitrogen comprises about 78% of the air we breathe.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Atmosphere_of_Earth",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q103",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Which Canadian province has the smallest population?",
     "answer": "Prince Edward Island",
     "explanation": "Prince Edward Island has the smallest population of any Canadian province, with approximately 170,000 residents. Note: Nunavut has fewer people but is a territory, not a province.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Prince_Edward_Island",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q104",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'The Odyssey'?",
     "answer": "Homer",
     "explanation": "Homer was an ancient Greek poet.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Odyssey",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q105",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian actor stars in the TV show 'Letterkenny'?",
     "answer": "Jared Keeso",
     "explanation": "Keeso created and stars in the comedy series.",
-    "tags": ["CA", "Entertainment", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Letterkenny_(TV_series)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q106",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian artist released the acclaimed album 'Blue' in 1971?",
     "answer": "Joni Mitchell",
     "explanation": "Joni Mitchell is a Canadian singer-songwriter from Alberta. 'Blue' (1971) is considered one of the greatest albums of all time. Note: 'Take Me Home' is a Cher album (1979), not Joni Mitchell.",
-    "tags": ["CA", "Music", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Blue_(Joni_Mitchell_album)",
     "sourceName": "Wikipedia"
   },
@@ -1148,73 +1587,101 @@
     "question": "Which Canadian tennis player reached the Wimbledon finals?",
     "answer": "Milos Raonic",
     "explanation": "Raonic reached the Wimbledon final in 2016.",
-    "tags": ["CA", "Sports", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Milos_Raonic",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q108",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is butter tart filling made from?",
     "answer": "Butter, brown sugar, and eggs",
     "explanation": "This is a traditional Canadian dessert.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Butter_tart",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q109",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the deepest ocean trench?",
     "answer": "Mariana Trench",
     "explanation": "Located in the Western Pacific, it reaches nearly 11 km deep.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mariana_Trench",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q110",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the symbol for Iron in the periodic table?",
     "answer": "Fe",
     "explanation": "Fe comes from the Latin word 'ferrum'.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Iron",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q111",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did Canada abolish slavery?",
     "answer": "1834",
     "explanation": "The Slavery Abolition Act was passed throughout the British Empire.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Slavery_Abolition_Act_1833",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q112",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the longest river in Canada?",
     "answer": "Mackenzie River",
     "explanation": "The Mackenzie River flows through northern Canada.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mackenzie_River",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q113",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Barbadian musician performed at the Super Bowl LVII halftime show in 2023?",
     "answer": "Rihanna",
     "explanation": "Rihanna is from Saint Michael, Barbados. She performed at Super Bowl LVII in Glendale, Arizona on February 12, 2023.",
-    "tags": ["Global", "Entertainment", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Super_Bowl_LVII_halftime_show",
     "sourceName": "Wikipedia"
   },
@@ -1225,95 +1692,131 @@
     "question": "What year did the Vancouver Canucks join the NHL?",
     "answer": "1970",
     "explanation": "The Canucks have been a major NHL team since then.",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Vancouver_Canucks",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q115",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote 'Alice in Wonderland'?",
     "answer": "Lewis Carroll",
     "explanation": "The British author created the iconic tale.",
-    "tags": ["Global", "Literature", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Alice%27s_Adventures_in_Wonderland",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q116",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the boiling point of water in Fahrenheit?",
     "answer": "212",
     "explanation": "At sea level, water boils at 212\u00b0F or 100\u00b0C.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Boiling_point",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q117",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian band performed at Live Aid in 1985?",
     "answer": "Rush",
     "explanation": "The prog rock band is from Toronto.",
-    "tags": ["CA", "Music", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rush_(band)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q118",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Japan?",
     "answer": "Tokyo",
     "explanation": "Tokyo is the most populous metropolitan area in the world.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tokyo",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q119",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the fastest land animal?",
     "answer": "Cheetah",
     "explanation": "Cheetahs can reach speeds of over 70 mph.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Cheetah",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q120",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "What is a Beaver Tail in Canadian cuisine?",
     "answer": "A pastry dessert",
     "explanation": "It's a fried dough pastry traditionally served at Canadian fairs.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/BeaverTails",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q121",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian show aired on Nickelodeon called 'Drake & Josh'?",
     "answer": "Actually American",
     "explanation": "Despite some Canadian involvement, it's primarily American.",
-    "tags": ["Global", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Drake_%26_Josh",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q122",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "When was the Canadian Constitution patriated?",
     "answer": "1982",
     "explanation": "Canada officially adopted its own constitution on April 17, 1982.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Patriation",
     "sourceName": "Wikipedia"
   },
@@ -1324,62 +1827,86 @@
     "question": "In which sport do you serve and volley?",
     "answer": "Tennis",
     "explanation": "Tennis is played on courts worldwide.",
-    "tags": ["Global", "Sports", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tennis",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q124",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the most abundant element in the universe?",
     "answer": "Hydrogen",
     "explanation": "Hydrogen makes up about 75% of all matter.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hydrogen",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q125",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the capital of New Zealand?",
     "answer": "Wellington",
     "explanation": "Despite being smaller than Auckland, Wellington is the capital.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Wellington",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q126",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'The Great Gatsby'?",
     "answer": "F. Scott Fitzgerald",
     "explanation": "Fitzgerald wrote this American classic in 1925.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Great_Gatsby",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q127",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which Canadian jazz pianist was nicknamed the 'Maharaja of the keyboard'?",
     "answer": "Oscar Peterson",
     "explanation": "Oscar Peterson, born in Montreal, was a legendary Canadian jazz pianist known as the 'Maharaja of the keyboard.'",
-    "tags": ["CA", "Music", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Oscar_Peterson",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q128",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian actor is known for 'Trailer Park Boys'?",
     "answer": "Robb Wells",
     "explanation": "Robb Wells plays Ricky in the comedy series. Mike Smith plays Bubbles, and John Paul Tremblay plays Julian.",
-    "tags": ["CA", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Robb_Wells",
     "sourceName": "Wikipedia"
   },
@@ -1390,84 +1917,116 @@
     "question": "How many times has Canada hosted the Summer Olympics?",
     "answer": "1",
     "explanation": "Canada hosted the Summer Olympics once, in Montreal in 1976. Vancouver 2010 was the Winter Olympics.",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/1976_Summer_Olympics",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q130",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What ingredient makes Canadian bacon different from regular bacon?",
     "answer": "It comes from pork loin",
     "explanation": "Canadian bacon is back bacon from the loin, not belly.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Back_bacon",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q131",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What year was the Canadian flag officially adopted?",
     "answer": "1965",
     "explanation": "The maple leaf flag replaced the Union Jack on February 15.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Flag_of_Canada",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q132",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the freezing point of water in Celsius?",
     "answer": "0",
     "explanation": "Water freezes at 0\u00b0C or 32\u00b0F.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Melting_point",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q133",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which Canadian city is farthest north?",
     "answer": "Alert",
     "explanation": "Alert, Nunavut is the northernmost settlement.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Alert,_Nunavut",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q134",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many species of bears are there?",
     "answer": "8",
     "explanation": "Including polar, grizzly, black, panda, and others.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bear",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q135",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Who created the TV series 'The X-Files'?",
     "answer": "Chris Carter",
     "explanation": "Chris Carter is an American writer and producer born in Bellflower, California. He created The X-Files in 1993.",
-    "tags": ["US", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Chris_Carter_(screenwriter)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q136",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian band is known for 'Smells Like Teen Spirit'?",
     "answer": "Not a Canadian band",
     "explanation": "Nirvana was from Seattle, Washington.",
-    "tags": ["Global", "Music", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nirvana_(band)",
     "sourceName": "Wikipedia"
   },
@@ -1478,73 +2037,101 @@
     "question": "How many Winter Olympic Games has Canada hosted?",
     "answer": "2",
     "explanation": "Canada has hosted the Winter Olympics twice: Calgary in 1988 and Vancouver in 2010.",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canada_at_the_Winter_Olympics",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q138",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'Crime and Punishment'?",
     "answer": "Fyodor Dostoevsky",
     "explanation": "The Russian author wrote this psychological novel.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Crime_and_Punishment",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q139",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "How many provinces and territories does Canada have?",
     "answer": "13",
     "explanation": "10 provinces and 3 territories.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Provinces_and_territories_of_Canada",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q140",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the chemical formula for table salt?",
     "answer": "NaCl",
     "explanation": "Sodium chloride is the most common salt.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sodium_chloride",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q141",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did Canada gain independence from Britain?",
     "answer": "1867",
     "explanation": "Confederation in 1867 marked the creation of the Dominion.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_Confederation",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q142",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian actor played Deadpool?",
     "answer": "Ryan Reynolds",
     "explanation": "Reynolds is from Vancouver and starred in the Marvel films.",
-    "tags": ["CA", "Entertainment", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ryan_Reynolds",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q143",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "What country is known for sushi?",
     "answer": "Japan",
     "explanation": "Sushi originated in Japan centuries ago.",
-    "tags": ["Global", "Food", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sushi",
     "sourceName": "Wikipedia"
   },
@@ -1555,73 +2142,101 @@
     "question": "How many players does a baseball team have on the field?",
     "answer": "9",
     "explanation": "Eight players in the field plus a pitcher.",
-    "tags": ["Global", "Sports", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Baseball",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q145",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the tallest living tree?",
     "answer": "Hyperion",
     "explanation": "Hyperion is a coast redwood in California.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hyperion_(tree)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q146",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian singer-songwriter released 'Blue'?",
     "answer": "Joni Mitchell",
     "explanation": "This iconic 1971 album is considered one of the greatest albums of all time.",
-    "tags": ["CA", "Music", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Blue_(Joni_Mitchell_album)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q147",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the second-largest country in the world by area?",
     "answer": "Canada",
     "explanation": "Only Russia is larger.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/List_of_countries_and_dependencies_by_area",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q148",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote 'Pride and Prejudice'?",
     "answer": "Jane Austen",
     "explanation": "Austen was a British novelist from the 19th century.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pride_and_Prejudice",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q149",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "How many planets are in our solar system?",
     "answer": "8",
     "explanation": "Pluto was reclassified as a dwarf planet in 2006.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Solar_System",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q150",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which American actor voices Metro Man in 'Megamind'?",
     "answer": "Brad Pitt",
     "explanation": "Brad Pitt is an American actor from Shawnee, Oklahoma. He voiced Metro Man in the 2010 animated film 'Megamind'.",
-    "tags": ["Global", "Entertainment", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Megamind",
     "sourceName": "Wikipedia"
   },
@@ -1632,96 +2247,135 @@
     "question": "Which Canadian curler won an Olympic gold medal?",
     "answer": "Brad Gushue",
     "explanation": "Brad Gushue won gold in men's curling at the 2006 Turin Olympics, becoming the first Newfoundlander to win Olympic gold. He also won bronze at the 2022 Beijing Olympics.",
-    "tags": ["CA", "Sports", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Brad_Gushue",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q152",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What year did Canada approve same-sex marriage?",
     "answer": "2005",
     "explanation": "Canada was the fourth country to legalize same-sex marriage.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Same-sex_marriage_in_Canada",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q153",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is Montreal-style bagel?",
     "answer": "A boiled and baked bagel",
     "explanation": "Montreal bagels are smaller and sweeter than New York bagels.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Montreal-style_bagel",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q154",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the most common element in the Earth's crust?",
     "answer": "Oxygen",
     "explanation": "Oxygen makes up about 46% of Earth's crust.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Abundance_of_elements_in_Earth%27s_crust",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q155",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the smallest province in Canada by area?",
     "answer": "Prince Edward Island",
     "explanation": "PEI is only about 5,600 square kilometers.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Prince_Edward_Island",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q156",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which Canadian musician won a Grammy for 'Immigrant Song'?",
     "answer": "Not a Canadian",
     "explanation": "Led Zeppelin's 'Immigrant Song' was by a British band.",
-    "tags": ["Global", "Music", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Immigrant_Song",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q157",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which American actor starred as Percy Jackson in the original film series?",
     "answer": "Logan Lerman",
     "explanation": "Logan Lerman is an American actor from Beverly Hills, California. He starred in 'Percy Jackson & the Olympians: The Lightning Thief' (2010) and its sequel.",
-    "tags": ["Global", "Entertainment", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Logan_Lerman",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q158",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What type of mammal lays eggs?",
     "answer": "Monotreme",
-    "acceptableAnswers": ["Platypus", "Echidna"],
+    "acceptableAnswers": [
+      "Platypus",
+      "Echidna"
+    ],
     "explanation": "Monotremes are egg-laying mammals. There are five species: the platypus and four species of echidna. All are found in Australia and New Guinea.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Monotreme",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q159",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'The Catcher in the Rye'?",
     "answer": "J.D. Salinger",
     "explanation": "Salinger wrote this classic American novel.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Catcher_in_the_Rye",
     "sourceName": "Wikipedia"
   },
@@ -1732,73 +2386,101 @@
     "question": "Which Canadian figure skater won two Olympic silver medals?",
     "answer": "Elvis Stojko",
     "explanation": "Elvis Stojko won silver medals at both the 1994 Lillehammer and 1998 Nagano Olympics. He is a three-time World champion (1994, 1995, 1997).",
-    "tags": ["CA", "Sports", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Elvis_Stojko",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q161",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What year did World War II end?",
     "answer": "1945",
     "explanation": "Japan surrendered in September 1945.",
-    "tags": ["Global", "History", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/World_War_II",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q162",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Mexico?",
     "answer": "Mexico City",
     "explanation": "Mexico City is one of the largest cities in the world.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mexico_City",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q163",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the symbol for Silver in the periodic table?",
     "answer": "Ag",
     "explanation": "Ag comes from the Latin word 'argentum'.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Silver",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q164",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which British-American director made 'Inception' and 'The Dark Knight' trilogy?",
     "answer": "Christopher Nolan",
     "explanation": "Christopher Nolan was born in London, England and holds dual British-American citizenship. He is known for films like 'Inception', 'Interstellar', and 'The Dark Knight' trilogy.",
-    "tags": ["Global", "Entertainment", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Christopher_Nolan",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q165",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian band released 'Hotel California'?",
     "answer": "Not a Canadian band",
     "explanation": "The Eagles were an American rock band.",
-    "tags": ["Global", "Music", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hotel_California_(Eagles_album)",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q166",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What is Poutine Royale?",
     "answer": "Poutine with gravy and meat",
     "explanation": "A variation of poutine with added protein.",
-    "tags": ["CA", "Food", "GreatOutdoors"],
+    "tags": [
+      "CA",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Poutine",
     "sourceName": "Wikipedia"
   },
@@ -1809,85 +2491,119 @@
     "question": "How many players are in a soccer team on the field?",
     "answer": "11",
     "explanation": "Including the goalkeeper.",
-    "tags": ["Global", "Sports", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Association_football",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q168",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Which four provinces formed Canada at Confederation in 1867?",
     "answer": "Ontario, Quebec, Nova Scotia, New Brunswick",
-    "acceptableAnswers": ["Ontario, Quebec, New Brunswick, Nova Scotia"],
+    "acceptableAnswers": [
+      "Ontario, Quebec, New Brunswick, Nova Scotia"
+    ],
     "explanation": "On July 1, 1867, Ontario, Quebec, Nova Scotia, and New Brunswick united to form the Dominion of Canada. Ontario and Quebec were created from the former Province of Canada.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_Confederation",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q169",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What do you call a baby kangaroo?",
     "answer": "Joey",
     "explanation": "Young kangaroos are called joeys.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Kangaroo",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q170",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'War and Peace'?",
     "answer": "Leo Tolstoy",
     "explanation": "Tolstoy was a Russian author.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/War_and_Peace",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q171",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the westernmost province of Canada?",
     "answer": "British Columbia",
     "explanation": "BC is on the Pacific coast.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/British_Columbia",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q172",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is DNA?",
     "answer": "Deoxyribonucleic acid",
     "explanation": "DNA carries genetic instructions for life.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/DNA",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q173",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which British actor played Batman in 'The Dark Knight' trilogy?",
     "answer": "Christian Bale",
     "explanation": "Christian Bale was born in Haverfordwest, Wales. He played Batman in Christopher Nolan's Dark Knight trilogy (2005-2012). Note: Bale was NOT in 'Inception' - that film starred Leonardo DiCaprio.",
-    "tags": ["Global", "Entertainment", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Christian_Bale",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q174",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian musician was part of Nickelback?",
     "answer": "Chad Kroeger",
     "explanation": "Chad Kroeger is the lead singer of Nickelback. He was born and raised in Hanna, Alberta, where the band formed in 1995. They later relocated to Vancouver, British Columbia.",
-    "tags": ["CA", "Music", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nickelback",
     "sourceName": "Wikipedia"
   },
@@ -1898,95 +2614,131 @@
     "question": "How many teams are in the NHL?",
     "answer": "32",
     "explanation": "The NHL expanded to 32 teams in recent years.",
-    "tags": ["Global", "Sports", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/National_Hockey_League",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q176",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Which dish was declared Britain's 'true national dish' by Foreign Secretary Robin Cook in 2001?",
     "answer": "Chicken Tikka Masala",
     "explanation": "Chicken Tikka Masala was declared a 'true British national dish' by UK Foreign Secretary Robin Cook in 2001. It was likely invented in Glasgow, Scotland in the 1970s. India has no official national dish.",
-    "tags": ["Global", "Food", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://www.britannica.com/topic/chicken-tikka-masala",
     "sourceName": "Britannica"
   },
   {
     "id": "q177",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What year did Canada join the United Nations?",
     "answer": "1945",
     "explanation": "Canada was a founding member of the UN.",
-    "tags": ["CA", "History", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canada_and_the_United_Nations",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q178",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many legs does an octopus have?",
     "answer": "8",
     "explanation": "All octopuses have eight arms/legs.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Octopus",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q179",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote 'The Lord of the Rings'?",
     "answer": "J.R.R. Tolkien",
     "explanation": "Tolkien was a British author and philologist.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Lord_of_the_Rings",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q180",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the easternmost province of Canada?",
     "answer": "Newfoundland and Labrador",
     "explanation": "It is the most eastern point of North America.",
-    "tags": ["CA", "Geography", "GlobalEh"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Newfoundland_and_Labrador",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q181",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What does RNA stand for?",
     "answer": "Ribonucleic acid",
     "explanation": "RNA is a key molecule in all living cells.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/RNA",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q182",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian actress stars in 'Orphan Black'?",
     "answer": "Tatiana Maslany",
     "explanation": "Tatiana Maslany is from Regina, Saskatchewan. She won an Emmy Award for Outstanding Lead Actress in a Drama Series in 2016 for 'Orphan Black', plus two Critics' Choice Awards and five Canadian Screen Awards. She was nominated for a Golden Globe in 2014 but did not win.",
-    "tags": ["CA", "Entertainment", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tatiana_Maslany",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q183",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which British rock band is known for the album 'Absolution' and songs like 'Hysteria'?",
     "answer": "Muse",
     "explanation": "Muse is a British rock band formed in Teignmouth, Devon, England in 1994. 'Hysteria' is from their 2003 album 'Absolution'.",
-    "tags": ["Global", "Music", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Muse_(band)",
     "sourceName": "Wikipedia"
   },
@@ -1997,84 +2749,116 @@
     "question": "How many periods does a hockey game have?",
     "answer": "3",
     "explanation": "Each period lasts 20 minutes.",
-    "tags": ["Global", "Sports", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ice_hockey",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q185",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is the main ingredient in hummus?",
     "answer": "Chickpeas",
     "explanation": "Hummus is made from pureed chickpeas.",
-    "tags": ["Global", "Food", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hummus",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q187",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the smallest bird in the world?",
     "answer": "Bee hummingbird",
     "explanation": "It weighs less than 2 grams.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bee_hummingbird",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q188",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'Jane Eyre'?",
     "answer": "Charlotte Bront\u00eb",
     "explanation": "Bront\u00eb was a British novelist.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Jane_Eyre",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q189",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Which Asian country has the same name as its capital city?",
     "answer": "Singapore",
     "explanation": "Singapore is both a city and a country.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Singapore",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q190",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the chemical symbol for Copper?",
     "answer": "Cu",
     "explanation": "Cu comes from the Latin word 'cuprum'.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Copper",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q191",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which Canadian filmmaker directed 'Telefilm'?",
     "answer": "David Cronenberg",
     "explanation": "Cronenberg is a legendary Canadian director.",
-    "tags": ["CA", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/David_Cronenberg",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q192",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian musician released 'I'm Like a Bird'?",
     "answer": "Nelly Furtado",
     "explanation": "Furtado is from Victoria, BC.",
-    "tags": ["CA", "Music", "FreshPrints"],
+    "tags": [
+      "CA",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nelly_Furtado",
     "sourceName": "Wikipedia"
   },
@@ -2085,73 +2869,101 @@
     "question": "How many holes does a golf course have?",
     "answer": "18",
     "explanation": "Standard golf courses have 18 holes.",
-    "tags": ["Global", "Sports", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Golf_course",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q194",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What is the main ingredient in tempura?",
     "answer": "Battered and fried",
     "explanation": "Tempura is a Japanese battered and deep-fried dish.",
-    "tags": ["Global", "Food", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tempura",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q196",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the largest reptile in the world?",
     "answer": "Saltwater crocodile",
     "explanation": "They can reach lengths of over 20 feet.",
-    "tags": ["Global", "Nature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Saltwater_crocodile",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q197",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'Moby Dick'?",
     "answer": "Herman Melville",
     "explanation": "Melville wrote this American epic.",
-    "tags": ["Global", "Literature", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Moby-Dick",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q198",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Spain?",
     "answer": "Madrid",
     "explanation": "Madrid is the largest city in Spain.",
-    "tags": ["Global", "Geography", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Madrid",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q199",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the process by which plants make their own food?",
     "answer": "Photosynthesis",
     "explanation": "Plants convert sunlight into chemical energy.",
-    "tags": ["Global", "Science", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Photosynthesis",
     "sourceName": "Wikipedia"
   },
   {
     "id": "q200",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian actor is known for 'Degrassi'?",
     "answer": "Nina Dobrev",
     "explanation": "Dobrev played Mia in the Canadian teen drama.",
-    "tags": ["CA", "Entertainment", "TimeCapsule"],
+    "tags": [
+      "CA",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nina_Dobrev",
     "sourceName": "Wikipedia"
   }

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -17,6 +17,7 @@ import { Save, LogIn, Shield } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/use-auth';
 import { useAdmin } from '@/hooks/use-admin';
+import { VALID_CATEGORIES } from '@shared/constants/categories';
 
 export default function Admin() {
   const [_, setLocation] = useLocation();
@@ -26,7 +27,7 @@ export default function Admin() {
   const { isAdmin, isLoading: adminLoading } = useAdmin();
 
   const [formData, setFormData] = useState({
-    category: '',
+    category: VALID_CATEGORIES[0] as string,
     difficulty: 'Medium' as Difficulty,
     question: '',
     answer: '',
@@ -43,7 +44,7 @@ export default function Admin() {
 
     const newQuestion: Question = {
       id: crypto.randomUUID(),
-      category: formData.category || 'General Knowledge',
+      category: formData.category,
       difficulty: formData.difficulty,
       question: formData.question,
       answer: formData.answer,
@@ -61,7 +62,7 @@ export default function Admin() {
         description: 'Successfully added to the database.',
       });
       setFormData({
-        category: '',
+        category: VALID_CATEGORIES[0],
         difficulty: 'Medium',
         question: '',
         answer: '',
@@ -166,12 +167,19 @@ export default function Admin() {
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <label className="text-sm font-medium">Category</label>
-                  <Input
+                  <Select
                     value={formData.category}
-                    onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                    placeholder="e.g. Science"
-                    data-testid="input-category"
-                  />
+                    onValueChange={(v) => setFormData({ ...formData, category: v })}
+                  >
+                    <SelectTrigger data-testid="select-category">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {VALID_CATEGORIES.map((cat) => (
+                        <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium">Difficulty</label>

--- a/client/src/pages/admin-questions.tsx
+++ b/client/src/pages/admin-questions.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { VALID_CATEGORIES } from '@shared/constants/categories';
 import { AdminLayout } from '@/components/admin-layout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -181,6 +182,7 @@ interface EditableFieldProps {
   fieldKey: string;
   question: Question;
   inputType?: 'text' | 'textarea' | 'url';
+  selectOptions?: readonly string[];
   onSaved: (updated: Question) => void;
 }
 
@@ -189,6 +191,7 @@ function EditableField({
   fieldKey,
   question,
   inputType = 'text',
+  selectOptions,
   onSaved,
 }: EditableFieldProps) {
   const { toast } = useToast();
@@ -328,7 +331,29 @@ function EditableField({
       {/* Content */}
       {editing ? (
         <div className="space-y-2">
-          {inputType === 'textarea' ? (
+          {selectOptions ? (
+            <Select
+              value={draft}
+              onValueChange={(v) => {
+                setDraft(v);
+                setAiSuggested(false);
+              }}
+            >
+              <SelectTrigger
+                className="bg-white/5 border-white/20 text-sm"
+                data-testid={`input-field-${fieldKey}-${question.id}`}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {selectOptions.map((opt) => (
+                  <SelectItem key={opt} value={opt}>
+                    {opt}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : inputType === 'textarea' ? (
             <Textarea
               ref={inputRef as React.RefObject<HTMLTextAreaElement>}
               value={draft}
@@ -581,7 +606,13 @@ function ExpandedRow({ q, onUpdated }: { q: Question; onUpdated: (updated: Quest
             question={q}
             onSaved={onUpdated}
           />
-          <EditableField label="Category" fieldKey="category" question={q} onSaved={onUpdated} />
+          <EditableField
+            label="Category"
+            fieldKey="category"
+            question={q}
+            selectOptions={VALID_CATEGORIES}
+            onSaved={onUpdated}
+          />
 
           {/* Read-only fields */}
           <div>

--- a/server/lib/guardian.ts
+++ b/server/lib/guardian.ts
@@ -2,7 +2,7 @@ import OpenAI from 'openai';
 import { insertQuestionSchema, type InsertQuestion, type Question } from '@shared/models/questions';
 import { auditQuestionQuality, type QuestionQualityFinding } from './question-quality-audit';
 import { batchFactCheck, type FactCheckVerdict } from './verifier';
-import { VALID_CATEGORIES, CATEGORY_SET } from '@shared/constants/categories';
+import { VALID_CATEGORIES, CATEGORY_SET, LEGACY_CATEGORY_MAP } from '@shared/constants/categories';
 
 const openai = new OpenAI({
   apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY,
@@ -56,12 +56,22 @@ function normalizeCandidate(
   if (CATEGORY_SET.has(rawCategory)) {
     category = rawCategory;
   } else {
-    console.warn('[guardian] AI returned non-canonical category — defaulting', {
-      received: rawCategory || '(empty)',
-      topic,
-      defaulting: VALID_CATEGORIES[0],
-    });
-    category = VALID_CATEGORIES[0];
+    const mapped = LEGACY_CATEGORY_MAP[rawCategory.toLowerCase()];
+    if (mapped) {
+      console.warn('[guardian] AI returned legacy category — mapping to canonical', {
+        received: rawCategory,
+        topic,
+        mappedTo: mapped,
+      });
+      category = mapped;
+    } else {
+      console.warn('[guardian] AI returned non-canonical category — defaulting', {
+        received: rawCategory || '(empty)',
+        topic,
+        defaulting: VALID_CATEGORIES[0],
+      });
+      category = VALID_CATEGORIES[0];
+    }
   }
 
   return {

--- a/server/lib/guardian.ts
+++ b/server/lib/guardian.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { insertQuestionSchema, type InsertQuestion, type Question } from '@shared/models/questions';
 import { auditQuestionQuality, type QuestionQualityFinding } from './question-quality-audit';
 import { batchFactCheck, type FactCheckVerdict } from './verifier';
+import { VALID_CATEGORIES, CATEGORY_SET } from '@shared/constants/categories';
 
 const openai = new OpenAI({
   apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY,
@@ -48,11 +49,25 @@ function normalizeCandidate(
   topic: string,
   pillar: string
 ): GenerateQuestionInput {
+  const rawCategory = typeof raw.category === 'string' ? raw.category.trim() : '';
+  // Only accept the AI-supplied category if it matches a canonical value; otherwise
+  // default to 'History & Geography' and log so the mismatch is visible.
+  let category: string;
+  if (CATEGORY_SET.has(rawCategory)) {
+    category = rawCategory;
+  } else {
+    console.warn('[guardian] AI returned non-canonical category — defaulting', {
+      received: rawCategory || '(empty)',
+      topic,
+      defaulting: VALID_CATEGORIES[0],
+    });
+    category = VALID_CATEGORIES[0];
+  }
+
   return {
     ...raw,
     id: typeof raw.id === 'string' && raw.id.trim().length > 0 ? raw.id : crypto.randomUUID(),
-    category:
-      typeof raw.category === 'string' && raw.category.trim().length > 0 ? raw.category : topic,
+    category,
     pillar,
     status: 'pending',
     tags: Array.isArray(raw.tags) ? raw.tags : [],
@@ -62,7 +77,7 @@ function normalizeCandidate(
 
 const QUESTION_JSON_SCHEMA = (pillar: string) => `{
   "id": "uuid",
-  "category": "string",
+  "category": "History & Geography | Science & Nature | Sports | Entertainment & Pop Culture | Food & Culture | Technology",
   "difficulty": "Easy | Medium | Hard",
   "question": "string",
   "answer": "string",
@@ -88,6 +103,7 @@ const QUESTION_RULES = (pillar: string) => `Rules:
 - Use a unique UUID as id.
 - Ensure all fields are filled and valid.
 - status must always be "pending".
+- category MUST be exactly one of: ${VALID_CATEGORIES.map((c) => `"${c}"`).join(', ')}. Choose the best fit for the question content.
 - tags must include a region tag (CA, US, or Global), the pillar name, and the category name.
 - sourceUrl MUST be a real, publicly accessible URL (Wikipedia, official government site, reputable encyclopedia, or authoritative reference) that directly supports the stated answer. Never use null, empty string, or a placeholder.
 - sourceName MUST be the human-readable name of that source (e.g. "Wikipedia", "Statistics Canada", "National Geographic"). Never use null or empty string.

--- a/server/routes.admin-validation.test.ts
+++ b/server/routes.admin-validation.test.ts
@@ -1,6 +1,7 @@
 import type { Express, NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VALID_CATEGORIES } from '../shared/constants/categories';
 
 import { createQueryMock } from './test/dbMock';
 import { buildTestApp } from './test/testApp';
@@ -115,5 +116,82 @@ describe('admin route validation', () => {
     expect(insertQuery.values).toHaveBeenCalledWith({ key: 'openai_api_key', value: 'secret' });
     expect(insertQuery.onConflictDoUpdate).toHaveBeenCalledOnce();
     expect(response.body).toEqual({ message: 'Configuration saved', key: 'openai_api_key' });
+  });
+});
+
+describe('category validation on field-patch endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('rejects a non-canonical category value on PATCH /api/admin/questions/:id/field', async () => {
+    dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .patch('/api/admin/questions/q-1/field')
+      .set('x-test-user-id', 'admin-user')
+      .send({ field: 'category', value: 'History' })
+      .expect(422);
+
+    expect(response.body).toMatchObject({ message: 'Invalid question field update' });
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it.each(VALID_CATEGORIES)(
+    'accepts canonical category "%s" on PATCH /api/admin/questions/:id/field',
+    async (category) => {
+      const questionRow = {
+        id: 'q-1',
+        category,
+        difficulty: 'Easy',
+        question: 'Test?',
+        answer: 'Yes',
+        explanation: 'Because.',
+        pillar: 'GlobalEh',
+        tags: ['CA', 'GlobalEh', category],
+        sourceUrl: 'https://en.wikipedia.org/wiki/Test',
+        sourceName: 'Wikipedia',
+        status: 'approved',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        aiAnalysis: null,
+        acceptableAnswers: [],
+      };
+
+      dbMocks.select
+        .mockReturnValueOnce(createQueryMock([adminRole])) // admin check
+        .mockReturnValueOnce(createQueryMock([questionRow])); // fetch current row
+      const updateQuery = createQueryMock([{ ...questionRow, category }]);
+      dbMocks.update.mockReturnValue(updateQuery);
+      const insertQuery = createQueryMock([{}]);
+      dbMocks.insert.mockReturnValue(insertQuery);
+      const app = await buildTestApp();
+
+      const response = await request(app)
+        .patch('/api/admin/questions/q-1/field')
+        .set('x-test-user-id', 'admin-user')
+        .send({ field: 'category', value: category })
+        .expect(200);
+
+      expect(response.body).toMatchObject({ category });
+    }
+  );
+
+  it('rejects legacy category values like "Geography", "Science", "Movies"', async () => {
+    const legacyValues = ['Geography', 'Science', 'Movies', 'movies', 'pop culture', 'technology'];
+    for (const value of legacyValues) {
+      dbMocks.select.mockReturnValueOnce(createQueryMock([adminRole]));
+      const app = await buildTestApp();
+
+      const response = await request(app)
+        .patch('/api/admin/questions/q-1/field')
+        .set('x-test-user-id', 'admin-user')
+        .send({ field: 'category', value })
+        .expect(422);
+
+      expect(response.body).toMatchObject({ message: 'Invalid question field update' });
+    }
   });
 });

--- a/server/routes.questions.test.ts
+++ b/server/routes.questions.test.ts
@@ -67,14 +67,14 @@ vi.mock('./lib/verifier', () => ({ batchFactCheck: vi.fn() }));
 const adminRole = { userId: 'admin-user' };
 const questionPayload = {
   id: 'q-1',
-  category: 'Geography',
+  category: 'History & Geography',
   difficulty: 'Easy',
   question: 'What is the capital of Canada?',
   answer: 'Ottawa',
   acceptableAnswers: ['Ottawa, Ontario'],
   explanation: 'Ottawa is the federal capital of Canada.',
   pillar: 'GlobalEh',
-  tags: ['CA', 'GlobalEh', 'Geography'],
+  tags: ['CA', 'GlobalEh', 'History & Geography'],
   sourceUrl: 'https://www.canada.ca/en/canadian-heritage/services/crown-canada/about.html',
   sourceName: 'Government of Canada',
   status: 'approved',
@@ -119,7 +119,7 @@ describe('question routes', () => {
     expect(questionQuery.limit).toHaveBeenCalledWith(1);
     expect(response.body).toMatchObject({
       total: 1,
-      categories: ['Geography'],
+      categories: ['History & Geography'],
       pillars: ['GlobalEh'],
       questions: [{ id: 'q-1', question: questionPayload.question }],
     });

--- a/server/seed-data.json
+++ b/server/seed-data.json
@@ -1,14 +1,17 @@
 [
   {
     "id": "q1",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital city of Canada?",
     "answer": "Ottawa",
     "acceptableAnswers": [],
     "explanation": "Ottawa was chosen as the capital on December 31, 1857 by Queen Victoria.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ottawa",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -18,14 +21,19 @@
   },
   {
     "id": "q2",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which US state is known as the 'Sunshine State'?",
     "answer": "Florida",
-    "acceptableAnswers": ["FL"],
+    "acceptableAnswers": [
+      "FL"
+    ],
     "explanation": "Florida officially adopted 'The Sunshine State' nickname in 1970 when the state legislature included it on license plates.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Florida",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -35,14 +43,19 @@
   },
   {
     "id": "q3",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What represents the 'K' in the periodic table?",
     "answer": "Potassium",
-    "acceptableAnswers": ["K"],
+    "acceptableAnswers": [
+      "K"
+    ],
     "explanation": "The symbol K comes from the Latin word 'Kalium'.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Potassium",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -52,14 +65,21 @@
   },
   {
     "id": "q4",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Who was the first Prime Minister of Canada?",
     "answer": "Sir John A. Macdonald",
-    "acceptableAnswers": ["John A Macdonald", "Macdonald", "John Macdonald"],
+    "acceptableAnswers": [
+      "John A Macdonald",
+      "Macdonald",
+      "John Macdonald"
+    ],
     "explanation": "He served as the first Prime Minister of Canada from 1867 to 1873.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/John_A._Macdonald",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -69,14 +89,17 @@
   },
   {
     "id": "q5",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "In which year was the Declaration of Independence signed?",
     "answer": "1776",
     "acceptableAnswers": [],
     "explanation": "The Declaration of Independence was ADOPTED on July 4, 1776, declaring the 13 colonies independent from Britain. The actual signing began on August 2, 1776, when delegates started signing the engrossed parchment copy.",
     "pillar": "GlobalEh",
-    "tags": ["US", "History"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://www.archives.gov/milestone-documents/declaration-of-independence",
     "sourceName": "National Archives",
     "status": "approved",
@@ -86,14 +109,17 @@
   },
   {
     "id": "q6",
-    "category": "Pop Culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian rapper released the album 'Views'?",
     "answer": "Drake",
     "acceptableAnswers": [],
     "explanation": "Drake released Views in April 2016. 'Hotline Bling' was released earlier as a single on July 31, 2015, and is credited as a bonus track on the physical album. Major album tracks include 'One Dance' and 'Controlla'.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Pop Culture"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Views_(album)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -110,7 +136,10 @@
     "acceptableAnswers": [],
     "explanation": "Vancouver, Canada hosted the XXI Olympic Winter Games.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/2010_Winter_Olympics",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -127,7 +156,10 @@
     "acceptableAnswers": [],
     "explanation": "While Hockey is the national winter sport, Lacrosse is the official national summer sport of Canada.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/National_Sports_of_Canada_Act",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -137,14 +169,17 @@
   },
   {
     "id": "q9",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the longest river in the United States?",
     "answer": "Missouri River",
     "acceptableAnswers": [],
     "explanation": "The Missouri River is about 2,341 miles long, slightly longer than the Mississippi River at 2,340 miles.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Missouri_River",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -154,14 +189,17 @@
   },
   {
     "id": "q10",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which TV show is set in the fictional city of Springfield?",
     "answer": "The Simpsons",
     "acceptableAnswers": [],
     "explanation": "The Simpsons is the longest-running American animated series and longest-running American sitcom.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "Entertainment"],
+    "tags": [
+      "US",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Simpsons",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -171,14 +209,17 @@
   },
   {
     "id": "q11",
-    "category": "General Knowledge",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the currency of Japan?",
     "answer": "Yen",
     "acceptableAnswers": [],
     "explanation": "The Japanese Yen is the third most traded currency in the foreign exchange market.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "General Knowledge"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Japanese_yen",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -188,14 +229,17 @@
   },
   {
     "id": "q12",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the hardest natural substance on Earth?",
     "answer": "Diamond",
     "acceptableAnswers": [],
     "explanation": "Diamonds are formed deep within the Earth under extreme heat and pressure. They rank 10 on the Mohs hardness scale.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Diamond",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -205,14 +249,17 @@
   },
   {
     "id": "q13",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which province joined Canada last?",
     "answer": "Newfoundland and Labrador",
     "acceptableAnswers": [],
     "explanation": "They joined Confederation on March 31, 1949, becoming Canada's tenth province.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Newfoundland_and_Labrador",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -222,14 +269,20 @@
   },
   {
     "id": "q14",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which U.S. president who served four terms is not depicted on Mount Rushmore?",
     "answer": "Franklin D. Roosevelt",
-    "acceptableAnswers": ["FDR", "Franklin Roosevelt"],
+    "acceptableAnswers": [
+      "FDR",
+      "Franklin Roosevelt"
+    ],
     "explanation": "The four presidents on Mount Rushmore are George Washington, Thomas Jefferson, Theodore Roosevelt, and Abraham Lincoln. Franklin D. Roosevelt is not depicted.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mount_Rushmore",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -239,14 +292,17 @@
   },
   {
     "id": "q15",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Poutine originated in which Canadian province?",
     "answer": "Quebec",
     "acceptableAnswers": [],
-    "explanation": "It emerged in the late 1950s in the Centre-du-Québec area.",
+    "explanation": "It emerged in the late 1950s in the Centre-du-Qu\u00e9bec area.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Poutine",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -256,14 +312,17 @@
   },
   {
     "id": "q17",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "How many time zones does Canada have?",
     "answer": "Six",
     "acceptableAnswers": [],
     "explanation": "Pacific, Mountain, Central, Eastern, Atlantic, and Newfoundland.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Time_in_Canada",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -273,14 +332,17 @@
   },
   {
     "id": "q18",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Who was the 16th President of the United States?",
     "answer": "Abraham Lincoln",
     "acceptableAnswers": [],
     "explanation": "He served from 1861 to 1865 during the American Civil War.",
     "pillar": "GlobalEh",
-    "tags": ["US", "History"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Abraham_Lincoln",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -290,14 +352,17 @@
   },
   {
     "id": "q19",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the national animal of the United States?",
     "answer": "Bald Eagle",
     "acceptableAnswers": [],
     "explanation": "The Bald Eagle was adopted as the national bird in 1782.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Nature"],
+    "tags": [
+      "US",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bald_eagle",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -307,14 +372,17 @@
   },
   {
     "id": "q20",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the national animal of Canada?",
     "answer": "Beaver",
     "acceptableAnswers": [],
     "explanation": "The North American Beaver became an official symbol of Canada in 1975.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Nature"],
+    "tags": [
+      "CA",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/North_American_beaver",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -324,14 +392,17 @@
   },
   {
     "id": "q21",
-    "category": "Space",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "Which planet is known as the Red Planet?",
     "answer": "Mars",
     "acceptableAnswers": [],
     "explanation": "Iron oxide prevalent on its surface gives it a reddish appearance.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Space"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mars",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -341,14 +412,17 @@
   },
   {
     "id": "q22",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'The Handmaid's Tale'?",
     "answer": "Margaret Atwood",
     "acceptableAnswers": [],
     "explanation": "Margaret Atwood is a celebrated Canadian author. The novel was published in 1985.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Literature"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Handmaid%27s_Tale",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -358,14 +432,17 @@
   },
   {
     "id": "q23",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which city is known as the 'Big Apple'?",
     "answer": "New York City",
     "acceptableAnswers": [],
     "explanation": "The nickname was popularized in the 1920s by sports writer John J. Fitz Gerald.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Big_Apple",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -382,7 +459,10 @@
     "acceptableAnswers": [],
     "explanation": "Basketball was invented by Canadian James Naismith in 1891.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "Sports"],
+    "tags": [
+      "US",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Slam_dunk",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -392,14 +472,17 @@
   },
   {
     "id": "q25",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Ryan Reynolds was born in which Canadian city?",
     "answer": "Vancouver",
     "acceptableAnswers": [],
     "explanation": "He was born in Vancouver, British Columbia on October 23, 1976.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ryan_Reynolds",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -409,14 +492,17 @@
   },
   {
     "id": "q26",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the smallest US state by area?",
     "answer": "Rhode Island",
     "acceptableAnswers": [],
     "explanation": "Rhode Island is about 1,545 square miles. Despite its name, it is not an island.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rhode_Island",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -426,14 +512,17 @@
   },
   {
     "id": "q27",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "H2O is the chemical formula for what?",
     "answer": "Water",
     "acceptableAnswers": [],
     "explanation": "Two hydrogen atoms and one oxygen atom.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Water",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -443,14 +532,17 @@
   },
   {
     "id": "q28",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which American singer is known as the 'King of Pop'?",
     "answer": "Michael Jackson",
     "acceptableAnswers": [],
     "explanation": "He is regarded as one of the most significant cultural figures of the 20th century.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "Music"],
+    "tags": [
+      "US",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Michael_Jackson",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -460,14 +552,17 @@
   },
   {
     "id": "q29",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the largest province in Canada by area?",
     "answer": "Quebec",
     "acceptableAnswers": [],
-    "explanation": "Quebec covers about 1.5 million km². Nunavut is larger, but it is a territory, not a province.",
+    "explanation": "Quebec covers about 1.5 million km\u00b2. Nunavut is larger, but it is a territory, not a province.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Quebec",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -477,14 +572,18 @@
   },
   {
     "id": "q30",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did the War of 1812 end?",
     "answer": "1815",
     "acceptableAnswers": [],
     "explanation": "The Treaty of Ghent was signed December 24, 1814, but fighting continued into 1815, including the Battle of New Orleans.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "History", "CA"],
+    "tags": [
+      "US",
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/War_of_1812",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -501,7 +600,10 @@
     "acceptableAnswers": [],
     "explanation": "Founded on April 4, 1975 in Albuquerque, New Mexico.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "Technology"],
+    "tags": [
+      "US",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Microsoft",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -511,14 +613,17 @@
   },
   {
     "id": "q32",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Celine Dion is from which Canadian province?",
     "answer": "Quebec",
     "acceptableAnswers": [],
     "explanation": "She was born on March 30, 1968 in Charlemagne, Quebec.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Celine_Dion",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -528,14 +633,17 @@
   },
   {
     "id": "q33",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the capital of California?",
     "answer": "Sacramento",
     "acceptableAnswers": [],
     "explanation": "Sacramento became California's state capital in 1854. It's not Los Angeles or San Francisco!",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sacramento,_California",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -545,14 +653,17 @@
   },
   {
     "id": "q34",
-    "category": "General Knowledge",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many sides does a hexagon have?",
     "answer": "Six",
     "acceptableAnswers": [],
     "explanation": "From the Greek 'hex' meaning six.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "General Knowledge"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hexagon",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -562,14 +673,17 @@
   },
   {
     "id": "q35",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is the main ingredient in Guacamole?",
     "answer": "Avocado",
     "acceptableAnswers": [],
     "explanation": "It's an avocado-based dip, spread, or salad originating from Mexico.",
     "pillar": "GreatOutdoors",
-    "tags": ["Global", "Food"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Guacamole",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -579,14 +693,17 @@
   },
   {
     "id": "q36",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "The CN Tower is located in which city?",
     "answer": "Toronto",
     "acceptableAnswers": [],
     "explanation": "It held the record for the world's tallest free-standing structure for 32 years (1975-2007).",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/CN_Tower",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -596,14 +713,17 @@
   },
   {
     "id": "q37",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which ocean is on the West Coast of the US and Canada?",
     "answer": "Pacific Ocean",
     "acceptableAnswers": [],
     "explanation": "It is the largest and deepest of Earth's oceanic divisions, covering about 63 million square miles.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pacific_Ocean",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -620,7 +740,10 @@
     "acceptableAnswers": [],
     "explanation": "They defeated the Kansas City Chiefs 35-10 on January 15, 1967.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "Sports"],
+    "tags": [
+      "US",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Super_Bowl_I",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -630,14 +753,17 @@
   },
   {
     "id": "q39",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the largest mammal in the world?",
     "answer": "Blue Whale",
     "acceptableAnswers": [],
     "explanation": "They can grow up to 100 feet long and weigh as much as 200 tons.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Blue_whale",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -647,14 +773,17 @@
   },
   {
     "id": "q40",
-    "category": "Culture",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Tim Hortons is famous for what two items?",
     "answer": "Coffee and Donuts",
     "acceptableAnswers": [],
     "explanation": "Founded in 1964 in Hamilton, Ontario by Canadian hockey player Tim Horton.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Culture"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tim_Hortons",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -664,14 +793,17 @@
   },
   {
     "id": "q41",
-    "category": "Government",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "How many senators are in the US Senate?",
     "answer": "100",
     "acceptableAnswers": [],
     "explanation": "Two for each of the 50 states, serving six-year terms.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Government"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/United_States_Senate",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -681,14 +813,17 @@
   },
   {
     "id": "q42",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the speed of light approximately?",
     "answer": "299,792 km/s",
     "acceptableAnswers": [],
     "explanation": "Often approximated as 300,000 km/s. Light travels at exactly 299,792,458 meters per second in a vacuum.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Speed_of_light",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -698,14 +833,17 @@
   },
   {
     "id": "q43",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What are the two official languages of Canada?",
     "answer": "English and French",
     "acceptableAnswers": [],
     "explanation": "Canada became officially bilingual at the federal level with the Official Languages Act of 1969.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Official_Languages_Act_(Canada)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -715,14 +853,17 @@
   },
   {
     "id": "q44",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which Great Lake is the only one located entirely within the US?",
     "answer": "Lake Michigan",
     "acceptableAnswers": [],
     "explanation": "The other four Great Lakes (Superior, Huron, Erie, Ontario) are shared with Canada.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Lake_Michigan",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -732,14 +873,17 @@
   },
   {
     "id": "q45",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Who played Iron Man in the Marvel Cinematic Universe?",
     "answer": "Robert Downey Jr.",
     "acceptableAnswers": [],
     "explanation": "He kicked off the MCU in Iron Man (2008) and played Tony Stark until Avengers: Endgame (2019).",
     "pillar": "FreshPrints",
-    "tags": ["US", "Entertainment"],
+    "tags": [
+      "US",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Robert_Downey_Jr.",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -756,7 +900,10 @@
     "acceptableAnswers": [],
     "explanation": "He holds over 60 NHL records including most career goals (894) and assists (1,963).",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Wayne_Gretzky",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -766,14 +913,17 @@
   },
   {
     "id": "q47",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the powerhouse of the cell?",
     "answer": "Mitochondria",
     "acceptableAnswers": [],
     "explanation": "They generate most of the cell's supply of adenosine triphosphate (ATP) through cellular respiration.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mitochondrion",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -783,14 +933,17 @@
   },
   {
     "id": "q48",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the capital of Texas?",
     "answer": "Austin",
     "acceptableAnswers": [],
     "explanation": "Austin has been the state capital since 1839. 'Keep Austin Weird' is the city's unofficial slogan.",
     "pillar": "GlobalEh",
-    "tags": ["US", "Geography"],
+    "tags": [
+      "US",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Austin,_Texas",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -800,14 +953,17 @@
   },
   {
     "id": "q49",
-    "category": "General Knowledge",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What color do you get when you mix Red and Blue?",
     "answer": "Purple",
     "acceptableAnswers": [],
     "explanation": "Purple is a secondary color in the traditional RYB color model used in painting.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "General Knowledge"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Purple",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -817,14 +973,17 @@
   },
   {
     "id": "q50",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the northernmost permanent settlement in the world?",
     "answer": "Alert, Nunavut",
     "acceptableAnswers": [],
-    "explanation": "Alert is located at 82°30'N in the Qikiqtaaluk Region of Nunavut, Canada, just 817 km from the North Pole.",
+    "explanation": "Alert is located at 82\u00b030'N in the Qikiqtaaluk Region of Nunavut, Canada, just 817 km from the North Pole.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Alert,_Nunavut",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -834,14 +993,17 @@
   },
   {
     "id": "q51",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "In what year did Canada become a nation?",
     "answer": "1867",
     "acceptableAnswers": [],
     "explanation": "Confederation occurred on July 1, 1867, now celebrated as Canada Day.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_Confederation",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -851,14 +1013,17 @@
   },
   {
     "id": "q52",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian artist performed the halftime show at Super Bowl LV?",
     "answer": "The Weeknd",
     "acceptableAnswers": [],
     "explanation": "The Weeknd performed at Super Bowl LV (55) on February 7, 2021 in Tampa, Florida. Super Bowl LIV (54) in 2020 featured Shakira and Jennifer Lopez.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Super_Bowl_LV_halftime_show",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -875,7 +1040,10 @@
     "acceptableAnswers": [],
     "explanation": "Their last championship was in 1967, the longest active drought in the NHL.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Toronto_Maple_Leafs",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -885,14 +1053,17 @@
   },
   {
     "id": "q54",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the chemical symbol for Gold?",
     "answer": "Au",
     "acceptableAnswers": [],
     "explanation": "Au comes from the Latin word 'aurum', meaning 'shining dawn'.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Gold",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -902,14 +1073,20 @@
   },
   {
     "id": "q55",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the tallest mountain in North America?",
     "answer": "Denali",
-    "acceptableAnswers": ["Mount Denali", "Mt. Denali"],
+    "acceptableAnswers": [
+      "Mount Denali",
+      "Mt. Denali"
+    ],
     "explanation": "Denali in Alaska stands at 20,310 feet (6,190 meters). It was formerly known as Mount McKinley.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Denali",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -919,14 +1096,17 @@
   },
   {
     "id": "q56",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Maple syrup comes from which tree?",
     "answer": "Sugar Maple",
     "acceptableAnswers": [],
     "explanation": "The sugar maple (Acer saccharum) is the primary source of maple syrup and is Canada's national tree.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sugar_maple",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -936,14 +1116,17 @@
   },
   {
     "id": "q57",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which British actor stars as Batman in 'The Batman' (2022)?",
     "answer": "Robert Pattinson",
     "acceptableAnswers": [],
     "explanation": "Robert Pattinson was born on May 13, 1986 in Barnes, London, England. He is British and starred in 'The Batman' (2022).",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.britannica.com/facts/Robert-Pattinson",
     "sourceName": "Britannica",
     "status": "approved",
@@ -953,14 +1136,17 @@
   },
   {
     "id": "q58",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Who discovered insulin and won a Nobel Prize for Medicine?",
     "answer": "Frederick Banting",
     "acceptableAnswers": [],
     "explanation": "Sir Frederick Banting was a Canadian physician who shared the 1923 Nobel Prize with John Macleod for the discovery of insulin.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Frederick_Banting",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -970,14 +1156,17 @@
   },
   {
     "id": "q59",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the world's largest freshwater lake?",
     "answer": "Lake Superior",
     "acceptableAnswers": [],
     "explanation": "Lake Superior is the largest freshwater lake by surface area (31,700 sq mi), shared between Canada and the United States.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Lake_Superior",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -987,14 +1176,17 @@
   },
   {
     "id": "q60",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'Anne of Green Gables'?",
     "answer": "Lucy Maud Montgomery",
     "acceptableAnswers": [],
     "explanation": "L.M. Montgomery was a Canadian author born in Clifton, Prince Edward Island. The novel was published in 1908.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Literature"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Anne_of_Green_Gables",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1004,14 +1196,17 @@
   },
   {
     "id": "q61",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which Canadian city is known as the 'City of Festivals'?",
     "answer": "Montreal",
     "acceptableAnswers": [],
     "explanation": "Montreal hosts over 100 festivals annually including the Montreal Jazz Festival and Just for Laughs.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Montreal",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1021,14 +1216,20 @@
   },
   {
     "id": "q62",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What gas do plants absorb for photosynthesis?",
     "answer": "Carbon Dioxide",
-    "acceptableAnswers": ["CO2", "CO2"],
+    "acceptableAnswers": [
+      "CO2",
+      "CO2"
+    ],
     "explanation": "Plants use CO2 and sunlight to create glucose and release oxygen.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Photosynthesis",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1043,9 +1244,12 @@
     "question": "Which Canadian tennis player won the US Open in 2019?",
     "answer": "Bianca Andreescu",
     "acceptableAnswers": [],
-    "explanation": "Andreescu defeated Serena Williams 6–3, 7–5 in the final, becoming the first Canadian to win a Grand Slam singles title.",
+    "explanation": "Andreescu defeated Serena Williams 6\u20133, 7\u20135 in the final, becoming the first Canadian to win a Grand Slam singles title.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bianca_Andreescu",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1055,14 +1259,17 @@
   },
   {
     "id": "q64",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian actor is known for the TV series 'Schitt's Creek'?",
     "answer": "Dan Levy",
     "acceptableAnswers": [],
     "explanation": "Dan Levy co-created the show with his father Eugene Levy. It won 9 Emmy Awards in 2020.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Schitt%27s_Creek",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1072,14 +1279,17 @@
   },
   {
     "id": "q65",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "In which year did the Titanic sink?",
     "answer": "1912",
     "acceptableAnswers": [],
     "explanation": "RMS Titanic struck an iceberg on April 14, 1912 and sank in the early morning of April 15. Over 1,500 people died.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "History"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sinking_of_the_Titanic",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1089,14 +1299,17 @@
   },
   {
     "id": "q66",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the capital of Australia?",
     "answer": "Canberra",
     "acceptableAnswers": [],
     "explanation": "Canberra was chosen in 1908 as a compromise between Sydney and Melbourne, and became the capital in 1927.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canberra",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1106,14 +1319,17 @@
   },
   {
     "id": "q67",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian singer-songwriter wrote 'Hallelujah'?",
     "answer": "Leonard Cohen",
     "acceptableAnswers": [],
     "explanation": "Leonard Cohen was born in Montreal and originally released 'Hallelujah' on his 1984 album 'Various Positions'.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hallelujah_(Leonard_Cohen_song)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1123,14 +1339,17 @@
   },
   {
     "id": "q68",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is the national dish of Canada?",
     "answer": "Poutine",
     "acceptableAnswers": [],
     "explanation": "Poutine consists of French fries topped with cheese curds and brown gravy. It originated in Quebec in the late 1950s.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Poutine",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1140,14 +1359,17 @@
   },
   {
     "id": "q69",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many bones does an adult human have?",
     "answer": "206",
     "acceptableAnswers": [],
     "explanation": "Babies are born with about 270 bones, but some fuse together as they grow into adults.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Human_skeleton",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1157,14 +1379,17 @@
   },
   {
     "id": "q70",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian comedy troupe created 'Kids in the Hall'?",
     "answer": "The Kids in the Hall",
     "acceptableAnswers": [],
     "explanation": "The Kids in the Hall is a Canadian sketch comedy group formed in 1984. Their TV series aired from 1988-1995.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Kids_in_the_Hall",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1179,9 +1404,12 @@
     "question": "What year did Canada first win an Olympic gold medal?",
     "answer": "1904",
     "acceptableAnswers": [],
-    "explanation": "Étienne Desmarteau and George Lyon won Canada's first official Olympic gold medals at the 1904 St. Louis Games. Gold, silver, and bronze medals were first awarded at the 1904 Olympics.",
+    "explanation": "\u00c9tienne Desmarteau and George Lyon won Canada's first official Olympic gold medals at the 1904 St. Louis Games. Gold, silver, and bronze medals were first awarded at the 1904 Olympics.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canada_at_the_1904_Summer_Olympics",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1191,14 +1419,17 @@
   },
   {
     "id": "q72",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Who was the first European to reach North America?",
     "answer": "Leif Erikson",
     "acceptableAnswers": [],
     "explanation": "The Viking explorer reached North America around 1000 AD, establishing a settlement at L'Anse aux Meadows in Newfoundland.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "History"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Leif_Erikson",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1208,14 +1439,17 @@
   },
   {
     "id": "q73",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the capital of France?",
     "answer": "Paris",
     "acceptableAnswers": [],
     "explanation": "Paris is located on the Seine River and has been France's capital since 987 AD.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Paris",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1225,14 +1459,17 @@
   },
   {
     "id": "q74",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the largest land animal on Earth?",
     "answer": "African Elephant",
     "acceptableAnswers": [],
     "explanation": "Adult male African bush elephants can weigh up to 14,000 pounds (6,350 kg) and stand up to 13 feet tall.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/African_elephant",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1242,14 +1479,17 @@
   },
   {
     "id": "q75",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote the Harry Potter series?",
     "answer": "J.K. Rowling",
     "acceptableAnswers": [],
     "explanation": "J.K. Rowling is a British author who published the first Harry Potter book in 1997.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Harry_Potter",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1259,14 +1499,17 @@
   },
   {
     "id": "q77",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which British rock band released the iconic album 'The Wall' in 1979?",
     "answer": "Pink Floyd",
     "acceptableAnswers": [],
     "explanation": "Pink Floyd is a British rock band formed in London in 1965. 'The Wall' is one of rock's most acclaimed concept albums.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Music"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pink_Floyd",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1283,7 +1526,10 @@
     "acceptableAnswers": [],
     "explanation": "The 2024 Paris Olympics featured 32 sports. The number of sports varies with each Olympic Games.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Sports"],
+    "tags": [
+      "Global",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Summer_Olympic_Games",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1293,14 +1539,17 @@
   },
   {
     "id": "q79",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "Which Canadian province has the highest population?",
     "answer": "Ontario",
     "acceptableAnswers": [],
     "explanation": "Ontario is home to over 15 million people, about 38% of Canada's total population.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ontario",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1310,14 +1559,17 @@
   },
   {
     "id": "q80",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the largest organ in the human body?",
     "answer": "Skin",
     "acceptableAnswers": [],
     "explanation": "The skin covers about 20 square feet in adults and weighs about 8 pounds.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Human_skin",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1327,14 +1579,17 @@
   },
   {
     "id": "q81",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which American actress plays Black Widow in Marvel films?",
     "answer": "Scarlett Johansson",
     "acceptableAnswers": [],
     "explanation": "Scarlett Johansson is an American actress born in New York City. She has played Natasha Romanoff/Black Widow since 2010.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Scarlett_Johansson",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1344,14 +1599,17 @@
   },
   {
     "id": "q82",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What year did the Berlin Wall fall?",
     "answer": "1989",
     "acceptableAnswers": [],
     "explanation": "The Berlin Wall fell on November 9, 1989, symbolizing the end of the Cold War division of Europe.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "History"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Fall_of_the_Berlin_Wall",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1361,14 +1619,20 @@
   },
   {
     "id": "q83",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "What is a Nanaimo bar?",
     "answer": "A chocolate dessert",
-    "acceptableAnswers": ["Chocolate bar", "Canadian candy"],
+    "acceptableAnswers": [
+      "Chocolate bar",
+      "Canadian candy"
+    ],
     "explanation": "It's a no-bake three-layer dessert bar originating from Nanaimo, British Columbia with a custard-flavored middle layer.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nanaimo_bar",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1378,14 +1642,17 @@
   },
   {
     "id": "q84",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the smallest independent country in the world?",
     "answer": "Vatican City",
     "acceptableAnswers": [],
     "explanation": "Vatican City is about 0.44 square kilometers (110 acres), entirely surrounded by Rome, Italy.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Vatican_City",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1402,7 +1669,10 @@
     "acceptableAnswers": [],
     "explanation": "The Toronto Maple Leafs were founded in 1917 and play in the Atlantic Division of the Eastern Conference.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Toronto_Maple_Leafs",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1412,14 +1682,17 @@
   },
   {
     "id": "q86",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'One Hundred Years of Solitude'?",
-    "answer": "Gabriel García Márquez",
+    "answer": "Gabriel Garc\u00eda M\u00e1rquez",
     "acceptableAnswers": [],
-    "explanation": "García Márquez was a Colombian author who won the 1982 Nobel Prize in Literature.",
+    "explanation": "Garc\u00eda M\u00e1rquez was a Colombian author who won the 1982 Nobel Prize in Literature.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/One_Hundred_Years_of_Solitude",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1429,14 +1702,17 @@
   },
   {
     "id": "q87",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What element has the atomic number 1?",
     "answer": "Hydrogen",
     "acceptableAnswers": [],
     "explanation": "Hydrogen is the lightest element and makes up about 75% of all matter in the universe.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hydrogen",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1446,14 +1722,17 @@
   },
   {
     "id": "q88",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which British artist sings 'Watermelon Sugar'?",
     "answer": "Harry Styles",
     "acceptableAnswers": [],
     "explanation": "Harry Styles is a British singer born in Redditch, England. 'Watermelon Sugar' was released in 2019 from his album 'Fine Line'.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Music"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Harry_Styles",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1463,14 +1742,20 @@
   },
   {
     "id": "q89",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which civilization built Machu Picchu?",
     "answer": "Inca Empire",
-    "acceptableAnswers": ["Inca", "Incas"],
+    "acceptableAnswers": [
+      "Inca",
+      "Incas"
+    ],
     "explanation": "Machu Picchu was built by the Inca Empire in the 15th century and later became one of Peru's most famous archaeological sites.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "History"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Machu_Picchu",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1480,14 +1765,17 @@
   },
   {
     "id": "q90",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Italy?",
     "answer": "Rome",
     "acceptableAnswers": [],
-    "explanation": "Rome has been Italy's capital since 1871. It's known as the 'Eternal City' (La Città Eterna).",
+    "explanation": "Rome has been Italy's capital since 1871. It's known as the 'Eternal City' (La Citt\u00e0 Eterna).",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rome",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1497,14 +1785,17 @@
   },
   {
     "id": "q91",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Australian actor played Wolverine in the X-Men films?",
     "answer": "Hugh Jackman",
     "acceptableAnswers": [],
     "explanation": "Hugh Jackman is an Australian actor born in Sydney. He played Wolverine in nine X-Men films from 2000-2024.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hugh_Jackman",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1521,7 +1812,10 @@
     "acceptableAnswers": [],
     "explanation": "De Grasse won three medals: 1 silver and 2 bronze.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Andre_De_Grasse",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1531,14 +1825,17 @@
   },
   {
     "id": "q93",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many legs does a spider have?",
     "answer": "8",
     "acceptableAnswers": [],
     "explanation": "All spiders are arachnids with eight legs.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Spider",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1548,14 +1845,20 @@
   },
   {
     "id": "q94",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What is a Buxton cake?",
     "answer": "A Canadian pastry",
-    "acceptableAnswers": ["Pastry", "Dessert"],
+    "acceptableAnswers": [
+      "Pastry",
+      "Dessert"
+    ],
     "explanation": "A traditional Canadian dessert from the early 20th century.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_cuisine",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1565,14 +1868,17 @@
   },
   {
     "id": "q95",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the rarest blood type?",
     "answer": "Rh-null",
     "acceptableAnswers": [],
     "explanation": "Only a handful of people worldwide have this blood type.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rh_blood_group_system",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1582,14 +1888,17 @@
   },
   {
     "id": "q96",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did Canada get its own flag?",
     "answer": "1965",
     "acceptableAnswers": [],
     "explanation": "The Maple Leaf flag was officially adopted on February 15, 1965.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Flag_of_Canada",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1599,14 +1908,17 @@
   },
   {
     "id": "q97",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the capital of Brazil?",
-    "answer": "Brasília",
+    "answer": "Bras\u00edlia",
     "acceptableAnswers": [],
-    "explanation": "Brasília replaced Rio de Janeiro as the capital in 1960.",
+    "explanation": "Bras\u00edlia replaced Rio de Janeiro as the capital in 1960.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bras%C3%ADlia",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1616,14 +1928,17 @@
   },
   {
     "id": "q98",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Scottish artist sings 'Someone You Loved'?",
     "answer": "Lewis Capaldi",
     "acceptableAnswers": [],
     "explanation": "Lewis Capaldi is a Scottish singer-songwriter from Whitburn, West Lothian. 'Someone You Loved' reached #1 in the UK and US in 2019.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Music"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Lewis_Capaldi",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1633,14 +1948,17 @@
   },
   {
     "id": "q99",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "What streaming service did Netflix originate as?",
     "answer": "DVD rental by mail",
     "acceptableAnswers": [],
     "explanation": "Netflix started in 1997 as a mail-based DVD rental service.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Netflix",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1657,7 +1975,10 @@
     "acceptableAnswers": [],
     "explanation": "Five skaters and one goaltender.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ice_hockey",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1667,14 +1988,17 @@
   },
   {
     "id": "q102",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What gas makes up most of Earth's atmosphere?",
     "answer": "Nitrogen",
     "acceptableAnswers": [],
     "explanation": "Nitrogen comprises about 78% of the air we breathe.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Atmosphere_of_Earth",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1684,14 +2008,17 @@
   },
   {
     "id": "q103",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Which Canadian province has the smallest population?",
     "answer": "Prince Edward Island",
     "acceptableAnswers": [],
     "explanation": "Prince Edward Island has the smallest population of any Canadian province, with approximately 170,000 residents. Note: Nunavut has fewer people but is a territory, not a province.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Prince_Edward_Island",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1701,14 +2028,17 @@
   },
   {
     "id": "q104",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'The Odyssey'?",
     "answer": "Homer",
     "acceptableAnswers": [],
     "explanation": "Homer was an ancient Greek poet.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Odyssey",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1718,14 +2048,17 @@
   },
   {
     "id": "q105",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian actor stars in the TV show 'Letterkenny'?",
     "answer": "Jared Keeso",
     "acceptableAnswers": [],
     "explanation": "Keeso created and stars in the comedy series.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Letterkenny_(TV_series)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1735,14 +2068,17 @@
   },
   {
     "id": "q106",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian artist released the acclaimed album 'Blue' in 1971?",
     "answer": "Joni Mitchell",
     "acceptableAnswers": [],
     "explanation": "Joni Mitchell is a Canadian singer-songwriter from Alberta. 'Blue' (1971) is considered one of the greatest albums of all time. Note: 'Take Me Home' is a Cher album (1979), not Joni Mitchell.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Blue_(Joni_Mitchell_album)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1759,7 +2095,10 @@
     "acceptableAnswers": [],
     "explanation": "Raonic reached the Wimbledon final in 2016.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Milos_Raonic",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1769,14 +2108,17 @@
   },
   {
     "id": "q108",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is butter tart filling made from?",
     "answer": "Butter, brown sugar, and eggs",
     "acceptableAnswers": [],
     "explanation": "This is a traditional Canadian dessert.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Butter_tart",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1786,14 +2128,17 @@
   },
   {
     "id": "q109",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the deepest ocean trench?",
     "answer": "Mariana Trench",
     "acceptableAnswers": [],
     "explanation": "Located in the Western Pacific, it reaches nearly 11 km deep.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mariana_Trench",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1803,14 +2148,17 @@
   },
   {
     "id": "q110",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the symbol for Iron in the periodic table?",
     "answer": "Fe",
     "acceptableAnswers": [],
     "explanation": "Fe comes from the Latin word 'ferrum'.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Iron",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1820,14 +2168,17 @@
   },
   {
     "id": "q111",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did Canada abolish slavery?",
     "answer": "1834",
     "acceptableAnswers": [],
     "explanation": "The Slavery Abolition Act was passed throughout the British Empire.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Slavery_Abolition_Act_1833",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1837,14 +2188,17 @@
   },
   {
     "id": "q112",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the longest river in Canada?",
     "answer": "Mackenzie River",
     "acceptableAnswers": [],
     "explanation": "The Mackenzie River flows through northern Canada.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mackenzie_River",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1854,14 +2208,17 @@
   },
   {
     "id": "q113",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Barbadian musician performed at the Super Bowl LVII halftime show in 2023?",
     "answer": "Rihanna",
     "acceptableAnswers": [],
     "explanation": "Rihanna is from Saint Michael, Barbados. She performed at Super Bowl LVII in Glendale, Arizona on February 12, 2023.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Super_Bowl_LVII_halftime_show",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1878,7 +2235,10 @@
     "acceptableAnswers": [],
     "explanation": "The Canucks have been a major NHL team since then.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Vancouver_Canucks",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1888,14 +2248,17 @@
   },
   {
     "id": "q115",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote 'Alice in Wonderland'?",
     "answer": "Lewis Carroll",
     "acceptableAnswers": [],
     "explanation": "The British author created the iconic tale.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Alice%27s_Adventures_in_Wonderland",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1905,14 +2268,17 @@
   },
   {
     "id": "q116",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the boiling point of water in Fahrenheit?",
     "answer": "212",
     "acceptableAnswers": [],
-    "explanation": "At sea level, water boils at 212°F or 100°C.",
+    "explanation": "At sea level, water boils at 212\u00b0F or 100\u00b0C.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Boiling_point",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1922,14 +2288,17 @@
   },
   {
     "id": "q117",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian band performed at Live Aid in 1985?",
     "answer": "Rush",
     "acceptableAnswers": [],
     "explanation": "The prog rock band is from Toronto.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Rush_(band)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1939,14 +2308,17 @@
   },
   {
     "id": "q118",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Japan?",
     "answer": "Tokyo",
     "acceptableAnswers": [],
     "explanation": "Tokyo is the most populous metropolitan area in the world.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tokyo",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1956,14 +2328,17 @@
   },
   {
     "id": "q119",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the fastest land animal?",
     "answer": "Cheetah",
     "acceptableAnswers": [],
     "explanation": "Cheetahs can reach speeds of over 70 mph.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Cheetah",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1973,14 +2348,17 @@
   },
   {
     "id": "q120",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "What is a Beaver Tail in Canadian cuisine?",
     "answer": "A pastry dessert",
     "acceptableAnswers": [],
     "explanation": "It's a fried dough pastry traditionally served at Canadian fairs.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/BeaverTails",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -1990,14 +2368,17 @@
   },
   {
     "id": "q121",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian show aired on Nickelodeon called 'Drake & Josh'?",
     "answer": "Actually American",
     "acceptableAnswers": [],
     "explanation": "Despite some Canadian involvement, it's primarily American.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Drake_%26_Josh",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2007,14 +2388,17 @@
   },
   {
     "id": "q122",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "When was the Canadian Constitution patriated?",
     "answer": "1982",
     "acceptableAnswers": [],
     "explanation": "Canada officially adopted its own constitution on April 17, 1982.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Patriation",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2031,7 +2415,10 @@
     "acceptableAnswers": [],
     "explanation": "Tennis is played on courts worldwide.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Sports"],
+    "tags": [
+      "Global",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tennis",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2041,14 +2428,17 @@
   },
   {
     "id": "q124",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the most abundant element in the universe?",
     "answer": "Hydrogen",
     "acceptableAnswers": [],
     "explanation": "Hydrogen makes up about 75% of all matter.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hydrogen",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2058,14 +2448,17 @@
   },
   {
     "id": "q125",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the capital of New Zealand?",
     "answer": "Wellington",
     "acceptableAnswers": [],
     "explanation": "Despite being smaller than Auckland, Wellington is the capital.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Wellington",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2075,14 +2468,17 @@
   },
   {
     "id": "q126",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'The Great Gatsby'?",
     "answer": "F. Scott Fitzgerald",
     "acceptableAnswers": [],
     "explanation": "Fitzgerald wrote this American classic in 1925.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Great_Gatsby",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2092,14 +2488,17 @@
   },
   {
     "id": "q127",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which Canadian jazz pianist was nicknamed the 'Maharaja of the keyboard'?",
     "answer": "Oscar Peterson",
     "acceptableAnswers": [],
     "explanation": "Oscar Peterson, born in Montreal, was a legendary Canadian jazz pianist known as the 'Maharaja of the keyboard.'",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Oscar_Peterson",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2109,14 +2508,17 @@
   },
   {
     "id": "q128",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian actor is known for 'Trailer Park Boys'?",
     "answer": "Robb Wells",
     "acceptableAnswers": [],
     "explanation": "Robb Wells plays Ricky in the comedy series. Mike Smith plays Bubbles, and John Paul Tremblay plays Julian.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Robb_Wells",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2133,7 +2535,10 @@
     "acceptableAnswers": [],
     "explanation": "Canada hosted the Summer Olympics once, in Montreal in 1976. Vancouver 2010 was the Winter Olympics.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/1976_Summer_Olympics",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2143,14 +2548,17 @@
   },
   {
     "id": "q130",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What ingredient makes Canadian bacon different from regular bacon?",
     "answer": "It comes from pork loin",
     "acceptableAnswers": [],
     "explanation": "Canadian bacon is back bacon from the loin, not belly.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Back_bacon",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2160,14 +2568,17 @@
   },
   {
     "id": "q131",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What year was the Canadian flag officially adopted?",
     "answer": "1965",
     "acceptableAnswers": [],
     "explanation": "The maple leaf flag replaced the Union Jack on February 15.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Flag_of_Canada",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2177,14 +2588,17 @@
   },
   {
     "id": "q132",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the freezing point of water in Celsius?",
     "answer": "0",
     "acceptableAnswers": [],
-    "explanation": "Water freezes at 0°C or 32°F.",
+    "explanation": "Water freezes at 0\u00b0C or 32\u00b0F.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Melting_point",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2194,14 +2608,17 @@
   },
   {
     "id": "q133",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "Which Canadian city is farthest north?",
     "answer": "Alert",
     "acceptableAnswers": [],
     "explanation": "Alert, Nunavut is the northernmost settlement.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Alert,_Nunavut",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2211,14 +2628,17 @@
   },
   {
     "id": "q134",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many species of bears are there?",
     "answer": "8",
     "acceptableAnswers": [],
     "explanation": "Including polar, grizzly, black, panda, and others.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bear",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2228,14 +2648,17 @@
   },
   {
     "id": "q135",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Who created the TV series 'The X-Files'?",
     "answer": "Chris Carter",
     "acceptableAnswers": [],
     "explanation": "Chris Carter is an American writer and producer born in Bellflower, California. He created The X-Files in 1993.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "Entertainment"],
+    "tags": [
+      "US",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Chris_Carter_(screenwriter)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2245,14 +2668,17 @@
   },
   {
     "id": "q136",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian band is known for 'Smells Like Teen Spirit'?",
     "answer": "Not a Canadian band",
     "acceptableAnswers": [],
     "explanation": "Nirvana was from Seattle, Washington.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Music"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nirvana_(band)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2269,7 +2695,10 @@
     "acceptableAnswers": [],
     "explanation": "Canada has hosted the Winter Olympics twice: Calgary in 1988 and Vancouver in 2010.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canada_at_the_Winter_Olympics",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2279,14 +2708,17 @@
   },
   {
     "id": "q138",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'Crime and Punishment'?",
     "answer": "Fyodor Dostoevsky",
     "acceptableAnswers": [],
     "explanation": "The Russian author wrote this psychological novel.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Crime_and_Punishment",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2296,14 +2728,17 @@
   },
   {
     "id": "q139",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "How many provinces and territories does Canada have?",
     "answer": "13",
     "acceptableAnswers": [],
     "explanation": "10 provinces and 3 territories.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Provinces_and_territories_of_Canada",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2313,14 +2748,17 @@
   },
   {
     "id": "q140",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the chemical formula for table salt?",
     "answer": "NaCl",
     "acceptableAnswers": [],
     "explanation": "Sodium chloride is the most common salt.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sodium_chloride",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2330,14 +2768,17 @@
   },
   {
     "id": "q141",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "In which year did Canada gain independence from Britain?",
     "answer": "1867",
     "acceptableAnswers": [],
     "explanation": "Confederation in 1867 marked the creation of the Dominion.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_Confederation",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2347,14 +2788,17 @@
   },
   {
     "id": "q142",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian actor played Deadpool?",
     "answer": "Ryan Reynolds",
     "acceptableAnswers": [],
     "explanation": "Reynolds is from Vancouver and starred in the Marvel films.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ryan_Reynolds",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2364,14 +2808,17 @@
   },
   {
     "id": "q143",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "What country is known for sushi?",
     "answer": "Japan",
     "acceptableAnswers": [],
     "explanation": "Sushi originated in Japan centuries ago.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Food"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Sushi",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2388,7 +2835,10 @@
     "acceptableAnswers": [],
     "explanation": "Eight players in the field plus a pitcher.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Sports"],
+    "tags": [
+      "Global",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Baseball",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2398,14 +2848,17 @@
   },
   {
     "id": "q145",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the tallest living tree?",
     "answer": "Hyperion",
     "acceptableAnswers": [],
     "explanation": "Hyperion is a coast redwood in California.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hyperion_(tree)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2415,14 +2868,17 @@
   },
   {
     "id": "q146",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian singer-songwriter released 'Blue'?",
     "answer": "Joni Mitchell",
     "acceptableAnswers": [],
     "explanation": "This iconic 1971 album is considered one of the greatest albums of all time.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Blue_(Joni_Mitchell_album)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2432,14 +2888,17 @@
   },
   {
     "id": "q147",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the second-largest country in the world by area?",
     "answer": "Canada",
     "acceptableAnswers": [],
     "explanation": "Only Russia is larger.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/List_of_countries_and_dependencies_by_area",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2449,14 +2908,17 @@
   },
   {
     "id": "q148",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote 'Pride and Prejudice'?",
     "answer": "Jane Austen",
     "acceptableAnswers": [],
     "explanation": "Austen was a British novelist from the 19th century.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pride_and_Prejudice",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2466,14 +2928,17 @@
   },
   {
     "id": "q149",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "How many planets are in our solar system?",
     "answer": "8",
     "acceptableAnswers": [],
     "explanation": "Pluto was reclassified as a dwarf planet in 2006.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Solar_System",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2483,14 +2948,17 @@
   },
   {
     "id": "q150",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which American actor voices Metro Man in 'Megamind'?",
     "answer": "Brad Pitt",
     "acceptableAnswers": [],
     "explanation": "Brad Pitt is an American actor from Shawnee, Oklahoma. He voiced Metro Man in the 2010 animated film 'Megamind'.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Megamind",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2507,7 +2975,10 @@
     "acceptableAnswers": [],
     "explanation": "Brad Gushue won gold in men's curling at the 2006 Turin Olympics, becoming the first Newfoundlander to win Olympic gold. He also won bronze at the 2022 Beijing Olympics.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Brad_Gushue",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2517,14 +2988,17 @@
   },
   {
     "id": "q152",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What year did Canada approve same-sex marriage?",
     "answer": "2005",
     "acceptableAnswers": [],
     "explanation": "Canada was the fourth country to legalize same-sex marriage.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Same-sex_marriage_in_Canada",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2534,14 +3008,17 @@
   },
   {
     "id": "q153",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is Montreal-style bagel?",
     "answer": "A boiled and baked bagel",
     "acceptableAnswers": [],
     "explanation": "Montreal bagels are smaller and sweeter than New York bagels.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Montreal-style_bagel",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2551,14 +3028,17 @@
   },
   {
     "id": "q154",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the most common element in the Earth's crust?",
     "answer": "Oxygen",
     "acceptableAnswers": [],
     "explanation": "Oxygen makes up about 46% of Earth's crust.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Abundance_of_elements_in_Earth%27s_crust",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2568,14 +3048,17 @@
   },
   {
     "id": "q155",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the smallest province in Canada by area?",
     "answer": "Prince Edward Island",
     "acceptableAnswers": [],
     "explanation": "PEI is only about 5,600 square kilometers.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Prince_Edward_Island",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2585,14 +3068,17 @@
   },
   {
     "id": "q156",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which Canadian musician won a Grammy for 'Immigrant Song'?",
     "answer": "Not a Canadian",
     "acceptableAnswers": [],
     "explanation": "Led Zeppelin's 'Immigrant Song' was by a British band.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Music"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Immigrant_Song",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2602,14 +3088,17 @@
   },
   {
     "id": "q157",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which American actor starred as Percy Jackson in the original film series?",
     "answer": "Logan Lerman",
     "acceptableAnswers": [],
     "explanation": "Logan Lerman is an American actor from Beverly Hills, California. He starred in 'Percy Jackson & the Olympians: The Lightning Thief' (2010) and its sequel.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Logan_Lerman",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2619,14 +3108,20 @@
   },
   {
     "id": "q158",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What type of mammal lays eggs?",
     "answer": "Monotreme",
-    "acceptableAnswers": ["Platypus", "Echidna"],
+    "acceptableAnswers": [
+      "Platypus",
+      "Echidna"
+    ],
     "explanation": "Monotremes are egg-laying mammals. There are five species: the platypus and four species of echidna. All are found in Australia and New Guinea.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Monotreme",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2636,14 +3131,17 @@
   },
   {
     "id": "q159",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'The Catcher in the Rye'?",
     "answer": "J.D. Salinger",
     "acceptableAnswers": [],
     "explanation": "Salinger wrote this classic American novel.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Catcher_in_the_Rye",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2660,7 +3158,10 @@
     "acceptableAnswers": [],
     "explanation": "Elvis Stojko won silver medals at both the 1994 Lillehammer and 1998 Nagano Olympics. He is a three-time World champion (1994, 1995, 1997).",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Sports"],
+    "tags": [
+      "CA",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Elvis_Stojko",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2670,14 +3171,17 @@
   },
   {
     "id": "q161",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What year did World War II end?",
     "answer": "1945",
     "acceptableAnswers": [],
     "explanation": "Japan surrendered in September 1945.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "History"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/World_War_II",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2687,14 +3191,17 @@
   },
   {
     "id": "q162",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Mexico?",
     "answer": "Mexico City",
     "acceptableAnswers": [],
     "explanation": "Mexico City is one of the largest cities in the world.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mexico_City",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2704,14 +3211,17 @@
   },
   {
     "id": "q163",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the symbol for Silver in the periodic table?",
     "answer": "Ag",
     "acceptableAnswers": [],
     "explanation": "Ag comes from the Latin word 'argentum'.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Silver",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2721,14 +3231,17 @@
   },
   {
     "id": "q164",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which British-American director made 'Inception' and 'The Dark Knight' trilogy?",
     "answer": "Christopher Nolan",
     "acceptableAnswers": [],
     "explanation": "Christopher Nolan was born in London, England and holds dual British-American citizenship. He is known for films like 'Inception', 'Interstellar', and 'The Dark Knight' trilogy.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Christopher_Nolan",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2738,14 +3251,17 @@
   },
   {
     "id": "q165",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian band released 'Hotel California'?",
     "answer": "Not a Canadian band",
     "acceptableAnswers": [],
     "explanation": "The Eagles were an American rock band.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Music"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hotel_California_(Eagles_album)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2755,14 +3271,17 @@
   },
   {
     "id": "q166",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What is Poutine Royale?",
     "answer": "Poutine with gravy and meat",
     "acceptableAnswers": [],
     "explanation": "A variation of poutine with added protein.",
     "pillar": "GreatOutdoors",
-    "tags": ["CA", "Food"],
+    "tags": [
+      "CA",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Poutine",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2779,7 +3298,10 @@
     "acceptableAnswers": [],
     "explanation": "Including the goalkeeper.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Sports"],
+    "tags": [
+      "Global",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Association_football",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2789,14 +3311,19 @@
   },
   {
     "id": "q168",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Which four provinces formed Canada at Confederation in 1867?",
     "answer": "Ontario, Quebec, Nova Scotia, New Brunswick",
-    "acceptableAnswers": ["Ontario, Quebec, New Brunswick, Nova Scotia"],
+    "acceptableAnswers": [
+      "Ontario, Quebec, New Brunswick, Nova Scotia"
+    ],
     "explanation": "On July 1, 1867, Ontario, Quebec, Nova Scotia, and New Brunswick united to form the Dominion of Canada. Ontario and Quebec were created from the former Province of Canada.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canadian_Confederation",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2806,14 +3333,17 @@
   },
   {
     "id": "q169",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What do you call a baby kangaroo?",
     "answer": "Joey",
     "acceptableAnswers": [],
     "explanation": "Young kangaroos are called joeys.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Kangaroo",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2823,14 +3353,17 @@
   },
   {
     "id": "q170",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'War and Peace'?",
     "answer": "Leo Tolstoy",
     "acceptableAnswers": [],
     "explanation": "Tolstoy was a Russian author.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/War_and_Peace",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2840,14 +3373,17 @@
   },
   {
     "id": "q171",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "What is the westernmost province of Canada?",
     "answer": "British Columbia",
     "acceptableAnswers": [],
     "explanation": "BC is on the Pacific coast.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/British_Columbia",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2857,14 +3393,17 @@
   },
   {
     "id": "q172",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is DNA?",
     "answer": "Deoxyribonucleic acid",
     "acceptableAnswers": [],
     "explanation": "DNA carries genetic instructions for life.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/DNA",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2874,14 +3413,17 @@
   },
   {
     "id": "q173",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which British actor played Batman in 'The Dark Knight' trilogy?",
     "answer": "Christian Bale",
     "acceptableAnswers": [],
     "explanation": "Christian Bale was born in Haverfordwest, Wales. He played Batman in Christopher Nolan's Dark Knight trilogy (2005-2012). Note: Bale was NOT in 'Inception' - that film starred Leonardo DiCaprio.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "Entertainment"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Christian_Bale",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2891,14 +3433,17 @@
   },
   {
     "id": "q174",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian musician was part of Nickelback?",
     "answer": "Chad Kroeger",
     "acceptableAnswers": [],
     "explanation": "Chad Kroeger is the lead singer of Nickelback. He was born and raised in Hanna, Alberta, where the band formed in 1995. They later relocated to Vancouver, British Columbia.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nickelback",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2915,7 +3460,10 @@
     "acceptableAnswers": [],
     "explanation": "The NHL expanded to 32 teams in recent years.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Sports"],
+    "tags": [
+      "Global",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/National_Hockey_League",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2925,14 +3473,17 @@
   },
   {
     "id": "q176",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Which dish was declared Britain's 'true national dish' by Foreign Secretary Robin Cook in 2001?",
     "answer": "Chicken Tikka Masala",
     "acceptableAnswers": [],
     "explanation": "Chicken Tikka Masala was declared a 'true British national dish' by UK Foreign Secretary Robin Cook in 2001. It was likely invented in Glasgow, Scotland in the 1970s. India has no official national dish.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Food"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://www.britannica.com/topic/chicken-tikka-masala",
     "sourceName": "Britannica",
     "status": "approved",
@@ -2942,14 +3493,17 @@
   },
   {
     "id": "q177",
-    "category": "History",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What year did Canada join the United Nations?",
     "answer": "1945",
     "acceptableAnswers": [],
     "explanation": "Canada was a founding member of the UN.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "History"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Canada_and_the_United_Nations",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2959,14 +3513,17 @@
   },
   {
     "id": "q178",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "How many legs does an octopus have?",
     "answer": "8",
     "acceptableAnswers": [],
     "explanation": "All octopuses have eight arms/legs.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Octopus",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2976,14 +3533,17 @@
   },
   {
     "id": "q179",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Who wrote 'The Lord of the Rings'?",
     "answer": "J.R.R. Tolkien",
     "acceptableAnswers": [],
     "explanation": "Tolkien was a British author and philologist.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Lord_of_the_Rings",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -2993,14 +3553,17 @@
   },
   {
     "id": "q180",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Medium",
     "question": "What is the easternmost province of Canada?",
     "answer": "Newfoundland and Labrador",
     "acceptableAnswers": [],
     "explanation": "It is the most eastern point of North America.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "Geography"],
+    "tags": [
+      "CA",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Newfoundland_and_Labrador",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3010,14 +3573,17 @@
   },
   {
     "id": "q181",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What does RNA stand for?",
     "answer": "Ribonucleic acid",
     "acceptableAnswers": [],
     "explanation": "RNA is a key molecule in all living cells.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/RNA",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3027,14 +3593,17 @@
   },
   {
     "id": "q182",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian actress stars in 'Orphan Black'?",
     "answer": "Tatiana Maslany",
     "acceptableAnswers": [],
     "explanation": "Tatiana Maslany is from Regina, Saskatchewan. She won an Emmy Award for Outstanding Lead Actress in a Drama Series in 2016 for 'Orphan Black', plus two Critics' Choice Awards and five Canadian Screen Awards. She was nominated for a Golden Globe in 2014 but did not win.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tatiana_Maslany",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3044,14 +3613,17 @@
   },
   {
     "id": "q183",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which British rock band is known for the album 'Absolution' and songs like 'Hysteria'?",
     "answer": "Muse",
     "acceptableAnswers": [],
     "explanation": "Muse is a British rock band formed in Teignmouth, Devon, England in 1994. 'Hysteria' is from their 2003 album 'Absolution'.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "Music"],
+    "tags": [
+      "Global",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Muse_(band)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3068,7 +3640,10 @@
     "acceptableAnswers": [],
     "explanation": "Each period lasts 20 minutes.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Sports"],
+    "tags": [
+      "Global",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Ice_hockey",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3078,14 +3653,17 @@
   },
   {
     "id": "q185",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "What is the main ingredient in hummus?",
     "answer": "Chickpeas",
     "acceptableAnswers": [],
     "explanation": "Hummus is made from pureed chickpeas.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Food"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Hummus",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3095,14 +3673,17 @@
   },
   {
     "id": "q187",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Hard",
     "question": "What is the smallest bird in the world?",
     "answer": "Bee hummingbird",
     "acceptableAnswers": [],
     "explanation": "It weighs less than 2 grams.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Bee_hummingbird",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3112,14 +3693,17 @@
   },
   {
     "id": "q188",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who wrote 'Jane Eyre'?",
-    "answer": "Charlotte Brontë",
+    "answer": "Charlotte Bront\u00eb",
     "acceptableAnswers": [],
-    "explanation": "Brontë was a British novelist.",
+    "explanation": "Bront\u00eb was a British novelist.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Jane_Eyre",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3129,14 +3713,17 @@
   },
   {
     "id": "q189",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Hard",
     "question": "Which Asian country has the same name as its capital city?",
     "answer": "Singapore",
     "acceptableAnswers": [],
     "explanation": "Singapore is both a city and a country.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Singapore",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3146,14 +3733,17 @@
   },
   {
     "id": "q190",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Easy",
     "question": "What is the chemical symbol for Copper?",
     "answer": "Cu",
     "acceptableAnswers": [],
     "explanation": "Cu comes from the Latin word 'cuprum'.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Copper",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3163,14 +3753,17 @@
   },
   {
     "id": "q191",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which Canadian filmmaker directed 'Telefilm'?",
     "answer": "David Cronenberg",
     "acceptableAnswers": [],
     "explanation": "Cronenberg is a legendary Canadian director.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/David_Cronenberg",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3180,14 +3773,17 @@
   },
   {
     "id": "q192",
-    "category": "Music",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian musician released 'I'm Like a Bird'?",
     "answer": "Nelly Furtado",
     "acceptableAnswers": [],
     "explanation": "Furtado is from Victoria, BC.",
     "pillar": "FreshPrints",
-    "tags": ["CA", "Music"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nelly_Furtado",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3204,7 +3800,10 @@
     "acceptableAnswers": [],
     "explanation": "Standard golf courses have 18 holes.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Sports"],
+    "tags": [
+      "Global",
+      "Sports"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Golf_course",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3214,14 +3813,17 @@
   },
   {
     "id": "q194",
-    "category": "Food",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "What is the main ingredient in tempura?",
     "answer": "Battered and fried",
     "acceptableAnswers": [],
     "explanation": "Tempura is a Japanese battered and deep-fried dish.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Food"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Tempura",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3231,14 +3833,17 @@
   },
   {
     "id": "q196",
-    "category": "Nature",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the largest reptile in the world?",
     "answer": "Saltwater crocodile",
     "acceptableAnswers": [],
     "explanation": "They can reach lengths of over 20 feet.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Nature"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Saltwater_crocodile",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3248,14 +3853,17 @@
   },
   {
     "id": "q197",
-    "category": "Literature",
+    "category": "Food & Culture",
     "difficulty": "Hard",
     "question": "Who wrote 'Moby Dick'?",
     "answer": "Herman Melville",
     "acceptableAnswers": [],
     "explanation": "Melville wrote this American epic.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Literature"],
+    "tags": [
+      "Global",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Moby-Dick",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3265,14 +3873,17 @@
   },
   {
     "id": "q198",
-    "category": "Geography",
+    "category": "History & Geography",
     "difficulty": "Easy",
     "question": "What is the capital of Spain?",
     "answer": "Madrid",
     "acceptableAnswers": [],
     "explanation": "Madrid is the largest city in Spain.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Geography"],
+    "tags": [
+      "Global",
+      "History & Geography"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Madrid",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3282,14 +3893,17 @@
   },
   {
     "id": "q199",
-    "category": "Science",
+    "category": "Science & Nature",
     "difficulty": "Medium",
     "question": "What is the process by which plants make their own food?",
     "answer": "Photosynthesis",
     "acceptableAnswers": [],
     "explanation": "Plants convert sunlight into chemical energy.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "Science"],
+    "tags": [
+      "Global",
+      "Science & Nature"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Photosynthesis",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3299,14 +3913,17 @@
   },
   {
     "id": "q200",
-    "category": "Entertainment",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which Canadian actor is known for 'Degrassi'?",
     "answer": "Nina Dobrev",
     "acceptableAnswers": [],
     "explanation": "Dobrev played Mia in the Canadian teen drama.",
     "pillar": "TimeCapsule",
-    "tags": ["CA", "Entertainment"],
+    "tags": [
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Nina_Dobrev",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3316,20 +3933,27 @@
   },
   {
     "id": "5b7a9b70-d0c4-4f02-b244-41d1684ea5b9",
-    "category": "pop culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "What artist broke the record for most Grammy awards in history in 2023?",
-    "answer": "Beyoncé",
-    "acceptableAnswers": ["Beyoncé", "Beyonce"],
-    "explanation": "Beyoncé set a new record for the most Grammy wins in 2023, showcasing her immense achievements in music and pop culture.",
+    "answer": "Beyonc\u00e9",
+    "acceptableAnswers": [
+      "Beyonc\u00e9",
+      "Beyonce"
+    ],
+    "explanation": "Beyonc\u00e9 set a new record for the most Grammy wins in 2023, showcasing her immense achievements in music and pop culture.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.grammy.com/",
     "sourceName": "Grammy",
     "status": "approved",
     "aiAnalysis": {
       "factCheck": {
-        "reason": "Beyoncé indeed set the record for the most Grammy wins in history at the 2023 Grammy Awards.",
+        "reason": "Beyonc\u00e9 indeed set the record for the most Grammy wins in history at the 2023 Grammy Awards.",
         "verdict": "pass",
         "confidence": 100
       },
@@ -3348,14 +3972,21 @@
   },
   {
     "id": "b9326882-7d7f-4645-a435-d9e0827d3a94",
-    "category": "pop culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Marvel superhero movie became the highest-grossing movie of all time in 2019?",
     "answer": "Avengers: Endgame",
-    "acceptableAnswers": ["Avengers: Endgame", "Endgame"],
-    "explanation": "'Avengers: Endgame' dethroned 'Avatar' in 2019 as the highest-grossing movie globally, solidifying Marvel’s dominance in pop culture.",
+    "acceptableAnswers": [
+      "Avengers: Endgame",
+      "Endgame"
+    ],
+    "explanation": "'Avengers: Endgame' dethroned 'Avatar' in 2019 as the highest-grossing movie globally, solidifying Marvel\u2019s dominance in pop culture.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.boxofficemojo.com/",
     "sourceName": "Box Office Mojo",
     "status": "approved",
@@ -3380,14 +4011,20 @@
   },
   {
     "id": "326319af-bcd9-47d0-bb90-8fd9419a70d0",
-    "category": "pop culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "The famous Kardashian family launched their reality TV show in which year?",
     "answer": "2007",
-    "acceptableAnswers": ["2007"],
+    "acceptableAnswers": [
+      "2007"
+    ],
     "explanation": "'Keeping Up with the Kardashians' first aired in 2007, making the Kardashians a household name across pop culture.",
     "pillar": "FreshPrints",
-    "tags": ["US", "FreshPrints"],
+    "tags": [
+      "US",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.eonline.com/",
     "sourceName": "E! Online",
     "status": "approved",
@@ -3412,14 +4049,20 @@
   },
   {
     "id": "1e3cc8ed-7105-4a64-bbc7-97b19f573e8d",
-    "category": "pop culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which popular streaming service released the hit show 'Stranger Things'?",
     "answer": "Netflix",
-    "acceptableAnswers": ["Netflix"],
+    "acceptableAnswers": [
+      "Netflix"
+    ],
     "explanation": "'Stranger Things' is one of Netflix's most successful original series, known for its 1980s nostalgia and supernatural themes.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": null,
     "sourceName": null,
     "status": "approved",
@@ -3451,14 +4094,21 @@
   },
   {
     "id": "b1d8456f-78c3-493b-82ff-877c4912e627",
-    "category": "Pop Culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which 1990s TV show starred Will Smith as a young man from West Philadelphia sent to live with his wealthy relatives in Bel-Air?",
     "answer": "The Fresh Prince of Bel-Air",
-    "acceptableAnswers": ["Fresh Prince", "The Fresh Prince of Bel-Air"],
+    "acceptableAnswers": [
+      "Fresh Prince",
+      "The Fresh Prince of Bel-Air"
+    ],
     "explanation": "The show 'The Fresh Prince of Bel-Air' was a sitcom that aired from 1990 to 1996, starring Will Smith. It became an iconic part of pop culture and highlighted numerous social themes through humor and drama.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Fresh_Prince_of_Bel-Air",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3490,14 +4140,22 @@
   },
   {
     "id": "b7a5e361-e21a-4f7f-958f-01824c7d2c43",
-    "category": "Pop Culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which TV show popularized the phrase 'pivot!' during a comedic furniture-moving scene?",
     "answer": "Friends",
-    "acceptableAnswers": ["Friends", "Friends TV show"],
+    "acceptableAnswers": [
+      "Friends",
+      "Friends TV show"
+    ],
     "explanation": "The phrase 'pivot!' became a popular meme after a hilarious scene in Friends where Ross tries to move a sofa upstairs.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "TimeCapsule", "TV"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "TV",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.imdb.com/title/tt0108778/",
     "sourceName": "IMDb",
     "status": "approved",
@@ -3522,14 +4180,21 @@
   },
   {
     "id": "dae14391-12d2-41e3-a466-cf307f257640",
-    "category": "Pop Culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which famous album released in 1982 remains the best-selling album of all time?",
     "answer": "Thriller",
-    "acceptableAnswers": ["Thriller", "Michael Jackson's Thriller"],
+    "acceptableAnswers": [
+      "Thriller",
+      "Michael Jackson's Thriller"
+    ],
     "explanation": "Michael Jackson's Thriller, released in 1982, is widely regarded as one of the greatest albums ever and holds the record for best-selling album globally.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "Music"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.riaa.com/",
     "sourceName": "RIAA",
     "status": "approved",
@@ -3561,14 +4226,21 @@
   },
   {
     "id": "d9f32768-6afd-4a82-9444-3dfebc8234b8",
-    "category": "pop culture",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which famous music festival, often regarded as a symbol of outdoor communal experiences, first took place in 1969 in New York state?",
     "answer": "Woodstock",
-    "acceptableAnswers": ["Woodstock", "The Woodstock Festival"],
+    "acceptableAnswers": [
+      "Woodstock",
+      "The Woodstock Festival"
+    ],
     "explanation": "The Woodstock Festival, held in August 1969, became a cultural milestone representing peace, love, and music. Over 400,000 people gathered outdoors for the iconic event.",
     "pillar": "GreatOutdoors",
-    "tags": ["US", "GreatOutdoors"],
+    "tags": [
+      "US",
+      "GreatOutdoors",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.history.com/topics/1960s/woodstock",
     "sourceName": "History.com",
     "status": "approved",
@@ -3597,10 +4269,18 @@
     "difficulty": "Hard",
     "question": "What Canadian company was credited for inventing the first practical quantum computer in 2007?",
     "answer": "D-Wave Systems",
-    "acceptableAnswers": ["D-Wave", "D-Wave Systems"],
+    "acceptableAnswers": [
+      "D-Wave",
+      "D-Wave Systems"
+    ],
     "explanation": "D-Wave Systems, based in Canada, developed the first commercially available quantum computer in 2007, marking a significant advancement in quantum computing technology.",
     "pillar": "GlobalEh",
-    "tags": ["CA", "GlobalEh", "quantum computing", "technology"],
+    "tags": [
+      "CA",
+      "GlobalEh",
+      "quantum computing",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/D-Wave_Systems",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3629,10 +4309,17 @@
     "difficulty": "Easy",
     "question": "What is the name of the world's first general-purpose electronic computer?",
     "answer": "ENIAC",
-    "acceptableAnswers": ["Electronic Numerical Integrator and Computer", "ENIAC"],
+    "acceptableAnswers": [
+      "Electronic Numerical Integrator and Computer",
+      "ENIAC"
+    ],
     "explanation": "The ENIAC, short for Electronic Numerical Integrator and Computer, was developed in 1945 and is considered the first general-purpose electronic computer. It was used initially by the US Army for calculating artillery firing tables.",
     "pillar": "FreshPrints",
-    "tags": ["Technology", "Global", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Technology"
+    ],
     "sourceUrl": "https://www.britannica.com/technology/ENIAC",
     "sourceName": "Britannica",
     "status": "approved",
@@ -3653,10 +4340,17 @@
     "difficulty": "Medium",
     "question": "Which company developed the Android operating system before it was acquired by Google?",
     "answer": "Android Inc.",
-    "acceptableAnswers": ["Android Inc.", "Android Incorporated"],
+    "acceptableAnswers": [
+      "Android Inc.",
+      "Android Incorporated"
+    ],
     "explanation": "The Android operating system was initially developed by Android Inc. in 2003. The company was later acquired by Google in 2005 to expand its mobile technology efforts.",
     "pillar": "FreshPrints",
-    "tags": ["Technology", "Global", "FreshPrints"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Technology"
+    ],
     "sourceUrl": "https://www.britannica.com/technology/Android-operating-system",
     "sourceName": "Britannica",
     "status": "approved",
@@ -3673,14 +4367,21 @@
   },
   {
     "id": "3bd7cd9c-f053-47cd-8b44-f4bb9e2910cb",
-    "category": "technology",
+    "category": "Technology",
     "difficulty": "Hard",
     "question": "What was the primary programming language used to create the original World Wide Web?",
     "answer": "HTML",
-    "acceptableAnswers": ["HTML", "HyperText Markup Language"],
+    "acceptableAnswers": [
+      "HTML",
+      "HyperText Markup Language"
+    ],
     "explanation": "HTML (HyperText Markup Language) was developed by Tim Berners-Lee in 1991 as the foundation for the World Wide Web, allowing the creation and linking of web pages.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/HTML",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3705,14 +4406,21 @@
   },
   {
     "id": "b631df87-5c95-4b8b-93c4-99c14e4a4b5c",
-    "category": "technology",
+    "category": "Technology",
     "difficulty": "Medium",
     "question": "What technology is commonly used in outdoor navigation and relies on a network of orbiting satellites to determine location?",
     "answer": "Global Positioning System (GPS)",
-    "acceptableAnswers": ["GPS", "Global Positioning System"],
+    "acceptableAnswers": [
+      "GPS",
+      "Global Positioning System"
+    ],
     "explanation": "GPS, or Global Positioning System, is a satellite-based navigation system that provides geolocation and time information to a GPS receiver anywhere on or near the Earth where there is an unobstructed line of sight to four or more GPS satellites.",
     "pillar": "GreatOutdoors",
-    "tags": ["Global", "GreatOutdoors"],
+    "tags": [
+      "Global",
+      "GreatOutdoors",
+      "Technology"
+    ],
     "sourceUrl": "https://www.nasa.gov/directorates/heo/scan/communications/policy/GPS_history",
     "sourceName": "NASA",
     "status": "approved",
@@ -3737,14 +4445,20 @@
   },
   {
     "id": "a1e5c510-8e98-4289-8b6d-a565739c0e1b",
-    "category": "technology",
+    "category": "Technology",
     "difficulty": "Easy",
     "question": "What year was the first iPhone released?",
     "answer": "2007",
-    "acceptableAnswers": ["2007"],
+    "acceptableAnswers": [
+      "2007"
+    ],
     "explanation": "Apple released the first iPhone on June 29, 2007, revolutionizing the smartphone industry with its touchscreen interface and app ecosystem.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/IPhone_(1st_generation)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3773,10 +4487,18 @@
     "difficulty": "Medium",
     "question": "What is the name of the programming language created by Guido van Rossum in 1991 that emphasizes readability and simplicity?",
     "answer": "Python",
-    "acceptableAnswers": ["Python", "python programming language"],
+    "acceptableAnswers": [
+      "Python",
+      "python programming language"
+    ],
     "explanation": "Python is a popular programming language designed by Guido van Rossum in 1991, known for its readable syntax and ease of use. It is widely used in web development, data science, and automation.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh", "programming", "technology"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "programming",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Python_(programming_language)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3805,10 +4527,18 @@
     "difficulty": "Easy",
     "question": "Which company co-founded by Steve Jobs introduced the first iPhone in 2007?",
     "answer": "Apple",
-    "acceptableAnswers": ["Apple", "Apple Inc."],
+    "acceptableAnswers": [
+      "Apple",
+      "Apple Inc."
+    ],
     "explanation": "Apple, co-founded by Steve Jobs, launched the first iPhone in 2007, revolutionizing mobile technology by combining phone, internet, and multimedia functionalities in one device.",
     "pillar": "GlobalEh",
-    "tags": ["US", "GlobalEh", "technology", "smartphones"],
+    "tags": [
+      "US",
+      "GlobalEh",
+      "smartphones",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/History_of_the_iPhone",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3837,10 +4567,18 @@
     "difficulty": "Medium",
     "question": "What portable advanced navigation technology is commonly used by hikers and outdoor enthusiasts to pinpoint locations without cellular service?",
     "answer": "GPS device",
-    "acceptableAnswers": ["GPS device", "Global Positioning System", "GPS"],
+    "acceptableAnswers": [
+      "GPS device",
+      "Global Positioning System",
+      "GPS"
+    ],
     "explanation": "GPS devices use satellite signals to provide accurate location tracking, making them essential for outdoor activities in remote areas where cellular service is unavailable.",
     "pillar": "GreatOutdoors",
-    "tags": ["Global", "GreatOutdoors", "Technology"],
+    "tags": [
+      "Global",
+      "GreatOutdoors",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Global_Positioning_System",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3861,10 +4599,17 @@
     "difficulty": "Easy",
     "question": "Which company is commonly credited with developing the first smartphone?",
     "answer": "IBM",
-    "acceptableAnswers": ["IBM", "IBM Simon"],
+    "acceptableAnswers": [
+      "IBM",
+      "IBM Simon"
+    ],
     "explanation": "IBM Simon, introduced in 1994, is widely recognized as the world's first smartphone due to its ability to combine telephony and PDA features.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/IBM_Simon",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -3893,10 +4638,17 @@
     "difficulty": "Hard",
     "question": "What was the name of the first commercial computer sold in 1951?",
     "answer": "UNIVAC I",
-    "acceptableAnswers": ["UNIVAC I", "UNIVAC"],
+    "acceptableAnswers": [
+      "UNIVAC I",
+      "UNIVAC"
+    ],
     "explanation": "The UNIVAC I (Universal Automatic Computer I) was created by J. Presper Eckert and John Mauchly and became the first commercial computer available for general purpose use.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "TimeCapsule"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Technology"
+    ],
     "sourceUrl": "https://www.computerhistory.org/timeline/computers/",
     "sourceName": "Computer History Museum",
     "status": "approved",
@@ -3925,10 +4677,17 @@
     "difficulty": "Medium",
     "question": "What does the acronym 'HTTP' stand for in web technology?",
     "answer": "HyperText Transfer Protocol",
-    "acceptableAnswers": ["HyperText Transfer Protocol"],
+    "acceptableAnswers": [
+      "HyperText Transfer Protocol"
+    ],
     "explanation": "HTTP stands for HyperText Transfer Protocol, a foundational technology for transferring data over the web.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints", "Internet"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Internet",
+      "Technology"
+    ],
     "sourceUrl": "https://developer.mozilla.org/en-US/docs/Web/HTTP",
     "sourceName": "Mozilla Developer Network",
     "status": "approved",
@@ -3957,10 +4716,18 @@
     "difficulty": "Hard",
     "question": "Who is credited with inventing the World Wide Web?",
     "answer": "Tim Berners-Lee",
-    "acceptableAnswers": ["Sir Tim Berners-Lee", "Tim Berners-Lee"],
+    "acceptableAnswers": [
+      "Sir Tim Berners-Lee",
+      "Tim Berners-Lee"
+    ],
     "explanation": "Tim Berners-Lee invented the World Wide Web in 1989, creating the first web browser and server.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints", "Internet"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Internet",
+      "Technology"
+    ],
     "sourceUrl": "https://webfoundation.org/about/vision/history-of-the-web/",
     "sourceName": "World Wide Web Foundation",
     "status": "approved",
@@ -3989,10 +4756,16 @@
     "difficulty": "Hard",
     "question": "Which programming language, designed by Bjarne Stroustrup, is widely used for system programming and game development?",
     "answer": "C++",
-    "acceptableAnswers": ["C++"],
+    "acceptableAnswers": [
+      "C++"
+    ],
     "explanation": "C++, developed by Bjarne Stroustrup in 1985, is a powerful language known for its utility in system programming and high-performance applications, including game development.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Technology"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/C%2B%2B",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4021,10 +4794,17 @@
     "difficulty": "Easy",
     "question": "What year was the World Wide Web made publicly available?",
     "answer": "1991",
-    "acceptableAnswers": ["1991", "Nineteen ninety-one"],
+    "acceptableAnswers": [
+      "1991",
+      "Nineteen ninety-one"
+    ],
     "explanation": "The World Wide Web, developed by Tim Berners-Lee, was made publicly accessible in 1991, revolutionizing how people access and share information.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Technology"
+    ],
     "sourceUrl": "https://www.w3.org/History.html",
     "sourceName": "World Wide Web Consortium (W3C)",
     "status": "approved",
@@ -4049,14 +4829,22 @@
   },
   {
     "id": "4d35602b-a912-4749-8c94-bf63318e468e",
-    "category": "Art",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Which artist is known for the painting of the 'Mona Lisa'?",
     "answer": "Leonardo da Vinci",
-    "acceptableAnswers": ["Da Vinci", "Leonardo", "Leonardo di ser Piero da Vinci"],
+    "acceptableAnswers": [
+      "Da Vinci",
+      "Leonardo",
+      "Leonardo di ser Piero da Vinci"
+    ],
     "explanation": "Leonardo da Vinci is renowned for painting the 'Mona Lisa', one of the world's most famous artworks, noted for its mysterious expression.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "Art"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Mona_Lisa",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4073,14 +4861,21 @@
   },
   {
     "id": "a5e8232c-6d24-42a4-82b6-b0de6a09858b",
-    "category": "art",
+    "category": "Food & Culture",
     "difficulty": "Easy",
     "question": "Which famous French Impressionist artist often painted outdoor scenes that highlighted natural light?",
     "answer": "Claude Monet",
-    "acceptableAnswers": ["Monet", "Claude Monet"],
+    "acceptableAnswers": [
+      "Monet",
+      "Claude Monet"
+    ],
     "explanation": "Claude Monet was a leading figure in the Impressionist movement, known for his outdoor paintings that captured the effects of natural light, such as 'Impression, Sunrise' and his series on water lilies.",
     "pillar": "GreatOutdoors",
-    "tags": ["Global", "GreatOutdoors", "art"],
+    "tags": [
+      "Global",
+      "GreatOutdoors",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Claude_Monet",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4097,20 +4892,28 @@
   },
   {
     "id": "bb85f522-8c93-47f9-8bc7-1a4bde5d5c1a",
-    "category": "Art",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who painted the famous artwork 'The Persistence of Memory' featuring melting clocks?",
-    "answer": "Salvador Dalí",
-    "acceptableAnswers": ["Dalí", "Salvador Dali", "Salvador Felipe Jacinto Dalí i Domènech"],
-    "explanation": "'The Persistence of Memory' is a 1931 surrealist painting by Salvador Dalí, depicting melting clocks as a symbol of the fluidity of time.",
+    "answer": "Salvador Dal\u00ed",
+    "acceptableAnswers": [
+      "Dal\u00ed",
+      "Salvador Dali",
+      "Salvador Felipe Jacinto Dal\u00ed i Dom\u00e8nech"
+    ],
+    "explanation": "'The Persistence of Memory' is a 1931 surrealist painting by Salvador Dal\u00ed, depicting melting clocks as a symbol of the fluidity of time.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "Art"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Persistence_of_Memory",
     "sourceName": "Wikipedia",
     "status": "approved",
     "aiAnalysis": {
       "factCheck": {
-        "reason": "The question, answer, and explanation are all correct; Salvador Dalí is indeed the painter of 'The Persistence of Memory'.",
+        "reason": "The question, answer, and explanation are all correct; Salvador Dal\u00ed is indeed the painter of 'The Persistence of Memory'.",
         "verdict": "pass",
         "confidence": 100
       },
@@ -4121,14 +4924,22 @@
   },
   {
     "id": "e6a6cb1e-5b7b-4286-8739-2dc4574d596c",
-    "category": "Art",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Who painted the famous artwork known as 'The Starry Night'?",
     "answer": "Vincent van Gogh",
-    "acceptableAnswers": ["Vincent van Gogh", "Van Gogh", "Vincent"],
-    "explanation": "'The Starry Night' is one of Vincent van Gogh's most iconic paintings, created in 1889 while he was staying at the asylum of Saint-Paul-de-Mausole in Saint-Rémy-de-Provence, France.",
+    "acceptableAnswers": [
+      "Vincent van Gogh",
+      "Van Gogh",
+      "Vincent"
+    ],
+    "explanation": "'The Starry Night' is one of Vincent van Gogh's most iconic paintings, created in 1889 while he was staying at the asylum of Saint-Paul-de-Mausole in Saint-R\u00e9my-de-Provence, France.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints", "Art"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Starry_Night",
     "sourceName": "Test Source Name",
     "status": "approved",
@@ -4145,14 +4956,20 @@
   },
   {
     "id": "ed90d802-23e0-4df0-b3a5-fad9a9c16b0c",
-    "category": "art",
+    "category": "Food & Culture",
     "difficulty": "Medium",
     "question": "Which famous art movement, originating in the early 20th century, is known for its emphasis on dreams and the unconscious mind?",
     "answer": "Surrealism",
-    "acceptableAnswers": ["Surrealism"],
-    "explanation": "Surrealism is an art movement that began in the early 20th century, emphasizing illogical scenes, dream-like imagery, and the workings of the unconscious mind. Key figures include Salvador Dalí, René Magritte, and André Breton.",
+    "acceptableAnswers": [
+      "Surrealism"
+    ],
+    "explanation": "Surrealism is an art movement that began in the early 20th century, emphasizing illogical scenes, dream-like imagery, and the workings of the unconscious mind. Key figures include Salvador Dal\u00ed, Ren\u00e9 Magritte, and Andr\u00e9 Breton.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh", "art"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Food & Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Surrealism",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4169,14 +4986,22 @@
   },
   {
     "id": "21a00359-7f2a-4daa-9b17-3db4474c64d1",
-    "category": "Movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "What film directed by Steven Spielberg features a young boy befriending an alien who wants to 'phone home'?",
     "answer": "E.T. the Extra-Terrestrial",
-    "acceptableAnswers": ["E.T. the Extra-Terrestrial", "E.T.", "ET"],
-    "explanation": "Released in 1982, Steven Spielberg’s 'E.T. the Extra-Terrestrial' became an iconic family film about friendship and understanding, with a young boy helping a stranded alien return to its home planet.",
+    "acceptableAnswers": [
+      "E.T. the Extra-Terrestrial",
+      "E.T.",
+      "ET"
+    ],
+    "explanation": "Released in 1982, Steven Spielberg\u2019s 'E.T. the Extra-Terrestrial' became an iconic family film about friendship and understanding, with a young boy helping a stranded alien return to its home planet.",
     "pillar": "FreshPrints",
-    "tags": ["US", "FreshPrints", "Movies"],
+    "tags": [
+      "US",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/E.T._the_Extra-Terrestrial",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4193,14 +5018,20 @@
   },
   {
     "id": "56098d89-8936-43cc-a02b-14bd2a84f111",
-    "category": "Movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "What movie is set in the fictional country of Wakanda and became the first superhero film to be nominated for Best Picture at the Academy Awards?",
     "answer": "Black Panther",
-    "acceptableAnswers": ["Black Panther"],
+    "acceptableAnswers": [
+      "Black Panther"
+    ],
     "explanation": "Released in 2018, 'Black Panther' was the first superhero film to receive an Academy Award nomination for Best Picture. It is set in Wakanda, a fictional African nation with advanced technology.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints", "Movies"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Black_Panther_(film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4225,14 +5056,20 @@
   },
   {
     "id": "8adbb064-d146-475f-8914-4aa6072869ef",
-    "category": "Movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which 1927 film is considered the first feature-length 'talkie' and revolutionized the film industry?",
     "answer": "The Jazz Singer",
-    "acceptableAnswers": ["The Jazz Singer"],
+    "acceptableAnswers": [
+      "The Jazz Singer"
+    ],
     "explanation": "Released in 1927, 'The Jazz Singer' is regarded as the first movie with synchronized dialogue and songs, marking the transition from silent films to 'talkies' and changing the future of cinema.",
     "pillar": "FreshPrints",
-    "tags": ["US", "FreshPrints", "Movies"],
+    "tags": [
+      "US",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Jazz_Singer",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4249,14 +5086,20 @@
   },
   {
     "id": "0b7775a7-96e6-4037-9e73-069d9e02e1c7",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which movie follows a dog named Buck as he navigates the Alaskan wilderness, forming a bond with a man named John Thornton?",
     "answer": "The Call of the Wild",
-    "acceptableAnswers": ["The Call of the Wild"],
+    "acceptableAnswers": [
+      "The Call of the Wild"
+    ],
     "explanation": "The 2020 film 'The Call of the Wild,' based on Jack London's novel, features Buck, a sled dog, as he experiences life in the Alaskan wilderness and forms a deep bond with John Thornton. The movie captures themes of survival and connection with nature.",
     "pillar": "GreatOutdoors",
-    "tags": ["US", "GreatOutdoors", "movies"],
+    "tags": [
+      "US",
+      "GreatOutdoors",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Call_of_the_Wild_(2020_film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4274,14 +5117,20 @@
   },
   {
     "id": "d528c1d5-4523-42c3-869d-ec6c6f6fd78e",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which movie features the iconic line, 'I'll be back,' spoken by Arnold Schwarzenegger?",
     "answer": "The Terminator",
-    "acceptableAnswers": ["The Terminator"],
+    "acceptableAnswers": [
+      "The Terminator"
+    ],
     "explanation": "Arnold Schwarzenegger delivers the famous line 'I'll be back' in the 1984 science fiction classic 'The Terminator,' directed by James Cameron.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "TimeCapsule", "movies"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Terminator",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4298,14 +5147,21 @@
   },
   {
     "id": "e62f1c86-351b-4456-8536-b053808f7edd",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "What was the first feature-length animated movie ever released?",
     "answer": "Snow White and the Seven Dwarfs",
-    "acceptableAnswers": ["Snow White and the Seven Dwarfs", "Snow White"],
+    "acceptableAnswers": [
+      "Snow White and the Seven Dwarfs",
+      "Snow White"
+    ],
     "explanation": "'Snow White and the Seven Dwarfs,' released in 1937 by Walt Disney Productions, holds the distinction of being the first-ever feature-length animated movie.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "movies"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Snow_White_and_the_Seven_Dwarfs_(1937_film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4322,14 +5178,20 @@
   },
   {
     "id": "caac18aa-576a-4f64-9335-ab78f8474236",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which director is responsible for the groundbreaking 1927 film, 'Metropolis,' a pioneering work in science fiction cinema?",
     "answer": "Fritz Lang",
-    "acceptableAnswers": ["Fritz Lang"],
+    "acceptableAnswers": [
+      "Fritz Lang"
+    ],
     "explanation": "'Metropolis,' directed by Fritz Lang in 1927, is regarded as one of the most influential science fiction films in cinematic history. It introduced themes of dystopian future and class struggle.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "movies"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Metropolis_(1927_film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4346,14 +5208,20 @@
   },
   {
     "id": "733a7d08-6d33-4de2-be2c-f3e2d048feaf",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which 1997 movie featured the iconic phrase, 'I'm the king of the world!'?",
     "answer": "Titanic",
-    "acceptableAnswers": ["Titanic (1997)"],
+    "acceptableAnswers": [
+      "Titanic (1997)"
+    ],
     "explanation": "This line was famously shouted by Leonardo DiCaprio's character, Jack Dawson, in James Cameron's 1997 blockbuster 'Titanic'.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh", "movies"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Titanic_(1997_film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4370,14 +5238,20 @@
   },
   {
     "id": "92c758c9-c11b-4519-b836-b6eafa1f06cf",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "What is the highest-grossing movie of all time, adjusted for inflation?",
     "answer": "Gone with the Wind",
-    "acceptableAnswers": ["Gone with the Wind (1939)"],
+    "acceptableAnswers": [
+      "Gone with the Wind (1939)"
+    ],
     "explanation": "When adjusted for inflation, the 1939 movie 'Gone with the Wind' remains the highest-grossing film of all time due to its enduring popularity.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh", "movies"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/List_of_highest-grossing_films#Highest-grossing_films_adjusted_for_inflation",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4394,14 +5268,20 @@
   },
   {
     "id": "8481f9bb-9956-4024-a2dc-eb8f454db45e",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Who directed the 1927 science fiction classic 'Metropolis'?",
     "answer": "Fritz Lang",
-    "acceptableAnswers": ["Fritz Lang"],
+    "acceptableAnswers": [
+      "Fritz Lang"
+    ],
     "explanation": "'Metropolis' is a highly influential science fiction film, and its visionary director, Fritz Lang, is often credited for helping to define the genre in cinema.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh", "movies"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Metropolis_(1927_film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4418,14 +5298,21 @@
   },
   {
     "id": "e4602c67-1dbc-4aad-a5b9-3a9e35b35402",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "What was the first animated film to ever be nominated for the Best Picture Oscar?",
     "answer": "Beauty and the Beast",
-    "acceptableAnswers": ["Beauty and the Beast (1991)", "Beauty and the Beast"],
+    "acceptableAnswers": [
+      "Beauty and the Beast (1991)",
+      "Beauty and the Beast"
+    ],
     "explanation": "Released in 1991, Disney's 'Beauty and the Beast' was the first-ever animated film to receive a nomination for Best Picture at the Academy Awards, a significant milestone for animated filmmaking.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "movies"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.oscars.org/oscars/ceremonies/1992",
     "sourceName": "The Oscars (Academy of Motion Picture Arts and Sciences)",
     "status": "approved",
@@ -4450,14 +5337,21 @@
   },
   {
     "id": "5d675ce1-dd38-4e3b-9a64-b6b37cbe7d0d",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which 2015 movie centers around a man stranded alone on Mars and his battle to survive in the harsh, isolated environment?",
     "answer": "The Martian",
-    "acceptableAnswers": ["The Martian (2015)", "The Martian"],
+    "acceptableAnswers": [
+      "The Martian (2015)",
+      "The Martian"
+    ],
     "explanation": "The movie 'The Martian,' directed by Ridley Scott, follows astronaut Mark Watney as he uses his ingenuity and knowledge of science to survive after being mistakenly left behind on Mars. It focuses on themes of survival in an extreme environment.",
     "pillar": "GreatOutdoors",
-    "tags": ["Global", "GreatOutdoors", "movies"],
+    "tags": [
+      "Global",
+      "GreatOutdoors",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/The_Martian_(film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4475,14 +5369,20 @@
   },
   {
     "id": "8db345b7-8d7e-4075-b298-d599d49c79dc",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which actor starred in and directed the 1995 historical drama 'Braveheart'?",
     "answer": "Mel Gibson",
-    "acceptableAnswers": ["Mel Gibson"],
+    "acceptableAnswers": [
+      "Mel Gibson"
+    ],
     "explanation": "Mel Gibson not only played the lead role of William Wallace in the epic historical drama 'Braveheart,' but he also directed the movie, which went on to win the Academy Award for Best Picture and Best Director.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "movies"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://www.britannica.com/topic/Braveheart",
     "sourceName": "Encyclopaedia Britannica",
     "status": "approved",
@@ -4499,14 +5399,20 @@
   },
   {
     "id": "04f2d2b9-d892-4c81-b18d-01ffb8f15bee",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Canadian director is known for films such as 'Titanic', 'Avatar', and 'The Terminator'?",
     "answer": "James Cameron",
-    "acceptableAnswers": ["James Cameron"],
+    "acceptableAnswers": [
+      "James Cameron"
+    ],
     "explanation": "James Cameron, born in Kapuskasing, Ontario, is a world-renowned Canadian filmmaker famous for directing blockbuster hits such as 'Titanic' (1997), 'Avatar' (2009), and 'The Terminator' series.",
     "pillar": "GlobalEh",
-    "tags": ["GlobalEh", "movies", "CA"],
+    "tags": [
+      "GlobalEh",
+      "CA",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/James_Cameron",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4523,14 +5429,21 @@
   },
   {
     "id": "d9307d08-4d9a-4b8e-8b4e-06c85b963829",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "What is the highest-grossing movie of all time without adjusting for inflation?",
     "answer": "Avatar",
-    "acceptableAnswers": ["Avatar", "James Cameron's Avatar"],
+    "acceptableAnswers": [
+      "Avatar",
+      "James Cameron's Avatar"
+    ],
     "explanation": "James Cameron's 2009 science-fiction epic 'Avatar' holds the title of the highest-grossing movie of all time, generating massive box office revenue worldwide.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints", "movies"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/List_of_highest-grossing_films",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4547,14 +5460,20 @@
   },
   {
     "id": "7bb2a8a3-9774-45b5-b5a1-d603d0733cde",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Easy",
     "question": "Which 2007 movie follows a man who abandons his possessions to live in the Alaskan wilderness, inspired by a true story?",
     "answer": "Into the Wild",
-    "acceptableAnswers": ["Into the Wild"],
+    "acceptableAnswers": [
+      "Into the Wild"
+    ],
     "explanation": "\"Into the Wild\" is based on the true story of Christopher McCandless, a man who sought freedom in the wilderness and whose journey was documented in a book by Jon Krakauer before being adapted into the film.",
     "pillar": "GreatOutdoors",
-    "tags": ["US", "GreatOutdoors", "movies"],
+    "tags": [
+      "US",
+      "GreatOutdoors",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Into_the_Wild_(film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4571,14 +5490,20 @@
   },
   {
     "id": "2b0024ef-f5c8-4da2-927b-3d5e999cd5a7",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which Quentin Tarantino movie features a mysterious briefcase as a central plot element?",
     "answer": "Pulp Fiction",
-    "acceptableAnswers": ["Pulp Fiction"],
+    "acceptableAnswers": [
+      "Pulp Fiction"
+    ],
     "explanation": "In Quentin Tarantino's film 'Pulp Fiction', the briefcase serves as a mysterious plot device, driving intrigue as its contents are never revealed.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints", "movies"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pulp_Fiction",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4595,14 +5520,20 @@
   },
   {
     "id": "5f08bd8a-5801-45dc-bec0-26ec753e49b0",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Hard",
     "question": "Which silent film was the first movie to win the Academy Award for Best Picture?",
     "answer": "Wings",
-    "acceptableAnswers": ["Wings"],
+    "acceptableAnswers": [
+      "Wings"
+    ],
     "explanation": "Wings, a silent World War I drama released in 1927, was the first movie to win the Academy Award for Best Picture at the inaugural Oscars in 1929.",
     "pillar": "TimeCapsule",
-    "tags": ["US", "TimeCapsule", "movies"],
+    "tags": [
+      "US",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Wings_(1927_film)",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4627,14 +5558,20 @@
   },
   {
     "id": "5d3c1f91-4ab0-4c4e-9aa7-4b30a6f32dcf",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which movie won the Academy Award for Best Picture in 1994?",
     "answer": "Forrest Gump",
-    "acceptableAnswers": ["Forrest Gump"],
+    "acceptableAnswers": [
+      "Forrest Gump"
+    ],
     "explanation": "Forrest Gump, directed by Robert Zemeckis and starring Tom Hanks, won the Oscar for Best Picture at the 67th Academy Awards in 1994.",
     "pillar": "GlobalEh",
-    "tags": ["Global", "GlobalEh", "movies"],
+    "tags": [
+      "Global",
+      "GlobalEh",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/67th_Academy_Awards",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4659,14 +5596,20 @@
   },
   {
     "id": "5a2a1df4-7d37-4f3d-84dd-b29c8986b3e2",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which movie, released in 1985, features a time-traveling DeLorean car?",
     "answer": "Back to the Future",
-    "acceptableAnswers": ["Back to the Future"],
+    "acceptableAnswers": [
+      "Back to the Future"
+    ],
     "explanation": "'Back to the Future' is a 1985 science fiction film in which the protagonist, Marty McFly, travels through time using a DeLorean car modified by his friend Dr. Emmett Brown.",
     "pillar": "TimeCapsule",
-    "tags": ["Global", "TimeCapsule", "movies"],
+    "tags": [
+      "Global",
+      "TimeCapsule",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Back_to_the_Future",
     "sourceName": "Wikipedia",
     "status": "approved",
@@ -4683,14 +5626,20 @@
   },
   {
     "id": "d14e2f08-3f8c-42d8-89e5-4a996a4ceb4b",
-    "category": "movies",
+    "category": "Entertainment & Pop Culture",
     "difficulty": "Medium",
     "question": "Which 1994 movie directed by Quentin Tarantino revitalized John Travolta's career?",
     "answer": "Pulp Fiction",
-    "acceptableAnswers": ["Pulp Fiction"],
+    "acceptableAnswers": [
+      "Pulp Fiction"
+    ],
     "explanation": "Directed by Quentin Tarantino, 'Pulp Fiction' is widely regarded as a groundbreaking moment in cinematic history. Its success reinvigorated John Travolta's career, earning him widespread acclaim.",
     "pillar": "FreshPrints",
-    "tags": ["Global", "FreshPrints", "movies"],
+    "tags": [
+      "Global",
+      "FreshPrints",
+      "Entertainment & Pop Culture"
+    ],
     "sourceUrl": "https://en.wikipedia.org/wiki/Pulp_Fiction",
     "sourceName": "Wikipedia",
     "status": "approved",

--- a/server/seed-data.test.ts
+++ b/server/seed-data.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { VALID_CATEGORIES, CATEGORY_SET } from '../shared/constants/categories';
+
+const seedData = JSON.parse(
+  readFileSync(join(__dirname, 'seed-data.json'), 'utf-8')
+) as { category?: unknown }[];
+
+describe('seed-data.json category integrity', () => {
+  it('has no questions with a missing category', () => {
+    const missing = seedData.filter((q) => !q.category);
+    expect(missing).toHaveLength(0);
+  });
+
+  it('has no questions with a non-canonical category', () => {
+    const invalid = seedData.filter(
+      (q) => typeof q.category !== 'string' || !CATEGORY_SET.has(q.category)
+    );
+    if (invalid.length > 0) {
+      const badValues = [...new Set(invalid.map((q) => q.category))];
+      throw new Error(`Found ${invalid.length} question(s) with invalid categories: ${JSON.stringify(badValues)}`);
+    }
+    expect(invalid).toHaveLength(0);
+  });
+
+  it('uses every canonical category at least once', () => {
+    const used = new Set(seedData.map((q) => q.category));
+    for (const cat of VALID_CATEGORIES) {
+      expect(used.has(cat), `category "${cat}" has no questions in seed data`).toBe(true);
+    }
+  });
+
+  it('has no legacy category values', () => {
+    const legacy = [
+      'History', 'Geography', 'Government',
+      'Science', 'Nature', 'Space',
+      'Entertainment', 'Movies', 'movies', 'Music',
+      'Pop Culture', 'pop culture',
+      'Food', 'Culture', 'Art', 'art', 'Literature',
+      'technology',
+      'General Knowledge',
+    ];
+    const found = seedData.filter(
+      (q) => typeof q.category === 'string' && legacy.includes(q.category)
+    );
+    if (found.length > 0) {
+      const badValues = [...new Set(found.map((q) => q.category))];
+      throw new Error(`Legacy categories still present: ${JSON.stringify(badValues)}`);
+    }
+    expect(found).toHaveLength(0);
+  });
+});

--- a/shared/constants/categories.ts
+++ b/shared/constants/categories.ts
@@ -1,0 +1,12 @@
+export const VALID_CATEGORIES = [
+  'History & Geography',
+  'Science & Nature',
+  'Sports',
+  'Entertainment & Pop Culture',
+  'Food & Culture',
+  'Technology',
+] as const;
+
+export type Category = (typeof VALID_CATEGORIES)[number];
+
+export const CATEGORY_SET = new Set<string>(VALID_CATEGORIES);

--- a/shared/constants/categories.ts
+++ b/shared/constants/categories.ts
@@ -10,3 +10,23 @@ export const VALID_CATEGORIES = [
 export type Category = (typeof VALID_CATEGORIES)[number];
 
 export const CATEGORY_SET = new Set<string>(VALID_CATEGORIES);
+
+export const LEGACY_CATEGORY_MAP: Record<string, string> = {
+  geography: 'History & Geography',
+  history: 'History & Geography',
+  government: 'History & Geography',
+  science: 'Science & Nature',
+  nature: 'Science & Nature',
+  space: 'Science & Nature',
+  sports: 'Sports',
+  entertainment: 'Entertainment & Pop Culture',
+  movies: 'Entertainment & Pop Culture',
+  'pop culture': 'Entertainment & Pop Culture',
+  music: 'Entertainment & Pop Culture',
+  food: 'Food & Culture',
+  culture: 'Food & Culture',
+  art: 'Food & Culture',
+  literature: 'Food & Culture',
+  technology: 'Technology',
+  'general knowledge': 'Science & Nature',
+};

--- a/shared/models/questions.ts
+++ b/shared/models/questions.ts
@@ -12,6 +12,7 @@ import {
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 import { users } from './auth';
+import { VALID_CATEGORIES } from '../constants/categories';
 
 // Questions table — stores all trivia questions (migrated from client/src/lib/questions.json)
 export const questions = pgTable('questions', {
@@ -36,6 +37,7 @@ export const questions = pgTable('questions', {
 });
 
 export const insertQuestionSchema = createInsertSchema(questions, {
+  category: z.enum(VALID_CATEGORIES),
   difficulty: z.enum(['Easy', 'Medium', 'Hard']),
   pillar: z.enum(['GlobalEh', 'FreshPrints', 'TimeCapsule', 'GreatOutdoors']),
   status: z.enum(['draft', 'pending', 'approved', 'rejected']).default('approved'),

--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -13,7 +13,7 @@ const validDisputePayload = {
 
 const validQuestionPayload = {
   id: 'q-test',
-  category: 'History',
+  category: 'History & Geography',
   difficulty: 'Medium',
   question: 'Which civilization built Machu Picchu?',
   answer: 'Inca Empire',
@@ -50,10 +50,14 @@ describe('insertQuestionSchema', () => {
   });
 
   it.each([
+    ['category', 'History'],
+    ['category', 'Movies'],
+    ['category', 'General Knowledge'],
+    ['category', 'geography'],
     ['difficulty', 'Impossible'],
     ['pillar', 'WrongPillar'],
     ['status', 'archived'],
-  ])('rejects an invalid %s value', (field, value) => {
+  ])('rejects an invalid %s value "%s"', (field, value) => {
     const result = insertQuestionSchema.safeParse({
       ...validQuestionPayload,
       [field]: value,
@@ -61,5 +65,17 @@ describe('insertQuestionSchema', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.issues.some((issue) => issue.path.join('.') === field)).toBe(true);
+  });
+
+  it.each([
+    'History & Geography',
+    'Science & Nature',
+    'Sports',
+    'Entertainment & Pop Culture',
+    'Food & Culture',
+    'Technology',
+  ])('accepts canonical category "%s"', (category) => {
+    const result = insertQuestionSchema.safeParse({ ...validQuestionPayload, category });
+    expect(result.success).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **STE-142 (data migration):** Remapped all 439 questions across `server/seed-data.json` and `client/src/lib/questions.json` to 6 canonical category names. Tags arrays updated to match (old category names stripped, canonical names appended where missing).
- **STE-141 (enforcement):** Added `shared/constants/categories.ts` exporting `VALID_CATEGORIES`, `Category` type, and `CATEGORY_SET`. Schema enforcement via `z.enum(VALID_CATEGORIES)` on `insertQuestionSchema` (flows automatically to field-patch validation). Guardian prompt constrained to canonical set with fallback + warning. Admin category `EditableField` replaced with a `<Select>` dropdown.

### Canonical categories
`History & Geography` · `Science & Nature` · `Sports` · `Entertainment & Pop Culture` · `Food & Culture` · `Technology`

### Files changed
- `shared/constants/categories.ts` — new constants file
- `shared/models/questions.ts` — category Zod enum added
- `server/seed-data.json` — 244 questions remapped
- `client/src/lib/questions.json` — 195 questions remapped
- `server/lib/guardian.ts` — prompt + normalizeCandidate enforcement
- `client/src/pages/admin-questions.tsx` — category EditableField → Select dropdown
- `server/seed-data.test.ts` — new: validates all seed data against canonical set
- `server/routes.admin-validation.test.ts` — extended: canonical + legacy rejection tests
- `shared/schema.test.ts` — extended: valid/invalid category acceptance tests

## Test plan
- [x] `npm test` — 22 test files, 187 tests, all passing
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] Seed data integrity: all 244 questions use canonical categories, all 6 represented, no legacy values
- [x] Schema: valid canonical categories accepted, legacy/invalid values rejected with 422
- [x] Field-patch: `PATCH /api/admin/questions/:id/field` with `category` enforces canonical enum
- [x] Admin UI: category field renders as dropdown with exactly the 6 canonical options

Closes STE-142, Closes STE-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)