### PR TITLE
chore(data): migrate legacy DB category values to canonical set [STE-198]

### DIFF
--- a/docs/guides/category_migration.md
+++ b/docs/guides/category_migration.md
@@ -1,0 +1,66 @@
+# Category Migration Guide
+
+## Context
+
+Modern Trivia uses 6 canonical category names enforced via `shared/constants/categories.ts`:
+
+- `History & Geography`
+- `Science & Nature`
+- `Sports`
+- `Entertainment & Pop Culture`
+- `Food & Culture`
+- `Technology`
+
+PR #112 (STE-141/142) introduced these canonical values and updated seed data. However, rows already in the production database retain whatever legacy string was stored at insert time (e.g., `geography`, `movies`, `pop culture`). Migration `0001_migrate_legacy_categories.sql` remaps those rows.
+
+## Running the migration
+
+Drizzle migrations are applied in filename order. Run:
+
+```bash
+npx drizzle-kit migrate
+```
+
+Or apply the SQL directly against the database:
+
+```bash
+psql "$DATABASE_URL" -f migrations/0001_migrate_legacy_categories.sql
+```
+
+The migration is **idempotent** — rows whose `category` is already a canonical value are excluded by the `WHERE category NOT IN (...)` clause, so re-running has no effect.
+
+## Verification
+
+After applying the migration, confirm 0 non-canonical rows remain:
+
+```sql
+SELECT category, COUNT(*)
+FROM questions
+WHERE category NOT IN (
+  'History & Geography',
+  'Science & Nature',
+  'Sports',
+  'Entertainment & Pop Culture',
+  'Food & Culture',
+  'Technology'
+)
+GROUP BY category;
+```
+
+An empty result set means the migration succeeded.
+
+## Revert / rollback
+
+There is no automated rollback. Legacy string values are not recoverable from the database after the UPDATE. If a rollback is needed:
+
+1. Restore from a pre-migration database snapshot.
+2. Or re-insert questions from the authoritative JSON files (`server/seed-data.json`, `client/src/lib/questions.json`) which already use canonical values — in that case a rollback is unnecessary.
+
+## Adding a new legacy mapping
+
+If a future import introduces a new legacy category string, update **both**:
+
+1. `shared/constants/categories.ts` — add the entry to `LEGACY_CATEGORY_MAP`
+2. `migrations/` — add a new numbered migration with the additional `WHEN` branch
+
+Do **not** edit `0001_migrate_legacy_categories.sql` after it has been applied to production; write a new migration instead.

--- a/migrations/0001_migrate_legacy_categories.sql
+++ b/migrations/0001_migrate_legacy_categories.sql
@@ -1,0 +1,32 @@
+-- Migrate legacy category values to the 6 canonical categories.
+-- Source: shared/constants/categories.ts LEGACY_CATEGORY_MAP
+-- Idempotent: canonical values are excluded by the WHERE clause, so re-running is safe.
+UPDATE "questions"
+SET "category" = CASE LOWER("category")
+  WHEN 'geography'       THEN 'History & Geography'
+  WHEN 'history'         THEN 'History & Geography'
+  WHEN 'government'      THEN 'History & Geography'
+  WHEN 'science'         THEN 'Science & Nature'
+  WHEN 'nature'          THEN 'Science & Nature'
+  WHEN 'space'           THEN 'Science & Nature'
+  WHEN 'general knowledge' THEN 'Science & Nature'
+  WHEN 'sports'          THEN 'Sports'
+  WHEN 'entertainment'   THEN 'Entertainment & Pop Culture'
+  WHEN 'movies'          THEN 'Entertainment & Pop Culture'
+  WHEN 'pop culture'     THEN 'Entertainment & Pop Culture'
+  WHEN 'music'           THEN 'Entertainment & Pop Culture'
+  WHEN 'food'            THEN 'Food & Culture'
+  WHEN 'culture'         THEN 'Food & Culture'
+  WHEN 'art'             THEN 'Food & Culture'
+  WHEN 'literature'      THEN 'Food & Culture'
+  WHEN 'technology'      THEN 'Technology'
+  ELSE "category"
+END
+WHERE "category" NOT IN (
+  'History & Geography',
+  'Science & Nature',
+  'Sports',
+  'Entertainment & Pop Culture',
+  'Food & Culture',
+  'Technology'
+);


### PR DESCRIPTION
## Summary

- Adds `migrations/0001_migrate_legacy_categories.sql` — idempotent `UPDATE` that remaps all 17 legacy category strings (`geography`, `movies`, `pop culture`, etc.) to the 6 canonical values defined in `shared/constants/categories.ts` (introduced by PR #112, STE-141/142)
- Migration uses `LOWER(category)` matching so it handles any capitalisation variant; canonical rows are excluded via `WHERE category NOT IN (...)` making re-runs a no-op
- Adds `docs/guides/category_migration.md` explaining how to run, verify, and extend the migration for future republish/revert scenarios

### Canonical categories
`History & Geography` · `Science & Nature` · `Sports` · `Entertainment & Pop Culture` · `Food & Culture` · `Technology`

### Verification query (should return 0 rows after migration)
```sql
SELECT category, COUNT(*)
FROM questions
WHERE category NOT IN (
  'History & Geography','Science & Nature','Sports',
  'Entertainment & Pop Culture','Food & Culture','Technology'
)
GROUP BY category;
```

## Test plan
- [x] `npm test` — 23 test files, 202 tests, all passing
- [x] SQL reviewed for idempotency: canonical rows excluded by `WHERE NOT IN`
- [x] All 17 LEGACY_CATEGORY_MAP entries represented in the `CASE` expression
- [x] Guide documents run instructions, verification query, rollback path, and extension steps

Closes STE-198