### PR TITLE
feat(client): add useRoom polling hook and player token storage [STE-205]

### DIFF
--- a/client/src/hooks/use-room.test.tsx
+++ b/client/src/hooks/use-room.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RoomSnapshot } from '@shared/models/rooms';
 
 import { saveRoomSession } from '@/lib/room-session';
-import { buildPollUrl, getPollIntervalMs, useRoom } from './use-room';
+import { buildPollUrl, getPollIntervalMs, newerSnapshot, useRoom } from './use-room';
 
 const baseSnapshot: RoomSnapshot = {
   id: '11111111-1111-4111-8111-111111111111',
@@ -33,7 +33,7 @@ function createWrapper() {
   function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   }
-  return Wrapper;
+  return { Wrapper, queryClient };
 }
 
 function jsonResponse(body: unknown, status = 200) {
@@ -64,6 +64,21 @@ describe('buildPollUrl', () => {
 
   it('appends sinceVersion once a snapshot version is known', () => {
     expect(buildPollUrl('ABCD2', 3)).toBe('/api/rooms/ABCD2?sinceVersion=3');
+  });
+});
+
+describe('newerSnapshot', () => {
+  it('keeps the current snapshot when the candidate is not newer', () => {
+    const current = { ...baseSnapshot, version: 3 };
+    const candidate = { ...baseSnapshot, version: 2 };
+    expect(newerSnapshot(candidate, current)).toBe(current);
+    expect(newerSnapshot({ ...baseSnapshot, version: 3 }, current)).toBe(current);
+  });
+
+  it('adopts the candidate when it is newer or nothing is cached yet', () => {
+    const candidate = { ...baseSnapshot, version: 4 };
+    expect(newerSnapshot(candidate, { ...baseSnapshot, version: 3 })).toBe(candidate);
+    expect(newerSnapshot(candidate, undefined)).toBe(candidate);
   });
 });
 
@@ -99,7 +114,7 @@ describe('useRoom', () => {
     saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'secret-token' });
     fetchMock.mockResolvedValue(jsonResponse(baseSnapshot));
 
-    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper().Wrapper });
 
     await waitFor(() => expect(result.current.snapshot).toBeDefined());
 
@@ -112,7 +127,7 @@ describe('useRoom', () => {
   it('omits the token header when no session is stored', async () => {
     fetchMock.mockResolvedValue(jsonResponse(baseSnapshot));
 
-    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper().Wrapper });
 
     await waitFor(() => expect(result.current.snapshot).toBeDefined());
 
@@ -124,7 +139,7 @@ describe('useRoom', () => {
       .mockResolvedValueOnce(jsonResponse(baseSnapshot))
       .mockResolvedValueOnce(jsonResponse({ changed: false }));
 
-    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper().Wrapper });
 
     await waitFor(() => expect(result.current.snapshot).toBeDefined());
     const firstSnapshot = result.current.snapshot;
@@ -144,7 +159,7 @@ describe('useRoom', () => {
     vi.useFakeTimers();
     fetchMock.mockResolvedValue(new Response('Server error', { status: 500, statusText: 'Server error' }));
 
-    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper().Wrapper });
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -163,5 +178,66 @@ describe('useRoom', () => {
       await result.current.refetch();
     });
     expect(result.current.isDisconnected).toBe(false);
+  });
+
+  it('does not let a stale in-flight poll roll back a newer snapshot written by a mutation', async () => {
+    let resolveStalePoll!: (res: Response) => void;
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(baseSnapshot)) // initial mount fetch -> version 1
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveStalePoll = resolve;
+          })
+      );
+
+    const { Wrapper, queryClient } = createWrapper();
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.snapshot?.version).toBe(1));
+
+    let stalePoll!: Promise<unknown>;
+    act(() => {
+      stalePoll = result.current.refetch();
+    });
+
+    // A mutation (e.g. `answer`) resolves while the poll above is still in
+    // flight and writes a newer snapshot into the cache.
+    const newer = { ...baseSnapshot, version: 2, phase: 'REVEAL' as const };
+    act(() => {
+      queryClient.setQueryData(['/api/rooms', 'ABCD2'], newer);
+    });
+
+    // The stale poll now resolves as unchanged relative to the version it
+    // was sent with (1), which must not overwrite the newer cached data.
+    await act(async () => {
+      resolveStalePoll(jsonResponse({ changed: false }));
+      await stalePoll;
+    });
+
+    await waitFor(() => expect(result.current.snapshot).toEqual(newer));
+  });
+
+  it('does not let a stale mutation response overwrite a newer snapshot already in the cache', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(baseSnapshot));
+
+    const { Wrapper, queryClient } = createWrapper();
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.snapshot?.version).toBe(1));
+
+    // A concurrent poll (or another mutation) has already advanced the room
+    // past what this in-flight mutation is about to report.
+    const newer = { ...baseSnapshot, version: 5, phase: 'GAME_OVER' as const };
+    act(() => {
+      queryClient.setQueryData(['/api/rooms', 'ABCD2'], newer);
+    });
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ snapshot: { ...baseSnapshot, version: 2 } }));
+    await act(async () => {
+      await result.current.advance.mutateAsync();
+    });
+
+    await waitFor(() => expect(result.current.snapshot).toEqual(newer));
   });
 });

--- a/client/src/hooks/use-room.test.tsx
+++ b/client/src/hooks/use-room.test.tsx
@@ -1,0 +1,167 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RoomSnapshot } from '@shared/models/rooms';
+
+import { saveRoomSession } from '@/lib/room-session';
+import { buildPollUrl, getPollIntervalMs, useRoom } from './use-room';
+
+const baseSnapshot: RoomSnapshot = {
+  id: '11111111-1111-4111-8111-111111111111',
+  code: 'ABCD2',
+  status: 'lobby',
+  phase: 'LOBBY',
+  version: 1,
+  hostPlayerId: null,
+  category: 'All',
+  numRounds: 5,
+  currentQuestionIndex: 0,
+  activePlayerId: null,
+  currentAttempt: null,
+  currentQuestion: null,
+  players: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  expiresAt: '2026-01-02T00:00:00.000Z',
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return Wrapper;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('getPollIntervalMs', () => {
+  it.each(['LOBBY', 'QUESTION', 'REVEAL'] as const)('polls every 2s during %s', (phase) => {
+    expect(getPollIntervalMs(phase)).toBe(2000);
+  });
+
+  it.each(['ROUND_SCORE', 'GAME_OVER'] as const)('polls every 5s during %s', (phase) => {
+    expect(getPollIntervalMs(phase)).toBe(5000);
+  });
+
+  it('defaults to the fast interval before any snapshot has loaded', () => {
+    expect(getPollIntervalMs(undefined)).toBe(2000);
+  });
+});
+
+describe('buildPollUrl', () => {
+  it('omits sinceVersion when not yet known', () => {
+    expect(buildPollUrl('ABCD2')).toBe('/api/rooms/ABCD2');
+  });
+
+  it('appends sinceVersion once a snapshot version is known', () => {
+    expect(buildPollUrl('ABCD2', 3)).toBe('/api/rooms/ABCD2?sinceVersion=3');
+  });
+});
+
+describe('useRoom', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Stub localStorage for jsdom compatibility
+    const storage: Record<string, string> = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete storage[key];
+      },
+      clear: () => {
+        for (const key of Object.keys(storage)) delete storage[key];
+      },
+    });
+
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('sends the stored player token as an X-Player-Token header', async () => {
+    saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'secret-token' });
+    fetchMock.mockResolvedValue(jsonResponse(baseSnapshot));
+
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.snapshot).toBeDefined());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      buildPollUrl('ABCD2'),
+      expect.objectContaining({ headers: { 'X-Player-Token': 'secret-token' } })
+    );
+  });
+
+  it('omits the token header when no session is stored', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(baseSnapshot));
+
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.snapshot).toBeDefined());
+
+    expect(fetchMock).toHaveBeenCalledWith(buildPollUrl('ABCD2'), expect.objectContaining({ headers: {} }));
+  });
+
+  it('requests sinceVersion on the next poll and keeps the same snapshot reference when unchanged', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(baseSnapshot))
+      .mockResolvedValueOnce(jsonResponse({ changed: false }));
+
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.snapshot).toBeDefined());
+    const firstSnapshot = result.current.snapshot;
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      buildPollUrl('ABCD2', baseSnapshot.version),
+      expect.anything()
+    );
+    expect(result.current.snapshot).toBe(firstSnapshot);
+  });
+
+  it('marks the room disconnected after two consecutive poll failures and recovers on the next success', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(new Response('Server error', { status: 500, statusText: 'Server error' }));
+
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.isDisconnected).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.isDisconnected).toBe(true);
+
+    fetchMock.mockResolvedValue(jsonResponse(baseSnapshot));
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(result.current.isDisconnected).toBe(false);
+  });
+});

--- a/client/src/hooks/use-room.ts
+++ b/client/src/hooks/use-room.ts
@@ -87,6 +87,13 @@ function roomQueryKey(code: string) {
   return ['/api/rooms', code] as const;
 }
 
+// Never let a write (poll or mutation response) regress the cache to an
+// older version — the two can race, since polls and mutations both hit the
+// network concurrently and settle in whatever order the server responds.
+export function newerSnapshot(candidate: RoomSnapshot, current: RoomSnapshot | undefined): RoomSnapshot {
+  return current && current.version >= candidate.version ? current : candidate;
+}
+
 export interface UseRoomResult {
   snapshot: RoomSnapshot | undefined;
   isLoading: boolean;
@@ -110,20 +117,22 @@ export function useRoom(code: string): UseRoomResult {
   const query = useQuery<RoomSnapshot>({
     queryKey,
     queryFn: async () => {
-      const previous = queryClient.getQueryData<RoomSnapshot>(queryKey);
+      const basis = queryClient.getQueryData<RoomSnapshot>(queryKey);
 
       try {
-        const result = await fetchSnapshot(code, previous?.version);
+        const result = await fetchSnapshot(code, basis?.version);
         setFailureCount(0);
 
+        // A mutation (or a faster overlapping poll) may have written a newer
+        // snapshot into the cache while this fetch was in flight.
+        const current = queryClient.getQueryData<RoomSnapshot>(queryKey);
+
         if ('changed' in result) {
-          if (!previous) {
-            throw new Error('Room snapshot unavailable');
-          }
-          return previous;
+          if (current) return current;
+          throw new Error('Room snapshot unavailable');
         }
 
-        return result;
+        return newerSnapshot(result, current);
       } catch (err) {
         setFailureCount((count) => count + 1);
         throw err;
@@ -147,7 +156,7 @@ export function useRoom(code: string): UseRoomResult {
 
   const onActionSuccess = useCallback(
     (response: RoomActionResponse) => {
-      queryClient.setQueryData(queryKey, response.snapshot);
+      queryClient.setQueryData<RoomSnapshot>(queryKey, (current) => newerSnapshot(response.snapshot, current));
     },
     [queryClient, queryKey]
   );
@@ -157,7 +166,7 @@ export function useRoom(code: string): UseRoomResult {
       postRoomAction<JoinRoomRequest, JoinRoomResponse>(code, 'join', body),
     onSuccess: (response) => {
       saveRoomSession({ code, playerId: response.playerId, token: response.token });
-      queryClient.setQueryData(queryKey, response.snapshot);
+      queryClient.setQueryData<RoomSnapshot>(queryKey, (current) => newerSnapshot(response.snapshot, current));
     },
   });
 

--- a/client/src/hooks/use-room.ts
+++ b/client/src/hooks/use-room.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import type {
+  AdvanceRoomResponse,
+  AnswerRoomRequest,
+  AnswerRoomResponse,
+  ContinueRoomResponse,
+  EndRoomResponse,
+  JoinRoomRequest,
+  JoinRoomResponse,
+  RoomActionResponse,
+  RoomPhase,
+  RoomPollResponse,
+  RoomSnapshot,
+  SkipRoomResponse,
+  StartRoomResponse,
+} from '@shared/models/rooms';
+
+import { getRoomSession, saveRoomSession } from '@/lib/room-session';
+
+const FAST_POLL_MS = 2000;
+const SLOW_POLL_MS = 5000;
+const FAST_POLL_PHASES: readonly RoomPhase[] = ['LOBBY', 'QUESTION', 'REVEAL'];
+const DISCONNECT_THRESHOLD = 2;
+
+export function getPollIntervalMs(phase: RoomPhase | undefined): number {
+  if (!phase) return FAST_POLL_MS;
+  return FAST_POLL_PHASES.includes(phase) ? FAST_POLL_MS : SLOW_POLL_MS;
+}
+
+export function buildPollUrl(code: string, sinceVersion?: number): string {
+  const base = `/api/rooms/${encodeURIComponent(code)}`;
+  return sinceVersion === undefined ? base : `${base}?sinceVersion=${sinceVersion}`;
+}
+
+function roomActionUrl(code: string, action: string): string {
+  return `/api/rooms/${encodeURIComponent(code)}/${action}`;
+}
+
+function authHeaders(code: string): HeadersInit {
+  const session = getRoomSession(code);
+  return session ? { 'X-Player-Token': session.token } : {};
+}
+
+async function parseResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const body = await res.json();
+      if (typeof body?.message === 'string') message = body.message;
+    } catch {
+      // response had no JSON body; fall back to statusText
+    }
+    throw new Error(message);
+  }
+  return res.json() as Promise<T>;
+}
+
+async function fetchSnapshot(code: string, sinceVersion: number | undefined): Promise<RoomPollResponse> {
+  const res = await fetch(buildPollUrl(code, sinceVersion), {
+    credentials: 'include',
+    headers: authHeaders(code),
+  });
+  return parseResponse<RoomPollResponse>(res);
+}
+
+async function postRoomAction<TReq, TRes>(code: string, action: string, body: TReq): Promise<TRes> {
+  const res = await fetch(roomActionUrl(code, action), {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(code),
+    },
+    body: JSON.stringify(body),
+  });
+  return parseResponse<TRes>(res);
+}
+
+function roomQueryKey(code: string) {
+  return ['/api/rooms', code] as const;
+}
+
+export interface UseRoomResult {
+  snapshot: RoomSnapshot | undefined;
+  isLoading: boolean;
+  isDisconnected: boolean;
+  error: Error | null;
+  refetch: UseQueryResult<RoomSnapshot, Error>['refetch'];
+  join: UseMutationResult<JoinRoomResponse, Error, JoinRoomRequest>;
+  start: UseMutationResult<StartRoomResponse, Error, void>;
+  answer: UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest>;
+  advance: UseMutationResult<AdvanceRoomResponse, Error, void>;
+  continueRound: UseMutationResult<ContinueRoomResponse, Error, void>;
+  skip: UseMutationResult<SkipRoomResponse, Error, void>;
+  end: UseMutationResult<EndRoomResponse, Error, void>;
+}
+
+export function useRoom(code: string): UseRoomResult {
+  const queryClient = useQueryClient();
+  const queryKey = roomQueryKey(code);
+  const [failureCount, setFailureCount] = useState(0);
+
+  const query = useQuery<RoomSnapshot>({
+    queryKey,
+    queryFn: async () => {
+      const previous = queryClient.getQueryData<RoomSnapshot>(queryKey);
+
+      try {
+        const result = await fetchSnapshot(code, previous?.version);
+        setFailureCount(0);
+
+        if ('changed' in result) {
+          if (!previous) {
+            throw new Error('Room snapshot unavailable');
+          }
+          return previous;
+        }
+
+        return result;
+      } catch (err) {
+        setFailureCount((count) => count + 1);
+        throw err;
+      }
+    },
+    refetchInterval: (fetchQuery) => getPollIntervalMs(fetchQuery.state.data?.phase),
+    refetchIntervalInBackground: false,
+    staleTime: 0,
+  });
+
+  useEffect(() => {
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        query.refetch();
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [query.refetch]);
+
+  const onActionSuccess = useCallback(
+    (response: RoomActionResponse) => {
+      queryClient.setQueryData(queryKey, response.snapshot);
+    },
+    [queryClient, queryKey]
+  );
+
+  const join = useMutation({
+    mutationFn: (body: JoinRoomRequest) =>
+      postRoomAction<JoinRoomRequest, JoinRoomResponse>(code, 'join', body),
+    onSuccess: (response) => {
+      saveRoomSession({ code, playerId: response.playerId, token: response.token });
+      queryClient.setQueryData(queryKey, response.snapshot);
+    },
+  });
+
+  const start = useMutation({
+    mutationFn: () => postRoomAction<Record<string, never>, StartRoomResponse>(code, 'start', {}),
+    onSuccess: onActionSuccess,
+  });
+
+  const answer = useMutation({
+    mutationFn: (body: AnswerRoomRequest) =>
+      postRoomAction<AnswerRoomRequest, AnswerRoomResponse>(code, 'answer', body),
+    onSuccess: onActionSuccess,
+  });
+
+  const advance = useMutation({
+    mutationFn: () => postRoomAction<Record<string, never>, AdvanceRoomResponse>(code, 'advance', {}),
+    onSuccess: onActionSuccess,
+  });
+
+  const continueRound = useMutation({
+    mutationFn: () => postRoomAction<Record<string, never>, ContinueRoomResponse>(code, 'continue', {}),
+    onSuccess: onActionSuccess,
+  });
+
+  const skip = useMutation({
+    mutationFn: () => postRoomAction<Record<string, never>, SkipRoomResponse>(code, 'skip', {}),
+    onSuccess: onActionSuccess,
+  });
+
+  const end = useMutation({
+    mutationFn: () => postRoomAction<Record<string, never>, EndRoomResponse>(code, 'end', {}),
+    onSuccess: onActionSuccess,
+  });
+
+  return {
+    snapshot: query.data,
+    isLoading: query.isLoading,
+    isDisconnected: failureCount >= DISCONNECT_THRESHOLD,
+    error: query.error,
+    refetch: query.refetch,
+    join,
+    start,
+    answer,
+    advance,
+    continueRound,
+    skip,
+    end,
+  };
+}

--- a/client/src/lib/room-session.test.ts
+++ b/client/src/lib/room-session.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearRoomSession, getRoomSession, saveRoomSession } from './room-session';
+
+// Stub localStorage for jsdom compatibility
+const storage: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage[key] ?? null,
+  setItem: (key: string, value: string) => {
+    storage[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete storage[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(storage)) delete storage[key];
+  },
+});
+
+describe('room-session', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('round-trips a saved session', () => {
+    saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'token-1' });
+
+    expect(getRoomSession('ABCD2')).toEqual({
+      code: 'ABCD2',
+      playerId: 'player-1',
+      token: 'token-1',
+    });
+  });
+
+  it('looks up sessions case-insensitively by room code', () => {
+    saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'token-1' });
+
+    expect(getRoomSession('abcd2')).toEqual({
+      code: 'ABCD2',
+      playerId: 'player-1',
+      token: 'token-1',
+    });
+  });
+
+  it('returns null when no session is stored', () => {
+    expect(getRoomSession('ZZZZZ')).toBeNull();
+  });
+
+  it('returns null for malformed stored data instead of throwing', () => {
+    localStorage.setItem('trivia:room-session:ABCD2', 'not-json');
+    expect(getRoomSession('ABCD2')).toBeNull();
+
+    localStorage.setItem('trivia:room-session:ABCD2', JSON.stringify({ code: 'ABCD2' }));
+    expect(getRoomSession('ABCD2')).toBeNull();
+  });
+
+  it('clears a stored session', () => {
+    saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'token-1' });
+    clearRoomSession('ABCD2');
+    expect(getRoomSession('ABCD2')).toBeNull();
+  });
+});

--- a/client/src/lib/room-session.ts
+++ b/client/src/lib/room-session.ts
@@ -1,0 +1,41 @@
+export interface RoomSession {
+  code: string;
+  playerId: string;
+  token: string;
+}
+
+const STORAGE_PREFIX = 'trivia:room-session:';
+
+function storageKey(code: string): string {
+  return `${STORAGE_PREFIX}${code.toUpperCase()}`;
+}
+
+export function saveRoomSession(session: RoomSession): void {
+  localStorage.setItem(storageKey(session.code), JSON.stringify(session));
+}
+
+export function getRoomSession(code: string): RoomSession | null {
+  const raw = localStorage.getItem(storageKey(code));
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof parsed.code === 'string' &&
+      typeof parsed.playerId === 'string' &&
+      typeof parsed.token === 'string'
+    ) {
+      return parsed as RoomSession;
+    }
+  } catch {
+    // malformed JSON left over from an older schema; treat as no session
+  }
+
+  return null;
+}
+
+export function clearRoomSession(code: string): void {
+  localStorage.removeItem(storageKey(code));
+}


### PR DESCRIPTION
## Summary
- Adds `client/src/hooks/use-room.ts`: a React Query-backed `useRoom(code)` hook that polls the room snapshot (`RoomSnapshot` from `shared/models/rooms.ts`, landed in STE-202/#119), with a phase-aware `refetchInterval` (2s during LOBBY/QUESTION/REVEAL, 5s during ROUND_SCORE/GAME_OVER), no polling while the tab is backgrounded, and an immediate refetch on `visibilitychange`.
- Sends `?sinceVersion=` on every poll and merges `{changed: false}` responses by returning the previous snapshot object unchanged (same reference), so consumers relying on referential equality don't re-render on no-op polls.
- Sends `X-Player-Token` from the new `client/src/lib/room-session.ts` localStorage helper (`saveRoomSession` / `getRoomSession` / `clearRoomSession`, keyed by room code) on both polls and mutations.
- Exposes `join` / `start` / `answer` / `advance` / `continueRound` / `skip` / `end` mutations that write the returned snapshot straight into the query cache on success and surface 4xx/5xx error messages via the mutation's `error` state. `join` also persists the new player session.
- Tracks consecutive poll failures and exposes `isDisconnected` once it reaches 2, for a reconnecting banner.

**Note on API surface:** `STE-204` (room lifecycle API) hasn't landed yet, so the endpoint paths this hook calls (`POST /api/rooms/:code/join`, `GET /api/rooms/:code`, `POST /api/rooms/:code/{start,answer,advance,continue,skip,end}`) are an assumption based on the `shared/models/rooms.ts` request/response schemas, not a confirmed contract. Please reconcile these paths with STE-204 when it's implemented.

**Process note:** Per `docs/guides/ste_12_parallel_plan.md`, STE-205 is listed as Codex-owned; this PR was implemented by Claude at the user's explicit direction. Flagging for visibility in case Codex has already started or has WIP on the same ticket — worth checking Linear before merge.

## Tests
- `client/src/hooks/use-room.test.tsx`: interval switching (`getPollIntervalMs`), `sinceVersion` URL building, token header on poll, `{changed:false}` merge keeping snapshot referentially stable, and the 2-failure disconnect/recovery counter (via fake timers).
- `client/src/lib/room-session.test.ts`: save/get/clear round-trip, case-insensitive code lookup, malformed-storage handling.

## Test plan
- [x] `npm test` (278/278 passing)
- [x] `npx tsc --noEmit` (clean)
- [ ] Manual verification blocked until STE-204's API endpoints exist — no server routes to hit yet.