### PR TITLE
feat(client): home mode chooser and multiplayer route scaffolding [STE-203]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ LINEAR_API_KEY=your-linear-api-key-here
 
 # Optional until STE-15.
 AI_INTEGRATIONS_OPENAI_API_KEY=
+
+# Optional: gates multiplayer room UI (host/join/room routes). Defaults to false.
+VITE_MULTIPLAYER=false

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,9 @@ import { GameProvider } from '@/lib/store';
 import { Toaster } from '@/components/ui/toaster';
 import Home from '@/pages/Home';
 import Game from '@/pages/Game';
+import HostGame from '@/pages/HostGame';
+import JoinGame from '@/pages/JoinGame';
+import Room from '@/pages/Room';
 import Admin from '@/pages/Admin';
 import AdminDisputes from '@/pages/admin-disputes';
 import AdminSettings from '@/pages/admin-settings';
@@ -12,12 +15,17 @@ import AdminStaging from '@/pages/admin-staging';
 import AdminQuestions from '@/pages/admin-questions';
 import AdminQualitySweep from '@/pages/admin-quality-sweep';
 import NotFound from '@/pages/not-found';
+import { MULTIPLAYER } from '@/lib/featureFlags';
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
       <Route path="/game" component={Game} />
+      {MULTIPLAYER && <Route path="/host" component={HostGame} />}
+      {MULTIPLAYER && <Route path="/join" component={JoinGame} />}
+      {MULTIPLAYER && <Route path="/join/:code" component={JoinGame} />}
+      {MULTIPLAYER && <Route path="/room/:code" component={Room} />}
       <Route path="/admin" component={Admin} />
       <Route path="/admin/staging" component={AdminStaging} />
       <Route path="/admin/questions" component={AdminQuestions} />

--- a/client/src/lib/featureFlags.ts
+++ b/client/src/lib/featureFlags.ts
@@ -1,0 +1,1 @@
+export const MULTIPLAYER = import.meta.env.VITE_MULTIPLAYER === 'true';

--- a/client/src/pages/Home.multiplayer.test.tsx
+++ b/client/src/pages/Home.multiplayer.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Home from './Home';
+import { GameProvider } from '@/lib/store';
+
+// Stub localStorage for jsdom compatibility
+const storage: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage[key] ?? null,
+  setItem: (key: string, value: string) => {
+    storage[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete storage[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(storage)) delete storage[key];
+  },
+});
+
+function createFetchMock() {
+  return vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ questions: [], categories: [] }),
+    } as Response)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mocks — same as Home.test.tsx, but with MULTIPLAYER enabled
+// ---------------------------------------------------------------------------
+
+const mockSetLocation = vi.fn();
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/', mockSetLocation],
+}));
+
+vi.mock('@/lib/featureFlags', () => ({
+  MULTIPLAYER: true,
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({
+    user: null,
+    isLoading: false,
+    isAuthenticated: false,
+    logout: vi.fn(),
+    isLoggingOut: false,
+  }),
+}));
+
+vi.mock('@/hooks/use-admin', () => ({
+  useAdmin: () => ({
+    isAdmin: false,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: React.forwardRef(
+      (
+        {
+          children,
+          layout: _layout,
+          ...props
+        }: React.HTMLAttributes<HTMLDivElement> & {
+          layout?: boolean;
+        },
+        ref: React.Ref<HTMLDivElement>
+      ) => (
+        <div ref={ref} {...props}>
+          {children}
+        </div>
+      )
+    ),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function renderHome() {
+  return render(
+    <GameProvider>
+      <Home />
+    </GameProvider>
+  );
+}
+
+describe('Home page with VITE_MULTIPLAYER enabled', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockSetLocation.mockClear();
+    vi.stubGlobal('fetch', createFetchMock());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the mode chooser instead of the solo setup screen', () => {
+    renderHome();
+    expect(screen.getByTestId('button-mode-solo')).toBeDefined();
+    expect(screen.getByTestId('button-mode-host')).toBeDefined();
+    expect(screen.getByTestId('button-mode-join')).toBeDefined();
+    expect(screen.queryByText('Team Setup')).toBeNull();
+  });
+
+  it('navigates to /host when "Host a Game" is clicked', () => {
+    renderHome();
+    fireEvent.click(screen.getByTestId('button-mode-host'));
+    expect(mockSetLocation).toHaveBeenCalledWith('/host');
+  });
+
+  it('navigates to /join when "Join a Game" is clicked', () => {
+    renderHome();
+    fireEvent.click(screen.getByTestId('button-mode-join'));
+    expect(mockSetLocation).toHaveBeenCalledWith('/join');
+  });
+
+  it('shows the existing solo setup flow after clicking "Play Solo"', async () => {
+    renderHome();
+    fireEvent.click(screen.getByTestId('button-mode-solo'));
+    expect(await screen.findByText('Team Setup')).toBeDefined();
+  });
+});

--- a/client/src/pages/Home.test.tsx
+++ b/client/src/pages/Home.test.tsx
@@ -77,6 +77,10 @@ vi.mock('wouter', () => ({
   useLocation: () => ['/', vi.fn()],
 }));
 
+vi.mock('@/lib/featureFlags', () => ({
+  MULTIPLAYER: false,
+}));
+
 vi.mock('@/hooks/use-auth', () => ({
   useAuth: () => ({
     user: null,

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -7,10 +7,93 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { X, Plus, Settings, Users, Zap, LogIn, LogOut, Shield, AlertTriangle } from 'lucide-react';
+import { X, Plus, Settings, Users, Zap, LogIn, LogOut, Shield, AlertTriangle, UserPlus } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { MULTIPLAYER } from '@/lib/featureFlags';
 
 export default function Home() {
+  const [, setLocation] = useLocation();
+  const [mode, setMode] = useState<'choose' | 'solo'>(MULTIPLAYER ? 'choose' : 'solo');
+
+  if (MULTIPLAYER && mode === 'choose') {
+    return (
+      <ModeChooser
+        onPlaySolo={() => setMode('solo')}
+        onHost={() => setLocation('/host')}
+        onJoin={() => setLocation('/join')}
+      />
+    );
+  }
+
+  return <SoloSetup />;
+}
+
+function ModeChooser({
+  onPlaySolo,
+  onHost,
+  onJoin,
+}: {
+  onPlaySolo: () => void;
+  onHost: () => void;
+  onJoin: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-900 via-background to-background">
+      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-primary/20 rounded-full blur-[120px] opacity-50" />
+        <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] bg-blue-500/10 rounded-full blur-[120px] opacity-50" />
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="w-full max-w-md z-10 space-y-8"
+      >
+        <div className="text-center space-y-2">
+          <h1 className="text-6xl font-extrabold tracking-tighter bg-gradient-to-br from-white to-white/50 bg-clip-text text-transparent drop-shadow-sm">
+            TRIVIA
+            <br />
+            CLASH
+          </h1>
+          <p className="text-muted-foreground font-medium tracking-wide">
+            THE COMPETITIVE PARTY GAME
+          </p>
+        </div>
+
+        <div className="flex flex-col w-full gap-4">
+          <Button
+            className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
+            onClick={onPlaySolo}
+            data-testid="button-mode-solo"
+          >
+            <Users className="w-5 h-5 mr-2" />
+            Play Solo
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl border-white/10 hover:bg-white/10"
+            onClick={onHost}
+            data-testid="button-mode-host"
+          >
+            <UserPlus className="w-5 h-5 mr-2" />
+            Host a Game
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl border-white/10 hover:bg-white/10"
+            onClick={onJoin}
+            data-testid="button-mode-join"
+          >
+            <LogIn className="w-5 h-5 mr-2" />
+            Join a Game
+          </Button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+function SoloSetup() {
   const [_, setLocation] = useLocation();
   const { state, addTeam, removeTeam, setCategory, setNumRounds, startGame } = useGame();
   const { user, isAuthenticated, logout } = useAuth();

--- a/client/src/pages/HostGame.tsx
+++ b/client/src/pages/HostGame.tsx
@@ -1,0 +1,17 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+export default function HostGame() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
+        <CardHeader>
+          <CardTitle>Host a Game</CardTitle>
+          <CardDescription>Multiplayer hosting is coming soon.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">This screen is a placeholder for STE-207.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/JoinGame.tsx
+++ b/client/src/pages/JoinGame.tsx
@@ -1,0 +1,24 @@
+import { useParams } from 'wouter';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+export default function JoinGame() {
+  const { code } = useParams<{ code?: string }>();
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
+        <CardHeader>
+          <CardTitle>Join a Game</CardTitle>
+          <CardDescription>Multiplayer joining is coming soon.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            {code
+              ? `This screen is a placeholder for STE-208 (room code: ${code}).`
+              : 'This screen is a placeholder for STE-208.'}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -1,0 +1,20 @@
+import { useParams } from 'wouter';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+export default function Room() {
+  const { code } = useParams<{ code: string }>();
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
+        <CardHeader>
+          <CardTitle>Room {code}</CardTitle>
+          <CardDescription>Multiplayer gameplay is coming soon.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">This screen is a placeholder for STE-209 / STE-211.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `VITE_MULTIPLAYER` feature flag (`client/src/lib/featureFlags.ts`), following the existing `VITE_PIXEL_UI` pattern.
- Flag off (default): Home renders exactly as today, no multiplayer routes registered.
- Flag on: Home shows a mode chooser (Play Solo / Host a Game / Join a Game, stacked full-width buttons); "Play Solo" enters the existing unchanged team-setup flow; "Host a Game" and "Join a Game" navigate to new placeholder routes.
- Registers `/host`, `/join`, `/join/:code`, `/room/:code` in `client/src/App.tsx`, gated behind the flag.
- New placeholder pages: `HostGame.tsx`, `JoinGame.tsx`, `Room.tsx` (for STE-207/STE-208/STE-209/STE-211).
- Documents `VITE_MULTIPLAYER=false` in `.env.example`.
- Updates `Home.test.tsx` (flag-off regression coverage) and adds `Home.multiplayer.test.tsx` (flag-on: chooser renders, Host/Join navigate, Play Solo shows existing setup flow).

Client-only change per ticket scope; `shared/` and `server/` untouched.

## Test plan
- [x] `npm run check` — no type errors
- [x] `npm test` — 25 test files / 261 tests passing
- [x] Manually verified in browser with `VITE_MULTIPLAYER=true`: mode chooser renders, Host/Join/Room routes and room-code param display correctly, Play Solo transitions into the existing setup flow
- [x] Manually verified with `VITE_MULTIPLAYER=false` (default): Home unchanged, `/host` returns 404 (route not registered)