### PR TITLE
feat(novelty-filter): add duplicate detection observability logging [STE-200]

### DIFF
--- a/server/lib/novelty-filter.test.ts
+++ b/server/lib/novelty-filter.test.ts
@@ -260,6 +260,63 @@ describe('filterNovelQuestions — within-batch collisions', () => {
   });
 });
 
+describe('filterNovelQuestions — observability logging', () => {
+  it('emits novelty_filter_result with correct counts when duplicates are dropped', async () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const existing = [
+      makeQuestion({ id: 'e1', question: 'What is the capital of France?', answer: 'Paris' }),
+    ];
+    const batch = [
+      makeQuestion({ id: 'b1', question: 'What is the capital of France?', answer: 'Paris' }),
+      makeQuestion({ id: 'b2', question: 'What is the longest river in Asia?', answer: 'Yangtze' }),
+    ];
+
+    await filterNovelQuestions(batch, existing);
+
+    const logCall = spy.mock.calls.find(
+      (call) =>
+        typeof call[1] === 'object' &&
+        (call[1] as Record<string, unknown>)?.event === 'novelty_filter_result'
+    );
+    expect(logCall).toBeDefined();
+    expect(logCall![1]).toMatchObject({
+      event: 'novelty_filter_result',
+      batchSize: 2,
+      dropped: 1,
+      survived: 1,
+    });
+
+    spy.mockRestore();
+  });
+
+  it('emits novelty_filter_result with zero dropped when no duplicates exist', async () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const batch = [
+      makeQuestion({ id: 'b1', question: 'What is the capital of Canada?', answer: 'Ottawa' }),
+      makeQuestion({ id: 'b2', question: 'What is the tallest mountain?', answer: 'Everest' }),
+    ];
+
+    await filterNovelQuestions(batch, []);
+
+    const logCall = spy.mock.calls.find(
+      (call) =>
+        typeof call[1] === 'object' &&
+        (call[1] as Record<string, unknown>)?.event === 'novelty_filter_result'
+    );
+    expect(logCall).toBeDefined();
+    expect(logCall![1]).toMatchObject({
+      event: 'novelty_filter_result',
+      batchSize: 2,
+      dropped: 0,
+      survived: 2,
+    });
+
+    spy.mockRestore();
+  });
+});
+
 describe('filterNovelQuestions — performance guards', () => {
   it('does not call GPT-4o when no batch/existing pair has similar answers', async () => {
     const existing = [

--- a/server/lib/novelty-filter.ts
+++ b/server/lib/novelty-filter.ts
@@ -160,5 +160,13 @@ export async function filterNovelQuestions<T extends DetectableQuestion>(
     }
   }
 
+  console.info('[novelty-filter] novelty_filter_result', {
+    event: 'novelty_filter_result',
+    batchSize: batch.length,
+    dropped: dropped.length,
+    survived: kept.length,
+    timestamp: new Date().toISOString(),
+  });
+
   return { kept, dropped };
 }


### PR DESCRIPTION
## Summary

- Adds a `novelty_filter_result` structured log (via `console.info`) at the end of every non-empty `filterNovelQuestions` call, emitting `batchSize`, `dropped`, `survived`, and `timestamp`
- The log fires unconditionally — the existing `[staging] Novelty filter dropped duplicates` log in `routes.ts` only fires when something is dropped, leaving clean batches dark
- Two new unit tests in `novelty-filter.test.ts` verify the log is emitted with the correct counts for: (1) a batch where one question is a duplicate of an existing entry, and (2) a batch with no duplicates

## Test plan

- [x] `npm test server/lib/novelty-filter.test.ts` — 13 tests pass (2 new observability tests + 11 existing)
- [x] `npm test` — full suite 167/167 pass
- [ ] Phase 2 (answer-similarity gating) is explicitly out of scope per the issue — not implemented here

Closes STE-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)