### PR TITLE
feat(client): add host flow UI for creating a multiplayer room [STE-207]

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,7 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { GameProvider } from '@/lib/store';
 import { Toaster } from '@/components/ui/toaster';
-import { Toaster as SonnerToaster } from '@/components/ui/sonner';
+import { Toaster as Sonner } from 'sonner';
 import Home from '@/pages/Home';
 import Game from '@/pages/Game';
 import HostGame from '@/pages/HostGame';
@@ -45,7 +45,7 @@ function App() {
         <div className="min-h-screen bg-background text-foreground font-sans selection:bg-primary selection:text-primary-foreground">
           <Router />
           <Toaster />
-          <SonnerToaster />
+          <Sonner theme="dark" />
         </div>
       </GameProvider>
     </QueryClientProvider>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { GameProvider } from '@/lib/store';
 import { Toaster } from '@/components/ui/toaster';
+import { Toaster as SonnerToaster } from '@/components/ui/sonner';
 import Home from '@/pages/Home';
 import Game from '@/pages/Game';
 import HostGame from '@/pages/HostGame';
@@ -44,6 +45,7 @@ function App() {
         <div className="min-h-screen bg-background text-foreground font-sans selection:bg-primary selection:text-primary-foreground">
           <Router />
           <Toaster />
+          <SonnerToaster />
         </div>
       </GameProvider>
     </QueryClientProvider>

--- a/client/src/hooks/use-category-counts.ts
+++ b/client/src/hooks/use-category-counts.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+import type { Question } from '@/lib/store';
+
+export function useCategoryCounts(questions: Question[]): Record<string, number> {
+  return useMemo(() => {
+    const counts: Record<string, number> = {};
+    questions.forEach((q) => {
+      counts[q.category] = (counts[q.category] || 0) + 1;
+    });
+    counts['All'] = questions.length;
+    return counts;
+  }, [questions]);
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,13 +1,25 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'wouter';
 import { useGame, QUESTIONS_PER_TEAM_ROTATION } from '@/lib/store';
 import { useAuth } from '@/hooks/use-auth';
 import { useAdmin } from '@/hooks/use-admin';
+import { useCategoryCounts } from '@/hooks/use-category-counts';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { X, Plus, Settings, Users, Zap, LogIn, LogOut, Shield, AlertTriangle, UserPlus } from 'lucide-react';
+import {
+  X,
+  Plus,
+  Settings,
+  Users,
+  Zap,
+  LogIn,
+  LogOut,
+  Shield,
+  AlertTriangle,
+  UserPlus,
+} from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { MULTIPLAYER } from '@/lib/featureFlags';
 
@@ -100,18 +112,12 @@ function SoloSetup() {
   const { isAdmin } = useAdmin();
   const [newTeamName, setNewTeamName] = useState('');
 
-  const categoryCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    state.questions.forEach((q) => {
-      counts[q.category] = (counts[q.category] || 0) + 1;
-    });
-    counts['All'] = state.questions.length;
-    return counts;
-  }, [state.questions]);
+  const categoryCounts = useCategoryCounts(state.questions);
 
   const totalNeeded = state.numRounds * state.teams.length * QUESTIONS_PER_TEAM_ROTATION;
   const availableCount = categoryCounts[state.selectedCategory] || 0;
-  const hasInsufficientQuestions = state.teams.length >= 2 && availableCount < totalNeeded && availableCount > 0;
+  const hasInsufficientQuestions =
+    state.teams.length >= 2 && availableCount < totalNeeded && availableCount > 0;
 
   const handleAddTeam = (e: React.FormEvent) => {
     e.preventDefault();
@@ -239,20 +245,22 @@ function SoloSetup() {
               >
                 All ({categoryCounts['All'] || 0})
               </Button>
-              {state.categories.filter((c) => c !== 'All').map((category) => (
-                <Button
-                  key={category}
-                  variant={state.selectedCategory === category ? 'default' : 'outline'}
-                  onClick={() => setCategory(category)}
-                  className={`border-white/10 hover:bg-white/10 ${
-                    state.selectedCategory === category
-                      ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
-                      : ''
-                  }`}
-                >
-                  {category} ({categoryCounts[category] || 0})
-                </Button>
-              ))}
+              {state.categories
+                .filter((c) => c !== 'All')
+                .map((category) => (
+                  <Button
+                    key={category}
+                    variant={state.selectedCategory === category ? 'default' : 'outline'}
+                    onClick={() => setCategory(category)}
+                    className={`border-white/10 hover:bg-white/10 ${
+                      state.selectedCategory === category
+                        ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
+                        : ''
+                    }`}
+                  >
+                    {category} ({categoryCounts[category] || 0})
+                  </Button>
+                ))}
             </div>
           </CardContent>
         </Card>
@@ -291,10 +299,14 @@ function SoloSetup() {
               <div>
                 <p className="font-semibold text-yellow-300">Not enough questions</p>
                 <p className="mt-1">
-                  {state.selectedCategory === 'All' ? 'All categories have' : `"${state.selectedCategory}" has`} only{' '}
-                  <span className="font-bold">{availableCount}</span> question{availableCount !== 1 ? 's' : ''}, but your
-                  setup needs <span className="font-bold">{totalNeeded}</span> ({state.numRounds} rounds × {state.teams.length} teams × {QUESTIONS_PER_TEAM_ROTATION} questions/turn).
-                  The game will use all {availableCount} available.
+                  {state.selectedCategory === 'All'
+                    ? 'All categories have'
+                    : `"${state.selectedCategory}" has`}{' '}
+                  only <span className="font-bold">{availableCount}</span> question
+                  {availableCount !== 1 ? 's' : ''}, but your setup needs{' '}
+                  <span className="font-bold">{totalNeeded}</span> ({state.numRounds} rounds ×{' '}
+                  {state.teams.length} teams × {QUESTIONS_PER_TEAM_ROTATION} questions/turn). The
+                  game will use all {availableCount} available.
                 </p>
               </div>
             </div>

--- a/client/src/pages/HostGame.test.tsx
+++ b/client/src/pages/HostGame.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import HostGame from './HostGame';
+import { GameProvider } from '@/lib/store';
+import { getRoomSession } from '@/lib/room-session';
+
+// Stub localStorage for jsdom compatibility
+const storage: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage[key] ?? null,
+  setItem: (key: string, value: string) => {
+    storage[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete storage[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(storage)) delete storage[key];
+  },
+});
+
+const mockSetLocation = vi.fn();
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/host', mockSetLocation],
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: React.forwardRef(
+      (props: React.HTMLAttributes<HTMLDivElement>, ref: React.Ref<HTMLDivElement>) => (
+        <div ref={ref} {...props} />
+      )
+    ),
+  },
+}));
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+const QUESTIONS = [
+  {
+    id: 'q1',
+    category: 'Science & Nature',
+    difficulty: 'Easy',
+    question: 'H2O?',
+    answer: 'Water',
+    explanation: '',
+    tags: [],
+  },
+];
+
+function createFetchMock(overrides?: { createRoom?: () => Promise<Response> }) {
+  return vi.fn((input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+    if (url.includes('/api/questions')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ questions: QUESTIONS, categories: ['Science & Nature'] }),
+      } as Response);
+    }
+
+    if (url.includes('/api/rooms')) {
+      if (overrides?.createRoom) return overrides.createRoom();
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            code: 'ABCD2',
+            playerId: '11111111-1111-4111-8111-111111111111',
+            token: 'test-token',
+          }),
+      } as Response);
+    }
+
+    return Promise.reject(new Error(`Unhandled fetch: ${url}`));
+  });
+}
+
+function renderHostGame() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GameProvider>
+        <HostGame />
+      </GameProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('HostGame', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockSetLocation.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('disables the create room button until a nickname is entered', async () => {
+    vi.stubGlobal('fetch', createFetchMock());
+    renderHostGame();
+
+    const createButton = await screen.findByTestId('button-create-room');
+    expect(createButton.hasAttribute('disabled')).toBe(true);
+
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: '   ' } });
+    expect(createButton.hasAttribute('disabled')).toBe(true);
+
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    expect(createButton.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('shows a spinner while the create room request is in flight', async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    const pending = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.stubGlobal('fetch', createFetchMock({ createRoom: () => pending }));
+    renderHostGame();
+
+    fireEvent.change(await screen.findByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-create-room'));
+
+    expect(await screen.findByRole('status', { name: 'Loading' })).toBeDefined();
+    expect(screen.getByTestId('button-create-room').hasAttribute('disabled')).toBe(true);
+
+    resolveFetch({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          code: 'ABCD2',
+          playerId: '11111111-1111-4111-8111-111111111111',
+          token: 'test-token',
+        }),
+    } as Response);
+
+    await waitFor(() => expect(mockSetLocation).toHaveBeenCalled());
+  });
+
+  it('shows a toast and keeps the form editable when the server returns an error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        createRoom: () =>
+          Promise.resolve({
+            ok: false,
+            statusText: 'Internal Server Error',
+            json: () => Promise.resolve({ message: 'Room could not be created' }),
+          } as Response),
+      })
+    );
+    renderHostGame();
+
+    fireEvent.change(await screen.findByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-create-room'));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Room could not be created'));
+
+    const nicknameInput = screen.getByTestId('input-nickname') as HTMLInputElement;
+    expect(nicknameInput.hasAttribute('disabled')).toBe(false);
+    expect(nicknameInput.value).toBe('Steph');
+    expect(screen.getByTestId('button-create-room').hasAttribute('disabled')).toBe(false);
+    expect(mockSetLocation).not.toHaveBeenCalled();
+  });
+
+  it('saves the room session and redirects to /room/:code on success', async () => {
+    vi.stubGlobal('fetch', createFetchMock());
+    renderHostGame();
+
+    fireEvent.change(await screen.findByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-create-room'));
+
+    await waitFor(() => expect(mockSetLocation).toHaveBeenCalledWith('/room/ABCD2'));
+    expect(getRoomSession('ABCD2')).toEqual({
+      code: 'ABCD2',
+      playerId: '11111111-1111-4111-8111-111111111111',
+      token: 'test-token',
+    });
+  });
+});

--- a/client/src/pages/HostGame.test.tsx
+++ b/client/src/pages/HostGame.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -9,18 +10,20 @@ import { getRoomSession } from '@/lib/room-session';
 
 // Stub localStorage for jsdom compatibility
 const storage: Record<string, string> = {};
-vi.stubGlobal('localStorage', {
-  getItem: (key: string) => storage[key] ?? null,
-  setItem: (key: string, value: string) => {
-    storage[key] = value;
-  },
-  removeItem: (key: string) => {
-    delete storage[key];
-  },
-  clear: () => {
-    for (const key of Object.keys(storage)) delete storage[key];
-  },
-});
+function stubLocalStorage() {
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+    clear: () => {
+      for (const key of Object.keys(storage)) delete storage[key];
+    },
+  });
+}
 
 const mockSetLocation = vi.fn();
 
@@ -100,6 +103,7 @@ function renderHostGame() {
 
 describe('HostGame', () => {
   beforeEach(() => {
+    stubLocalStorage();
     localStorage.clear();
     mockSetLocation.mockClear();
     toastError.mockClear();
@@ -108,6 +112,7 @@ describe('HostGame', () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('disables the create room button until a nickname is entered', async () => {
@@ -115,13 +120,13 @@ describe('HostGame', () => {
     renderHostGame();
 
     const createButton = await screen.findByTestId('button-create-room');
-    expect(createButton.hasAttribute('disabled')).toBe(true);
+    expect(createButton).toBeDisabled();
 
     fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: '   ' } });
-    expect(createButton.hasAttribute('disabled')).toBe(true);
+    expect(createButton).toBeDisabled();
 
     fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
-    expect(createButton.hasAttribute('disabled')).toBe(false);
+    expect(createButton).not.toBeDisabled();
   });
 
   it('shows a spinner while the create room request is in flight', async () => {
@@ -136,7 +141,7 @@ describe('HostGame', () => {
     fireEvent.click(screen.getByTestId('button-create-room'));
 
     expect(await screen.findByRole('status', { name: 'Loading' })).toBeDefined();
-    expect(screen.getByTestId('button-create-room').hasAttribute('disabled')).toBe(true);
+    expect(screen.getByTestId('button-create-room')).toBeDisabled();
 
     resolveFetch({
       ok: true,
@@ -171,9 +176,9 @@ describe('HostGame', () => {
     await waitFor(() => expect(toastError).toHaveBeenCalledWith('Room could not be created'));
 
     const nicknameInput = screen.getByTestId('input-nickname') as HTMLInputElement;
-    expect(nicknameInput.hasAttribute('disabled')).toBe(false);
+    expect(nicknameInput).not.toBeDisabled();
     expect(nicknameInput.value).toBe('Steph');
-    expect(screen.getByTestId('button-create-room').hasAttribute('disabled')).toBe(false);
+    expect(screen.getByTestId('button-create-room')).not.toBeDisabled();
     expect(mockSetLocation).not.toHaveBeenCalled();
   });
 

--- a/client/src/pages/HostGame.tsx
+++ b/client/src/pages/HostGame.tsx
@@ -1,17 +1,210 @@
+import { useMemo, useState } from 'react';
+import { useLocation } from 'wouter';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { motion } from 'framer-motion';
+import { UserPlus, Zap } from 'lucide-react';
+import {
+  ROOM_ROUND_OPTIONS,
+  type CreateRoomRequest,
+  type CreateRoomResponse,
+  type RoomCategory,
+  type RoomRounds,
+} from '@shared/models/rooms';
+
+import { useGame } from '@/lib/store';
+import { saveRoomSession } from '@/lib/room-session';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Spinner } from '@/components/ui/spinner';
+
+async function createRoom(body: CreateRoomRequest): Promise<CreateRoomResponse> {
+  const res = await fetch('/api/rooms', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      if (typeof data?.message === 'string') message = data.message;
+    } catch {
+      // response had no JSON body; fall back to statusText
+    }
+    throw new Error(message);
+  }
+
+  return res.json() as Promise<CreateRoomResponse>;
+}
 
 export default function HostGame() {
+  const [, setLocation] = useLocation();
+  const { state, setCategory, setNumRounds } = useGame();
+  const [nickname, setNickname] = useState('');
+
+  const categoryCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    state.questions.forEach((q) => {
+      counts[q.category] = (counts[q.category] || 0) + 1;
+    });
+    counts['All'] = state.questions.length;
+    return counts;
+  }, [state.questions]);
+
+  const createRoomMutation = useMutation({
+    mutationFn: createRoom,
+    onSuccess: (response) => {
+      saveRoomSession({ code: response.code, playerId: response.playerId, token: response.token });
+      setLocation(`/room/${response.code}`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to create room. Please try again.');
+    },
+  });
+
+  const trimmedNickname = nickname.trim();
+  const isNicknameValid = trimmedNickname.length > 0;
+
+  const handleCreateRoom = () => {
+    if (!isNicknameValid) return;
+    createRoomMutation.mutate({
+      nickname: trimmedNickname,
+      category: state.selectedCategory as RoomCategory,
+      numRounds: state.numRounds as RoomRounds,
+    });
+  };
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4">
-      <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
-        <CardHeader>
-          <CardTitle>Host a Game</CardTitle>
-          <CardDescription>Multiplayer hosting is coming soon.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground text-sm">This screen is a placeholder for STE-207.</p>
-        </CardContent>
-      </Card>
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-900 via-background to-background">
+      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-primary/20 rounded-full blur-[120px] opacity-50" />
+        <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] bg-blue-500/10 rounded-full blur-[120px] opacity-50" />
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="w-full max-w-md z-10 space-y-8"
+      >
+        <div className="text-center space-y-2">
+          <h1 className="text-6xl font-extrabold tracking-tighter bg-gradient-to-br from-white to-white/50 bg-clip-text text-transparent drop-shadow-sm">
+            HOST A
+            <br />
+            GAME
+          </h1>
+          <p className="text-muted-foreground font-medium tracking-wide">SET UP YOUR ROOM</p>
+        </div>
+
+        <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-xl">
+              <UserPlus className="w-5 h-5 text-primary" />
+              Your Nickname
+            </CardTitle>
+            <CardDescription>Shown to players who join your room.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Input
+              placeholder="Enter your nickname..."
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              className="bg-white/5 border-white/10 focus:border-primary/50 text-lg py-6"
+              autoFocus
+              maxLength={20}
+              disabled={createRoomMutation.isPending}
+              data-testid="input-nickname"
+            />
+          </CardContent>
+        </Card>
+
+        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-lg">Category</CardTitle>
+            <CardDescription>Choose a topic for this room.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-2 max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
+              <Button
+                variant={state.selectedCategory === 'All' ? 'default' : 'outline'}
+                onClick={() => setCategory('All')}
+                disabled={createRoomMutation.isPending}
+                className={`border-white/10 hover:bg-white/10 ${
+                  state.selectedCategory === 'All'
+                    ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
+                    : ''
+                }`}
+              >
+                All ({categoryCounts['All'] || 0})
+              </Button>
+              {state.categories
+                .filter((c) => c !== 'All')
+                .map((category) => (
+                  <Button
+                    key={category}
+                    variant={state.selectedCategory === category ? 'default' : 'outline'}
+                    onClick={() => setCategory(category)}
+                    disabled={createRoomMutation.isPending}
+                    className={`border-white/10 hover:bg-white/10 ${
+                      state.selectedCategory === category
+                        ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
+                        : ''
+                    }`}
+                  >
+                    {category} ({categoryCounts[category] || 0})
+                  </Button>
+                ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Zap className="w-4 h-4 text-primary" />
+              Number of Rounds
+            </CardTitle>
+            <CardDescription>How many questions to play.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-4 gap-2">
+              {ROOM_ROUND_OPTIONS.map((rounds) => (
+                <Button
+                  key={rounds}
+                  variant={state.numRounds === rounds ? 'default' : 'outline'}
+                  onClick={() => setNumRounds(rounds)}
+                  disabled={createRoomMutation.isPending}
+                  className={`border-white/10 hover:bg-white/10 ${state.numRounds === rounds ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
+                >
+                  {rounds}
+                </Button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Button
+          className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
+          disabled={!isNicknameValid || createRoomMutation.isPending}
+          onClick={handleCreateRoom}
+          data-testid="button-create-room"
+        >
+          {createRoomMutation.isPending ? (
+            <>
+              <Spinner className="mr-2" />
+              Creating Room...
+            </>
+          ) : (
+            <>
+              <UserPlus className="w-5 h-5 mr-2" />
+              Create Room
+            </>
+          )}
+        </Button>
+      </motion.div>
     </div>
   );
 }

--- a/client/src/pages/HostGame.tsx
+++ b/client/src/pages/HostGame.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'wouter';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -6,13 +6,14 @@ import { motion } from 'framer-motion';
 import { UserPlus, Zap } from 'lucide-react';
 import {
   ROOM_ROUND_OPTIONS,
+  roomCategorySchema,
+  roomRoundsSchema,
   type CreateRoomRequest,
   type CreateRoomResponse,
-  type RoomCategory,
-  type RoomRounds,
 } from '@shared/models/rooms';
 
 import { useGame } from '@/lib/store';
+import { useCategoryCounts } from '@/hooks/use-category-counts';
 import { saveRoomSession } from '@/lib/room-session';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -46,14 +47,7 @@ export default function HostGame() {
   const { state, setCategory, setNumRounds } = useGame();
   const [nickname, setNickname] = useState('');
 
-  const categoryCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    state.questions.forEach((q) => {
-      counts[q.category] = (counts[q.category] || 0) + 1;
-    });
-    counts['All'] = state.questions.length;
-    return counts;
-  }, [state.questions]);
+  const categoryCounts = useCategoryCounts(state.questions);
 
   const createRoomMutation = useMutation({
     mutationFn: createRoom,
@@ -69,12 +63,21 @@ export default function HostGame() {
   const trimmedNickname = nickname.trim();
   const isNicknameValid = trimmedNickname.length > 0;
 
-  const handleCreateRoom = () => {
-    if (!isNicknameValid) return;
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isNicknameValid || createRoomMutation.isPending) return;
+
+    const category = roomCategorySchema.safeParse(state.selectedCategory);
+    const numRounds = roomRoundsSchema.safeParse(state.numRounds);
+    if (!category.success || !numRounds.success) {
+      toast.error('Invalid category or rounds selection. Please try again.');
+      return;
+    }
+
     createRoomMutation.mutate({
       nickname: trimmedNickname,
-      category: state.selectedCategory as RoomCategory,
-      numRounds: state.numRounds as RoomRounds,
+      category: category.data,
+      numRounds: numRounds.data,
     });
   };
 
@@ -99,111 +102,116 @@ export default function HostGame() {
           <p className="text-muted-foreground font-medium tracking-wide">SET UP YOUR ROOM</p>
         </div>
 
-        <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-xl">
-              <UserPlus className="w-5 h-5 text-primary" />
-              Your Nickname
-            </CardTitle>
-            <CardDescription>Shown to players who join your room.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Input
-              placeholder="Enter your nickname..."
-              value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
-              className="bg-white/5 border-white/10 focus:border-primary/50 text-lg py-6"
-              autoFocus
-              maxLength={20}
-              disabled={createRoomMutation.isPending}
-              data-testid="input-nickname"
-            />
-          </CardContent>
-        </Card>
-
-        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-lg">Category</CardTitle>
-            <CardDescription>Choose a topic for this room.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-2 max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
-              <Button
-                variant={state.selectedCategory === 'All' ? 'default' : 'outline'}
-                onClick={() => setCategory('All')}
+        <form onSubmit={handleSubmit} className="space-y-8">
+          <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <UserPlus className="w-5 h-5 text-primary" />
+                Your Nickname
+              </CardTitle>
+              <CardDescription>Shown to players who join your room.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Input
+                placeholder="Enter your nickname..."
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                className="bg-white/5 border-white/10 focus:border-primary/50 text-lg py-6"
+                autoFocus
+                maxLength={20}
                 disabled={createRoomMutation.isPending}
-                className={`border-white/10 hover:bg-white/10 ${
-                  state.selectedCategory === 'All'
-                    ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
-                    : ''
-                }`}
-              >
-                All ({categoryCounts['All'] || 0})
-              </Button>
-              {state.categories
-                .filter((c) => c !== 'All')
-                .map((category) => (
+                data-testid="input-nickname"
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-lg">Category</CardTitle>
+              <CardDescription>Choose a topic for this room.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 gap-2 max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
+                <Button
+                  type="button"
+                  variant={state.selectedCategory === 'All' ? 'default' : 'outline'}
+                  onClick={() => setCategory('All')}
+                  disabled={createRoomMutation.isPending}
+                  className={`border-white/10 hover:bg-white/10 ${
+                    state.selectedCategory === 'All'
+                      ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
+                      : ''
+                  }`}
+                >
+                  All ({categoryCounts['All'] || 0})
+                </Button>
+                {state.categories
+                  .filter((c) => c !== 'All')
+                  .map((category) => (
+                    <Button
+                      key={category}
+                      type="button"
+                      variant={state.selectedCategory === category ? 'default' : 'outline'}
+                      onClick={() => setCategory(category)}
+                      disabled={createRoomMutation.isPending}
+                      className={`border-white/10 hover:bg-white/10 ${
+                        state.selectedCategory === category
+                          ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
+                          : ''
+                      }`}
+                    >
+                      {category} ({categoryCounts[category] || 0})
+                    </Button>
+                  ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Zap className="w-4 h-4 text-primary" />
+                Number of Rounds
+              </CardTitle>
+              <CardDescription>How many questions to play.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-4 gap-2">
+                {ROOM_ROUND_OPTIONS.map((rounds) => (
                   <Button
-                    key={category}
-                    variant={state.selectedCategory === category ? 'default' : 'outline'}
-                    onClick={() => setCategory(category)}
+                    key={rounds}
+                    type="button"
+                    variant={state.numRounds === rounds ? 'default' : 'outline'}
+                    onClick={() => setNumRounds(rounds)}
                     disabled={createRoomMutation.isPending}
-                    className={`border-white/10 hover:bg-white/10 ${
-                      state.selectedCategory === category
-                        ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
-                        : ''
-                    }`}
+                    className={`border-white/10 hover:bg-white/10 ${state.numRounds === rounds ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
                   >
-                    {category} ({categoryCounts[category] || 0})
+                    {rounds}
                   </Button>
                 ))}
-            </div>
-          </CardContent>
-        </Card>
+              </div>
+            </CardContent>
+          </Card>
 
-        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-lg">
-              <Zap className="w-4 h-4 text-primary" />
-              Number of Rounds
-            </CardTitle>
-            <CardDescription>How many questions to play.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-4 gap-2">
-              {ROOM_ROUND_OPTIONS.map((rounds) => (
-                <Button
-                  key={rounds}
-                  variant={state.numRounds === rounds ? 'default' : 'outline'}
-                  onClick={() => setNumRounds(rounds)}
-                  disabled={createRoomMutation.isPending}
-                  className={`border-white/10 hover:bg-white/10 ${state.numRounds === rounds ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
-                >
-                  {rounds}
-                </Button>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Button
-          className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
-          disabled={!isNicknameValid || createRoomMutation.isPending}
-          onClick={handleCreateRoom}
-          data-testid="button-create-room"
-        >
-          {createRoomMutation.isPending ? (
-            <>
-              <Spinner className="mr-2" />
-              Creating Room...
-            </>
-          ) : (
-            <>
-              <UserPlus className="w-5 h-5 mr-2" />
-              Create Room
-            </>
-          )}
-        </Button>
+          <Button
+            type="submit"
+            className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
+            disabled={!isNicknameValid || createRoomMutation.isPending}
+            data-testid="button-create-room"
+          >
+            {createRoomMutation.isPending ? (
+              <>
+                <Spinner className="mr-2" />
+                Creating Room...
+              </>
+            ) : (
+              <>
+                <UserPlus className="w-5 h-5 mr-2" />
+                Create Room
+              </>
+            )}
+          </Button>
+        </form>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replaces the `HostGame.tsx` placeholder with the full host flow: nickname input, category picker, and rounds picker, reusing the exact card/button patterns from `Home.tsx`'s solo setup.
- `Create Room` button is disabled until the nickname is non-empty (trimmed), shows a spinner while the `POST /api/rooms` request is in flight, and surfaces server errors via a Sonner toast while keeping the form editable for retry.
- On success, stores the returned room session via `room-session.ts` and navigates to `/room/:code`.
- Mounts the (previously unused) Sonner `<Toaster />` in `App.tsx` alongside the existing Radix toaster so `toast.error()` actually renders.

Builds against the `/api/rooms` contract (`CreateRoomRequest`/`CreateRoomResponse` in `shared/models/rooms.ts`) defined for STE-204; that endpoint doesn't exist yet, so this can't be exercised against a live server until STE-204 lands.

Depends on STE-203 (mode chooser/routing) and STE-205 (`useRoom`/`room-session`), both already merged.

## Test plan
- [x] `client/src/pages/HostGame.test.tsx` — new component tests: nickname validation (button disabled state), loading spinner during POST, error toast + form stays editable, success redirect + session persisted to `/room/:code`.
- [x] `npm test` — 286/286 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `eslint` / `prettier --check` — clean.
- [ ] Manual browser verification — not possible in this environment: no local Postgres (`DATABASE_URL` → `localhost:5432` unreachable) and the `/api/rooms` route doesn't exist yet (STE-204). Recommend a manual pass once STE-204 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)