### PR TITLE
feat(db): add rooms schema and API contract [STE-202]

### DIFF
--- a/migrations/0003_create_rooms.sql
+++ b/migrations/0003_create_rooms.sql
@@ -1,0 +1,47 @@
+CREATE TYPE "public"."room_status" AS ENUM ('lobby', 'active', 'finished', 'abandoned');
+--> statement-breakpoint
+CREATE TYPE "public"."room_phase" AS ENUM ('LOBBY', 'QUESTION', 'REVEAL', 'ROUND_SCORE', 'GAME_OVER');
+--> statement-breakpoint
+CREATE TABLE "rooms" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"code" varchar(5) NOT NULL,
+	"status" "room_status" DEFAULT 'lobby' NOT NULL,
+	"phase" "room_phase" DEFAULT 'LOBBY' NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"host_player_id" uuid,
+	"category" varchar(80) NOT NULL,
+	"num_rounds" integer NOT NULL,
+	"question_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"current_question_index" integer DEFAULT 0 NOT NULL,
+	"active_player_id" uuid,
+	"current_attempt" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone DEFAULT now() + interval '24 hours' NOT NULL,
+	CONSTRAINT "rooms_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "room_players" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"room_id" uuid NOT NULL,
+	"nickname" varchar(20) NOT NULL,
+	"token" varchar(128) NOT NULL,
+	"join_order" integer NOT NULL,
+	"score" integer DEFAULT 0 NOT NULL,
+	"question_count" integer DEFAULT 0 NOT NULL,
+	"last_round_delta" integer DEFAULT 0 NOT NULL,
+	"is_host" boolean DEFAULT false NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"left_at" timestamp with time zone,
+	CONSTRAINT "room_players_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "room_players" ADD CONSTRAINT "room_players_room_id_rooms_id_fk" FOREIGN KEY ("room_id") REFERENCES "public"."rooms"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "rooms" ADD CONSTRAINT "rooms_host_player_id_room_players_id_fk" FOREIGN KEY ("host_player_id") REFERENCES "public"."room_players"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "rooms" ADD CONSTRAINT "rooms_active_player_id_room_players_id_fk" FOREIGN KEY ("active_player_id") REFERENCES "public"."room_players"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_room_players_room" ON "room_players" USING btree ("room_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_room_players_room_nickname_ci" ON "room_players" USING btree ("room_id", lower("nickname"));

--- a/migrations/0003_create_rooms.sql
+++ b/migrations/0003_create_rooms.sql
@@ -76,3 +76,5 @@ END $$;
 CREATE INDEX IF NOT EXISTS "idx_room_players_room" ON "room_players" USING btree ("room_id");
 --> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_room_players_room_nickname_ci" ON "room_players" USING btree ("room_id", lower("nickname"));
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_room_players_room_join_order" ON "room_players" USING btree ("room_id", "join_order");

--- a/migrations/0003_create_rooms.sql
+++ b/migrations/0003_create_rooms.sql
@@ -1,8 +1,18 @@
-CREATE TYPE "public"."room_status" AS ENUM ('lobby', 'active', 'finished', 'abandoned');
+DO $$
+BEGIN
+	CREATE TYPE "public"."room_status" AS ENUM ('lobby', 'active', 'finished', 'abandoned');
+EXCEPTION
+	WHEN duplicate_object THEN NULL;
+END $$;
 --> statement-breakpoint
-CREATE TYPE "public"."room_phase" AS ENUM ('LOBBY', 'QUESTION', 'REVEAL', 'ROUND_SCORE', 'GAME_OVER');
+DO $$
+BEGIN
+	CREATE TYPE "public"."room_phase" AS ENUM ('LOBBY', 'QUESTION', 'REVEAL', 'ROUND_SCORE', 'GAME_OVER');
+EXCEPTION
+	WHEN duplicate_object THEN NULL;
+END $$;
 --> statement-breakpoint
-CREATE TABLE "rooms" (
+CREATE TABLE IF NOT EXISTS "rooms" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"code" varchar(5) NOT NULL,
 	"status" "room_status" DEFAULT 'lobby' NOT NULL,
@@ -21,7 +31,7 @@ CREATE TABLE "rooms" (
 	CONSTRAINT "rooms_code_unique" UNIQUE("code")
 );
 --> statement-breakpoint
-CREATE TABLE "room_players" (
+CREATE TABLE IF NOT EXISTS "room_players" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"room_id" uuid NOT NULL,
 	"nickname" varchar(20) NOT NULL,
@@ -36,12 +46,33 @@ CREATE TABLE "room_players" (
 	CONSTRAINT "room_players_token_unique" UNIQUE("token")
 );
 --> statement-breakpoint
-ALTER TABLE "room_players" ADD CONSTRAINT "room_players_room_id_rooms_id_fk" FOREIGN KEY ("room_id") REFERENCES "public"."rooms"("id") ON DELETE cascade ON UPDATE no action;
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint WHERE conname = 'room_players_room_id_rooms_id_fk'
+	) THEN
+		ALTER TABLE "room_players" ADD CONSTRAINT "room_players_room_id_rooms_id_fk" FOREIGN KEY ("room_id") REFERENCES "public"."rooms"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-ALTER TABLE "rooms" ADD CONSTRAINT "rooms_host_player_id_room_players_id_fk" FOREIGN KEY ("host_player_id") REFERENCES "public"."room_players"("id") ON DELETE set null ON UPDATE no action;
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint WHERE conname = 'rooms_host_player_id_room_players_id_fk'
+	) THEN
+		ALTER TABLE "rooms" ADD CONSTRAINT "rooms_host_player_id_room_players_id_fk" FOREIGN KEY ("host_player_id") REFERENCES "public"."room_players"("id") ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-ALTER TABLE "rooms" ADD CONSTRAINT "rooms_active_player_id_room_players_id_fk" FOREIGN KEY ("active_player_id") REFERENCES "public"."room_players"("id") ON DELETE set null ON UPDATE no action;
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint WHERE conname = 'rooms_active_player_id_room_players_id_fk'
+	) THEN
+		ALTER TABLE "rooms" ADD CONSTRAINT "rooms_active_player_id_room_players_id_fk" FOREIGN KEY ("active_player_id") REFERENCES "public"."room_players"("id") ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;
 --> statement-breakpoint
-CREATE INDEX "idx_room_players_room" ON "room_players" USING btree ("room_id");
+CREATE INDEX IF NOT EXISTS "idx_room_players_room" ON "room_players" USING btree ("room_id");
 --> statement-breakpoint
-CREATE UNIQUE INDEX "uq_room_players_room_nickname_ci" ON "room_players" USING btree ("room_id", lower("nickname"));
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_room_players_room_nickname_ci" ON "room_players" USING btree ("room_id", lower("nickname"));

--- a/shared/models/rooms.ts
+++ b/shared/models/rooms.ts
@@ -84,6 +84,7 @@ export const roomPlayers = pgTable(
   (table) => [
     index('idx_room_players_room').on(table.roomId),
     uniqueIndex('uq_room_players_room_nickname_ci').on(table.roomId, sql`lower(${table.nickname})`),
+    uniqueIndex('uq_room_players_room_join_order').on(table.roomId, table.joinOrder),
   ]
 );
 
@@ -145,16 +146,18 @@ export const roomPlayerSnapshotSchema = z.object({
   leftAt: z.string().datetime().nullable(),
 });
 
-export const redactedRoomQuestionSchema = z.object({
-  id: z.string().min(1),
-  category: z.enum(VALID_CATEGORIES),
-  difficulty: z.enum(['Easy', 'Medium', 'Hard']),
-  question: z.string().min(1),
-  pillar: z.string().min(1),
-  tags: z.array(z.string()),
-  sourceUrl: z.string().url().nullable(),
-  sourceName: z.string().nullable(),
-});
+export const redactedRoomQuestionSchema = z
+  .object({
+    id: z.string().min(1),
+    category: z.enum(VALID_CATEGORIES),
+    difficulty: z.enum(['Easy', 'Medium', 'Hard']),
+    question: z.string().min(1),
+    pillar: z.string().min(1),
+    tags: z.array(z.string()),
+    sourceUrl: z.string().url().nullable(),
+    sourceName: z.string().nullable(),
+  })
+  .strict();
 
 export const revealedRoomQuestionSchema = redactedRoomQuestionSchema.extend({
   answer: z.string().min(1),
@@ -162,17 +165,15 @@ export const revealedRoomQuestionSchema = redactedRoomQuestionSchema.extend({
   explanation: z.string().min(1),
 });
 
-export const roomQuestionSnapshotSchema = redactedRoomQuestionSchema.extend({
-  answer: z.string().min(1).optional(),
-  acceptableAnswers: z.array(z.string()).optional(),
-  explanation: z.string().min(1).optional(),
-});
+export const roomQuestionSnapshotSchema = z.union([
+  redactedRoomQuestionSchema,
+  revealedRoomQuestionSchema,
+]);
 
-export const roomSnapshotSchema = z.object({
+const roomSnapshotBaseSchema = z.object({
   id: z.string().uuid(),
   code: roomCodeSchema,
   status: roomStatusSchema,
-  phase: roomPhaseSchema,
   version: z.number().int().positive(),
   hostPlayerId: z.string().uuid().nullable(),
   category: roomCategorySchema,
@@ -180,12 +181,34 @@ export const roomSnapshotSchema = z.object({
   currentQuestionIndex: z.number().int().nonnegative(),
   activePlayerId: z.string().uuid().nullable(),
   currentAttempt: roomAttemptSchema.nullable(),
-  currentQuestion: roomQuestionSnapshotSchema.nullable(),
   players: z.array(roomPlayerSnapshotSchema).max(4),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   expiresAt: z.string().datetime(),
 });
+
+export const roomSnapshotSchema = z.discriminatedUnion('phase', [
+  roomSnapshotBaseSchema.extend({
+    phase: z.literal('LOBBY'),
+    currentQuestion: redactedRoomQuestionSchema.nullable(),
+  }),
+  roomSnapshotBaseSchema.extend({
+    phase: z.literal('QUESTION'),
+    currentQuestion: redactedRoomQuestionSchema,
+  }),
+  roomSnapshotBaseSchema.extend({
+    phase: z.literal('REVEAL'),
+    currentQuestion: revealedRoomQuestionSchema,
+  }),
+  roomSnapshotBaseSchema.extend({
+    phase: z.literal('ROUND_SCORE'),
+    currentQuestion: revealedRoomQuestionSchema,
+  }),
+  roomSnapshotBaseSchema.extend({
+    phase: z.literal('GAME_OVER'),
+    currentQuestion: revealedRoomQuestionSchema,
+  }),
+]);
 
 export type RoomPlayerSnapshot = z.infer<typeof roomPlayerSnapshotSchema>;
 export type RedactedRoomQuestion = z.infer<typeof redactedRoomQuestionSchema>;

--- a/shared/models/rooms.ts
+++ b/shared/models/rooms.ts
@@ -1,0 +1,259 @@
+import { sql } from 'drizzle-orm';
+import {
+  type AnyPgColumn,
+  boolean,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+import { z } from 'zod';
+
+import { VALID_CATEGORIES } from '../constants/categories';
+
+export const ROOM_STATUSES = ['lobby', 'active', 'finished', 'abandoned'] as const;
+export const ROOM_PHASES = ['LOBBY', 'QUESTION', 'REVEAL', 'ROUND_SCORE', 'GAME_OVER'] as const;
+export const ROOM_VERDICTS = ['CORRECT', 'INCORRECT', 'PASS'] as const;
+export const ROOM_ROUND_OPTIONS = [5, 10, 15, 20] as const;
+export const ROOM_CODE_PATTERN = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{5}$/;
+
+export const roomStatusEnum = pgEnum('room_status', ROOM_STATUSES);
+export const roomPhaseEnum = pgEnum('room_phase', ROOM_PHASES);
+
+export const roomAttemptSchema = z.object({
+  questionId: z.string().min(1),
+  playerId: z.string().uuid(),
+  submittedAnswer: z.string().nullable(),
+  verdict: z.enum(ROOM_VERDICTS),
+  pointsDelta: z.number().int(),
+});
+
+export type RoomAttempt = z.infer<typeof roomAttemptSchema>;
+
+export const rooms = pgTable('rooms', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  code: varchar('code', { length: 5 }).notNull().unique(),
+  status: roomStatusEnum('status').notNull().default('lobby'),
+  phase: roomPhaseEnum('phase').notNull().default('LOBBY'),
+  version: integer('version').notNull().default(1),
+  // These remain nullable while the room and host player are created atomically.
+  hostPlayerId: uuid('host_player_id').references((): AnyPgColumn => roomPlayers.id, {
+    onDelete: 'set null',
+  }),
+  category: varchar('category', { length: 80 }).notNull(),
+  numRounds: integer('num_rounds').notNull(),
+  questionIds: jsonb('question_ids').$type<string[]>().notNull().default([]),
+  currentQuestionIndex: integer('current_question_index').notNull().default(0),
+  activePlayerId: uuid('active_player_id').references((): AnyPgColumn => roomPlayers.id, {
+    onDelete: 'set null',
+  }),
+  currentAttempt: jsonb('current_attempt').$type<RoomAttempt>(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+  expiresAt: timestamp('expires_at', { withTimezone: true })
+    .notNull()
+    .default(sql`now() + interval '24 hours'`),
+});
+
+export const roomPlayers = pgTable(
+  'room_players',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    roomId: uuid('room_id')
+      .notNull()
+      .references(() => rooms.id, { onDelete: 'cascade' }),
+    nickname: varchar('nickname', { length: 20 }).notNull(),
+    token: varchar('token', { length: 128 }).notNull().unique(),
+    joinOrder: integer('join_order').notNull(),
+    score: integer('score').notNull().default(0),
+    questionCount: integer('question_count').notNull().default(0),
+    lastRoundDelta: integer('last_round_delta').notNull().default(0),
+    isHost: boolean('is_host').notNull().default(false),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
+    leftAt: timestamp('left_at', { withTimezone: true }),
+  },
+  (table) => [
+    index('idx_room_players_room').on(table.roomId),
+    uniqueIndex('uq_room_players_room_nickname_ci').on(table.roomId, sql`lower(${table.nickname})`),
+  ]
+);
+
+export const roomStatusSchema = z.enum(ROOM_STATUSES);
+export const roomPhaseSchema = z.enum(ROOM_PHASES);
+export const roomVerdictSchema = z.enum(ROOM_VERDICTS);
+export const roomCodeSchema = z.string().regex(ROOM_CODE_PATTERN);
+export const roomNicknameSchema = z.string().trim().min(1).max(20);
+export const roomCategorySchema = z.enum(['All', ...VALID_CATEGORIES]);
+export const roomRoundsSchema = z.union([
+  z.literal(ROOM_ROUND_OPTIONS[0]),
+  z.literal(ROOM_ROUND_OPTIONS[1]),
+  z.literal(ROOM_ROUND_OPTIONS[2]),
+  z.literal(ROOM_ROUND_OPTIONS[3]),
+]);
+
+export type RoomStatus = z.infer<typeof roomStatusSchema>;
+export type RoomPhase = z.infer<typeof roomPhaseSchema>;
+export type RoomVerdict = z.infer<typeof roomVerdictSchema>;
+export type RoomCategory = z.infer<typeof roomCategorySchema>;
+export type RoomRounds = z.infer<typeof roomRoundsSchema>;
+
+export const insertRoomSchema = createInsertSchema(rooms, {
+  code: roomCodeSchema,
+  status: roomStatusSchema.default('lobby'),
+  phase: roomPhaseSchema.default('LOBBY'),
+  category: roomCategorySchema,
+  numRounds: roomRoundsSchema,
+  questionIds: z.array(z.string()).default([]),
+  currentAttempt: roomAttemptSchema.nullable().optional(),
+}).omit({ createdAt: true, updatedAt: true, expiresAt: true });
+
+export const selectRoomSchema = createSelectSchema(rooms, {
+  status: roomStatusSchema,
+  phase: roomPhaseSchema,
+  currentAttempt: roomAttemptSchema.nullable(),
+});
+
+export const insertRoomPlayerSchema = createInsertSchema(roomPlayers, {
+  nickname: roomNicknameSchema,
+}).omit({ lastSeenAt: true, leftAt: true });
+
+export const selectRoomPlayerSchema = createSelectSchema(roomPlayers);
+
+export type Room = typeof rooms.$inferSelect;
+export type InsertRoom = z.infer<typeof insertRoomSchema>;
+export type RoomPlayer = typeof roomPlayers.$inferSelect;
+export type InsertRoomPlayer = z.infer<typeof insertRoomPlayerSchema>;
+
+export const roomPlayerSnapshotSchema = z.object({
+  id: z.string().uuid(),
+  nickname: roomNicknameSchema,
+  joinOrder: z.number().int().nonnegative(),
+  score: z.number().int(),
+  questionCount: z.number().int().nonnegative(),
+  lastRoundDelta: z.number().int(),
+  isHost: z.boolean(),
+  lastSeenAt: z.string().datetime(),
+  leftAt: z.string().datetime().nullable(),
+});
+
+export const redactedRoomQuestionSchema = z.object({
+  id: z.string().min(1),
+  category: z.enum(VALID_CATEGORIES),
+  difficulty: z.enum(['Easy', 'Medium', 'Hard']),
+  question: z.string().min(1),
+  pillar: z.string().min(1),
+  tags: z.array(z.string()),
+  sourceUrl: z.string().url().nullable(),
+  sourceName: z.string().nullable(),
+});
+
+export const revealedRoomQuestionSchema = redactedRoomQuestionSchema.extend({
+  answer: z.string().min(1),
+  acceptableAnswers: z.array(z.string()),
+  explanation: z.string().min(1),
+});
+
+export const roomQuestionSnapshotSchema = redactedRoomQuestionSchema.extend({
+  answer: z.string().min(1).optional(),
+  acceptableAnswers: z.array(z.string()).optional(),
+  explanation: z.string().min(1).optional(),
+});
+
+export const roomSnapshotSchema = z.object({
+  id: z.string().uuid(),
+  code: roomCodeSchema,
+  status: roomStatusSchema,
+  phase: roomPhaseSchema,
+  version: z.number().int().positive(),
+  hostPlayerId: z.string().uuid().nullable(),
+  category: roomCategorySchema,
+  numRounds: roomRoundsSchema,
+  currentQuestionIndex: z.number().int().nonnegative(),
+  activePlayerId: z.string().uuid().nullable(),
+  currentAttempt: roomAttemptSchema.nullable(),
+  currentQuestion: roomQuestionSnapshotSchema.nullable(),
+  players: z.array(roomPlayerSnapshotSchema).max(4),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+});
+
+export type RoomPlayerSnapshot = z.infer<typeof roomPlayerSnapshotSchema>;
+export type RedactedRoomQuestion = z.infer<typeof redactedRoomQuestionSchema>;
+export type RevealedRoomQuestion = z.infer<typeof revealedRoomQuestionSchema>;
+export type RoomQuestionSnapshot = z.infer<typeof roomQuestionSnapshotSchema>;
+export type RoomSnapshot = z.infer<typeof roomSnapshotSchema>;
+
+export const roomCodeParamsSchema = z.object({ code: roomCodeSchema });
+export const createRoomRequestSchema = z.object({
+  nickname: roomNicknameSchema,
+  category: roomCategorySchema,
+  numRounds: roomRoundsSchema,
+});
+export const joinRoomRequestSchema = z.object({ nickname: roomNicknameSchema });
+export const startRoomRequestSchema = z.object({}).strict();
+export const answerRoomRequestSchema = z.object({ answer: z.string().trim().min(1).nullable() });
+export const advanceRoomRequestSchema = z.object({}).strict();
+export const continueRoomRequestSchema = z.object({}).strict();
+export const skipRoomRequestSchema = z.object({}).strict();
+export const endRoomRequestSchema = z.object({}).strict();
+export const pollRoomRequestSchema = z.object({
+  sinceVersion: z.coerce.number().int().nonnegative().optional(),
+});
+
+export const createRoomResponseSchema = z.object({
+  code: roomCodeSchema,
+  playerId: z.string().uuid(),
+  token: z.string().min(1),
+});
+export const joinRoomResponseSchema = z.object({
+  playerId: z.string().uuid(),
+  token: z.string().min(1),
+  snapshot: roomSnapshotSchema,
+});
+export const roomActionResponseSchema = z.object({ snapshot: roomSnapshotSchema });
+export const unchangedRoomPollResponseSchema = z.object({ changed: z.literal(false) });
+export const pollRoomResponseSchema = z.union([
+  unchangedRoomPollResponseSchema,
+  roomSnapshotSchema,
+]);
+export const roomErrorResponseSchema = z.object({ message: z.string().min(1) });
+
+export const startRoomResponseSchema = roomActionResponseSchema;
+export const answerRoomResponseSchema = roomActionResponseSchema;
+export const advanceRoomResponseSchema = roomActionResponseSchema;
+export const continueRoomResponseSchema = roomActionResponseSchema;
+export const skipRoomResponseSchema = roomActionResponseSchema;
+export const endRoomResponseSchema = roomActionResponseSchema;
+
+export type RoomCodeParams = z.infer<typeof roomCodeParamsSchema>;
+export type CreateRoomRequest = z.infer<typeof createRoomRequestSchema>;
+export type JoinRoomRequest = z.infer<typeof joinRoomRequestSchema>;
+export type StartRoomRequest = z.infer<typeof startRoomRequestSchema>;
+export type AnswerRoomRequest = z.infer<typeof answerRoomRequestSchema>;
+export type AdvanceRoomRequest = z.infer<typeof advanceRoomRequestSchema>;
+export type ContinueRoomRequest = z.infer<typeof continueRoomRequestSchema>;
+export type SkipRoomRequest = z.infer<typeof skipRoomRequestSchema>;
+export type EndRoomRequest = z.infer<typeof endRoomRequestSchema>;
+export type PollRoomRequest = z.infer<typeof pollRoomRequestSchema>;
+export type CreateRoomResponse = z.infer<typeof createRoomResponseSchema>;
+export type JoinRoomResponse = z.infer<typeof joinRoomResponseSchema>;
+export type RoomActionResponse = z.infer<typeof roomActionResponseSchema>;
+export type StartRoomResponse = RoomActionResponse;
+export type AnswerRoomResponse = RoomActionResponse;
+export type AdvanceRoomResponse = RoomActionResponse;
+export type ContinueRoomResponse = RoomActionResponse;
+export type SkipRoomResponse = RoomActionResponse;
+export type EndRoomResponse = RoomActionResponse;
+export type RoomPollResponse = z.infer<typeof pollRoomResponseSchema>;
+export type UnchangedRoomPollResponse = z.infer<typeof unchangedRoomPollResponseSchema>;
+export type RoomErrorResponse = z.infer<typeof roomErrorResponseSchema>;

--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from 'vitest';
 
-import { insertDisputeSchema, insertQuestionSchema } from './schema';
+import {
+  advanceRoomRequestSchema,
+  advanceRoomResponseSchema,
+  answerRoomRequestSchema,
+  answerRoomResponseSchema,
+  continueRoomRequestSchema,
+  continueRoomResponseSchema,
+  createRoomRequestSchema,
+  createRoomResponseSchema,
+  endRoomRequestSchema,
+  endRoomResponseSchema,
+  insertDisputeSchema,
+  insertQuestionSchema,
+  insertRoomPlayerSchema,
+  insertRoomSchema,
+  joinRoomRequestSchema,
+  joinRoomResponseSchema,
+  pollRoomRequestSchema,
+  pollRoomResponseSchema,
+  revealedRoomQuestionSchema,
+  roomAttemptSchema,
+  roomCodeParamsSchema,
+  roomErrorResponseSchema,
+  roomSnapshotSchema,
+  skipRoomRequestSchema,
+  skipRoomResponseSchema,
+  startRoomRequestSchema,
+  startRoomResponseSchema,
+} from './schema';
 
 const validDisputePayload = {
   questionId: 'q-1',
@@ -19,6 +47,60 @@ const validQuestionPayload = {
   answer: 'Inca Empire',
   explanation: 'Machu Picchu was built by the Inca Empire in the 15th century.',
   pillar: 'TimeCapsule',
+};
+
+const roomId = '11111111-1111-4111-8111-111111111111';
+const hostPlayerId = '22222222-2222-4222-8222-222222222222';
+const guestPlayerId = '33333333-3333-4333-8333-333333333333';
+const timestamp = '2026-06-20T18:00:00.000Z';
+
+const redactedQuestion = {
+  id: 'q-1',
+  category: 'History & Geography' as const,
+  difficulty: 'Medium' as const,
+  question: 'What is the capital of Canada?',
+  pillar: 'TimeCapsule',
+  tags: ['canada'],
+  sourceUrl: 'https://example.com/canada',
+  sourceName: 'Example',
+};
+
+const revealedQuestion = {
+  ...redactedQuestion,
+  answer: 'Ottawa',
+  acceptableAnswers: ['City of Ottawa'],
+  explanation: 'Ottawa is the capital of Canada.',
+};
+
+const validSnapshot = {
+  id: roomId,
+  code: 'ABCD2',
+  status: 'active' as const,
+  phase: 'QUESTION' as const,
+  version: 2,
+  hostPlayerId,
+  category: 'All' as const,
+  numRounds: 5 as const,
+  currentQuestionIndex: 0,
+  activePlayerId: hostPlayerId,
+  currentAttempt: null,
+  currentQuestion: redactedQuestion,
+  players: [
+    {
+      id: hostPlayerId,
+      nickname: 'Host',
+      joinOrder: 0,
+      score: 0,
+      questionCount: 0,
+      lastRoundDelta: 0,
+      isHost: true,
+      lastSeenAt: timestamp,
+      leftAt: null,
+    },
+  ],
+  createdAt: timestamp,
+  updatedAt: timestamp,
+  expiresAt: '2026-06-21T18:00:00.000Z',
 };
 
 describe('insertDisputeSchema', () => {
@@ -77,5 +159,160 @@ describe('insertQuestionSchema', () => {
   ])('accepts canonical category "%s"', (category) => {
     const result = insertQuestionSchema.safeParse({ ...validQuestionPayload, category });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('rooms database schemas', () => {
+  it('accepts a room insert and applies contract defaults', () => {
+    expect(
+      insertRoomSchema.parse({
+        code: 'ABCD2',
+        category: 'All',
+        numRounds: 5,
+      })
+    ).toMatchObject({
+      code: 'ABCD2',
+      status: 'lobby',
+      phase: 'LOBBY',
+      category: 'All',
+      numRounds: 5,
+      questionIds: [],
+    });
+  });
+
+  it('accepts a player insert while leaving database defaults optional', () => {
+    expect(
+      insertRoomPlayerSchema.parse({
+        roomId,
+        nickname: '  Guest  ',
+        token: 'secret-token',
+        joinOrder: 1,
+      })
+    ).toMatchObject({ roomId, nickname: 'Guest', token: 'secret-token', joinOrder: 1 });
+  });
+
+  it.each([
+    ['code', { code: 'OOPS1', category: 'All', numRounds: 5 }],
+    ['status', { code: 'ABCD2', category: 'All', numRounds: 5, status: 'waiting' }],
+    ['phase', { code: 'ABCD2', category: 'All', numRounds: 5, phase: 'VERIFYING' }],
+    ['category', { code: 'ABCD2', category: 'History', numRounds: 5 }],
+    ['numRounds', { code: 'ABCD2', category: 'All', numRounds: 7 }],
+  ])('rejects an invalid room %s', (_field, payload) => {
+    expect(insertRoomSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it.each(['', '123456789012345678901'])('rejects invalid nickname %j', (nickname) => {
+    expect(
+      insertRoomPlayerSchema.safeParse({ roomId, nickname, token: 'token', joinOrder: 1 }).success
+    ).toBe(false);
+  });
+});
+
+describe('RoomSnapshot contract', () => {
+  it('accepts a QUESTION snapshot with answer fields absent', () => {
+    const snapshot = roomSnapshotSchema.parse(validSnapshot);
+    expect(snapshot.currentQuestion).not.toHaveProperty('answer');
+    expect(snapshot.currentQuestion).not.toHaveProperty('acceptableAnswers');
+    expect(snapshot.currentQuestion).not.toHaveProperty('explanation');
+  });
+
+  it('accepts revealed answer fields for a REVEAL snapshot', () => {
+    expect(
+      roomSnapshotSchema.safeParse({
+        ...validSnapshot,
+        phase: 'REVEAL',
+        currentQuestion: revealedQuestion,
+        currentAttempt: {
+          questionId: 'q-1',
+          playerId: hostPlayerId,
+          submittedAnswer: 'Toronto',
+          verdict: 'INCORRECT',
+          pointsDelta: -2,
+        },
+      }).success
+    ).toBe(true);
+    expect(revealedRoomQuestionSchema.safeParse(revealedQuestion).success).toBe(true);
+  });
+
+  it.each([
+    ['status', 'waiting'],
+    ['phase', 'VERIFYING'],
+    ['code', 'OOPS1'],
+    ['category', 'History'],
+    ['numRounds', 7],
+  ])('rejects an invalid snapshot %s', (field, value) => {
+    expect(roomSnapshotSchema.safeParse({ ...validSnapshot, [field]: value }).success).toBe(false);
+  });
+
+  it('rejects malformed attempts', () => {
+    expect(
+      roomAttemptSchema.safeParse({
+        questionId: 'q-1',
+        playerId: 'not-a-uuid',
+        submittedAnswer: null,
+        verdict: 'PENDING',
+        pointsDelta: 0.5,
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('rooms endpoint contract', () => {
+  it('validates create, join, code params, poll query, and error payloads', () => {
+    expect(
+      createRoomRequestSchema.safeParse({ nickname: 'Host', category: 'All', numRounds: 5 }).success
+    ).toBe(true);
+    expect(joinRoomRequestSchema.safeParse({ nickname: 'Guest' }).success).toBe(true);
+    expect(roomCodeParamsSchema.safeParse({ code: 'ABCD2' }).success).toBe(true);
+    expect(pollRoomRequestSchema.parse({ sinceVersion: '2' })).toEqual({ sinceVersion: 2 });
+    expect(roomErrorResponseSchema.safeParse({ message: 'Room is full' }).success).toBe(true);
+  });
+
+  it('validates create and join responses', () => {
+    expect(
+      createRoomResponseSchema.safeParse({
+        code: 'ABCD2',
+        playerId: hostPlayerId,
+        token: 'host-token',
+      }).success
+    ).toBe(true);
+    expect(
+      joinRoomResponseSchema.safeParse({
+        playerId: guestPlayerId,
+        token: 'guest-token',
+        snapshot: validSnapshot,
+      }).success
+    ).toBe(true);
+  });
+
+  it.each([
+    ['start', startRoomRequestSchema, startRoomResponseSchema, {}],
+    ['answer', answerRoomRequestSchema, answerRoomResponseSchema, { answer: 'Ottawa' }],
+    ['pass', answerRoomRequestSchema, answerRoomResponseSchema, { answer: null }],
+    ['advance', advanceRoomRequestSchema, advanceRoomResponseSchema, {}],
+    ['continue', continueRoomRequestSchema, continueRoomResponseSchema, {}],
+    ['skip', skipRoomRequestSchema, skipRoomResponseSchema, {}],
+    ['end', endRoomRequestSchema, endRoomResponseSchema, {}],
+  ])(
+    'validates the %s endpoint request and response',
+    (_name, requestSchema, responseSchema, body) => {
+      expect(requestSchema.safeParse(body).success).toBe(true);
+      expect(responseSchema.safeParse({ snapshot: validSnapshot }).success).toBe(true);
+    }
+  );
+
+  it('accepts unchanged and changed poll responses', () => {
+    expect(pollRoomResponseSchema.safeParse({ changed: false }).success).toBe(true);
+    expect(pollRoomResponseSchema.safeParse(validSnapshot).success).toBe(true);
+    expect(pollRoomResponseSchema.safeParse({ changed: true }).success).toBe(false);
+  });
+
+  it('rejects invalid endpoint inputs', () => {
+    expect(
+      createRoomRequestSchema.safeParse({ nickname: '', category: 'All', numRounds: 5 }).success
+    ).toBe(false);
+    expect(answerRoomRequestSchema.safeParse({ answer: '' }).success).toBe(false);
+    expect(startRoomRequestSchema.safeParse({ unexpected: true }).success).toBe(false);
+    expect(roomCodeParamsSchema.safeParse({ code: 'ABCDE2' }).success).toBe(false);
   });
 });

--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -234,6 +234,29 @@ describe('RoomSnapshot contract', () => {
     expect(revealedRoomQuestionSchema.safeParse(revealedQuestion).success).toBe(true);
   });
 
+  it('rejects revealed answer fields before the REVEAL phase', () => {
+    expect(
+      roomSnapshotSchema.safeParse({
+        ...validSnapshot,
+        phase: 'QUESTION',
+        currentQuestion: revealedQuestion,
+      }).success
+    ).toBe(false);
+  });
+
+  it.each(['REVEAL', 'ROUND_SCORE', 'GAME_OVER'] as const)(
+    'requires revealed answer fields for a %s snapshot',
+    (phase) => {
+      expect(
+        roomSnapshotSchema.safeParse({
+          ...validSnapshot,
+          phase,
+          currentQuestion: redactedQuestion,
+        }).success
+      ).toBe(false);
+    }
+  );
+
   it.each([
     ['status', 'waiting'],
     ['phase', 'VERIFYING'],

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { pgTable, text, varchar, timestamp, boolean, jsonb } from 'drizzle-orm/pg-core';
+import { pgTable, text, varchar, timestamp, jsonb } from 'drizzle-orm/pg-core';
 import { createInsertSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
@@ -17,6 +17,9 @@ export * from './models/quality-sweep';
 
 // Export quality sweep dismissals (DB table)
 export * from './models/quality-sweep-dismissals';
+
+// Export multiplayer rooms tables and API contract
+export * from './models/rooms';
 
 // Disputes table for QA logging
 export const disputes = pgTable('disputes', {


### PR DESCRIPTION
## What changed

- added the `rooms` and `room_players` Drizzle models with PostgreSQL room status/phase enums, defaults, player references, cascade behavior, token/code uniqueness, case-insensitive nickname uniqueness per room, and unique turn order per room
- added the complete shared Zod/TypeScript contract for room snapshots and every multiplayer endpoint
- made snapshots phase-specific: `QUESTION` rejects answer fields, while `REVEAL`, `ROUND_SCORE`, and `GAME_OVER` require revealed answer data
- re-exported the contract from `shared/schema.ts`
- added `0003_create_rooms.sql` using an idempotent Drizzle custom migration scaffold, including the `(room_id, join_order)` unique index
- extended shared schema coverage for database inputs, snapshot redaction/reveal shapes, endpoint requests/responses, invalid values, pre-reveal answer rejection, and post-reveal answer requirements

## Why

STE-202 is the shared foundation for the multiplayer server and client lanes. Landing the schema and wire contract first lets STE-204, STE-205, STE-206, and STE-211 build against one source of truth. The review follow-up prevents answer leakage before reveal and prevents ambiguous persisted turn order during concurrent joins or retries.

## Migration note

The migration was generated and inspected but was **not applied to any database**. A separate Drizzle generation against only `shared/models/rooms.ts` produced matching tables, enums, foreign keys, and indexes.

## Validation

- `npm test -- --run shared/schema.test.ts` - 48 tests passed
- `npm run check` - passed
- `npm test` - 24 files, 257 tests passed
- ESLint - 0 errors, 21 existing warnings outside this change
- `npx prettier --check shared/models/rooms.ts shared/schema.test.ts` - passed
- `git diff --check` - passed

Linear: [STE-202](https://linear.app/stephs-vibe-coding/issue/STE-202/featdb-rooms-schema-migration-and-roomsnapshot-api-contract-lane-a-m)
