### PR TITLE
[codex] feat(api): add room lifecycle endpoints [STE-204]

### DIFF
--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -1,4 +1,5 @@
 import type { Express, NextFunction, Request, Response } from 'express';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,6 +9,8 @@ const dbMocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
   const insertResults: unknown[][] = [];
   const updateResults: unknown[][] = [];
+  const valueArgs: unknown[] = [];
+  const whereArgs: unknown[] = [];
 
   function query(result: unknown[]) {
     const promise = Promise.resolve(result);
@@ -19,8 +22,14 @@ const dbMocks = vi.hoisted(() => {
       returning: vi.fn(() => Promise.resolve(result)),
       set: vi.fn(() => chain),
       then: promise.then.bind(promise),
-      values: vi.fn(() => chain),
-      where: vi.fn(() => chain),
+      values: vi.fn((value) => {
+        valueArgs.push(value);
+        return chain;
+      }),
+      where: vi.fn((condition) => {
+        whereArgs.push(condition);
+        return chain;
+      }),
     };
     return chain;
   }
@@ -37,7 +46,15 @@ const dbMocks = vi.hoisted(() => {
     callback(methods)
   );
 
-  return { ...methods, transaction, selectResults, insertResults, updateResults };
+  return {
+    ...methods,
+    transaction,
+    selectResults,
+    insertResults,
+    updateResults,
+    valueArgs,
+    whereArgs,
+  };
 });
 
 const authMocks = vi.hoisted(() => ({
@@ -125,6 +142,8 @@ describe('room lifecycle routes', () => {
     dbMocks.selectResults.length = 0;
     dbMocks.insertResults.length = 0;
     dbMocks.updateResults.length = 0;
+    dbMocks.valueArgs.length = 0;
+    dbMocks.whereArgs.length = 0;
     dbMocks.transaction.mockImplementation(async (callback) =>
       callback({
         delete: dbMocks.delete,
@@ -155,6 +174,13 @@ describe('room lifecycle routes', () => {
     expect(dbMocks.transaction).toHaveBeenCalledOnce();
     expect(dbMocks.insert).toHaveBeenCalledTimes(2);
     expect(dbMocks.update).toHaveBeenCalledOnce();
+
+    const cleanupCondition = dbMocks.whereArgs[0] as Parameters<PgDialect['sqlToQuery']>[0];
+    const cleanupQuery = new PgDialect().sqlToQuery(cleanupCondition);
+    expect(cleanupQuery.sql).toContain('"rooms"."status" = $1');
+    expect(cleanupQuery.sql).toContain('"rooms"."phase" = $2');
+    expect(cleanupQuery.sql).toContain('"rooms"."expires_at" <= $3');
+    expect(cleanupQuery.params.slice(0, 2)).toEqual(['lobby', 'LOBBY']);
   });
 
   it('retries a room-code collision', async () => {
@@ -296,6 +322,40 @@ describe('room lifecycle routes', () => {
       .expect(409);
 
     expect(response.body.message).toBe('Nickname is already taken');
+  });
+
+  it('allocates join order after departed players instead of reusing an indexed value', async () => {
+    const departed = player({
+      id: guestId,
+      nickname: 'Departed',
+      joinOrder: 1,
+      isHost: false,
+      leftAt: new Date('2026-07-03T15:05:00.000Z'),
+    });
+    const active = player({
+      id: '44444444-4444-4444-8444-444444444444',
+      nickname: 'Active',
+      token: 'active-secret',
+      joinOrder: 2,
+      isHost: false,
+    });
+    const newcomer = player({
+      id: '55555555-5555-4555-8555-555555555555',
+      nickname: 'Newcomer',
+      token: 'newcomer-secret',
+      joinOrder: 3,
+      isHost: false,
+    });
+    queueSelect([room()], [player(), departed, active], [player(), departed, active, newcomer]);
+    dbMocks.insertResults.push([newcomer]);
+    dbMocks.updateResults.push([room({ version: 2 })]);
+    const app = await buildTestApp();
+
+    await request(app).post('/api/rooms/ABCD2/join').send({ nickname: 'Newcomer' }).expect(200);
+
+    expect(dbMocks.valueArgs).toContainEqual(
+      expect.objectContaining({ nickname: 'Newcomer', joinOrder: 3 })
+    );
   });
 
   it('returns unchanged while still refreshing presence', async () => {

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -1,0 +1,423 @@
+import type { Express, NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildTestApp } from './test/testApp';
+
+const dbMocks = vi.hoisted(() => {
+  const selectResults: unknown[][] = [];
+  const insertResults: unknown[][] = [];
+  const updateResults: unknown[][] = [];
+
+  function query(result: unknown[]) {
+    const promise = Promise.resolve(result);
+    const chain = {
+      for: vi.fn(() => chain),
+      from: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      returning: vi.fn(() => Promise.resolve(result)),
+      set: vi.fn(() => chain),
+      then: promise.then.bind(promise),
+      values: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+    };
+    return chain;
+  }
+
+  const methods = {
+    delete: vi.fn(() => query([])),
+    insert: vi.fn(() => query(insertResults.shift() ?? [])),
+    select: vi.fn(() => query(selectResults.shift() ?? [])),
+    selectDistinct: vi.fn(() => query([])),
+    update: vi.fn(() => query(updateResults.shift() ?? [])),
+  };
+
+  const transaction = vi.fn(async (callback: (tx: typeof methods) => Promise<unknown>) =>
+    callback(methods)
+  );
+
+  return { ...methods, transaction, selectResults, insertResults, updateResults };
+});
+
+const authMocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn((_req: Request, _res: Response, next: NextFunction) => next()),
+  registerAuthRoutes: vi.fn(),
+  setupAuth: vi.fn(async (_app: Express) => undefined),
+}));
+
+vi.mock('./db', () => ({
+  db: {
+    delete: dbMocks.delete,
+    insert: dbMocks.insert,
+    select: dbMocks.select,
+    selectDistinct: dbMocks.selectDistinct,
+    transaction: dbMocks.transaction,
+    update: dbMocks.update,
+  },
+}));
+
+vi.mock('./replit_integrations/auth', () => authMocks);
+vi.mock('./lib/subjectivity-enricher', () => ({ enrichSubjectiveFindings: vi.fn() }));
+vi.mock('./lib/ai', () => ({ analyzeDispute: vi.fn() }));
+vi.mock('./lib/guardian', () => ({ generateQuestions: vi.fn() }));
+vi.mock('./lib/field-fix', () => ({ getAiFieldFix: vi.fn() }));
+vi.mock('./lib/question-quality-audit', () => ({ auditQuestionQuality: vi.fn() }));
+vi.mock('./lib/duplicate-detector', () => ({ detectDuplicates: vi.fn() }));
+vi.mock('./lib/verifier', () => ({ batchFactCheck: vi.fn() }));
+
+const roomId = '11111111-1111-4111-8111-111111111111';
+const hostId = '22222222-2222-4222-8222-222222222222';
+const guestId = '33333333-3333-4333-8333-333333333333';
+const now = new Date('2026-07-03T15:00:00.000Z');
+
+function room(overrides: Record<string, unknown> = {}) {
+  return {
+    id: roomId,
+    code: 'ABCD2',
+    status: 'lobby',
+    phase: 'LOBBY',
+    version: 1,
+    hostPlayerId: hostId,
+    category: 'All',
+    numRounds: 5,
+    questionIds: [],
+    currentQuestionIndex: 0,
+    activePlayerId: null,
+    currentAttempt: null,
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: new Date('2099-07-03T17:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function player(overrides: Record<string, unknown> = {}) {
+  return {
+    id: hostId,
+    roomId,
+    nickname: 'Host',
+    token: 'host-secret',
+    joinOrder: 0,
+    score: 0,
+    questionCount: 0,
+    lastRoundDelta: 0,
+    isHost: true,
+    lastSeenAt: now,
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+function queueSelect(...results: unknown[][]) {
+  dbMocks.selectResults.push(...results);
+}
+
+function postgresUniqueViolation(constraint: string) {
+  return Object.assign(new Error('duplicate key'), { code: '23505', constraint });
+}
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+describe('room lifecycle routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.selectResults.length = 0;
+    dbMocks.insertResults.length = 0;
+    dbMocks.updateResults.length = 0;
+    dbMocks.transaction.mockImplementation(async (callback) =>
+      callback({
+        delete: dbMocks.delete,
+        insert: dbMocks.insert,
+        select: dbMocks.select,
+        selectDistinct: dbMocks.selectDistinct,
+        update: dbMocks.update,
+      })
+    );
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('creates a lobby room and its host atomically after cleaning up expired rooms', async () => {
+    dbMocks.insertResults.push([room({ hostPlayerId: null })], [player()]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms')
+      .send({ nickname: 'Host', category: 'All', numRounds: 5 })
+      .expect(201);
+
+    expect(response.body).toMatchObject({ code: 'ABCD2', playerId: hostId, token: 'host-secret' });
+    expect(dbMocks.delete).toHaveBeenCalledOnce();
+    expect(dbMocks.transaction).toHaveBeenCalledOnce();
+    expect(dbMocks.insert).toHaveBeenCalledTimes(2);
+    expect(dbMocks.update).toHaveBeenCalledOnce();
+  });
+
+  it('retries a room-code collision', async () => {
+    dbMocks.transaction.mockRejectedValueOnce(postgresUniqueViolation('rooms_code_unique'));
+    dbMocks.insertResults.push([room({ hostPlayerId: null })], [player()]);
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms')
+      .send({ nickname: 'Host', category: 'All', numRounds: 5 })
+      .expect(201);
+
+    expect(dbMocks.transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after five room-code collisions', async () => {
+    dbMocks.transaction.mockRejectedValue(postgresUniqueViolation('rooms_code_unique'));
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms')
+      .send({ nickname: 'Host', category: 'All', numRounds: 5 })
+      .expect(500);
+
+    expect(dbMocks.transaction).toHaveBeenCalledTimes(5);
+  });
+
+  it('returns 422 for invalid create input', async () => {
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms')
+      .send({ nickname: '', category: 'All', numRounds: 3 })
+      .expect(422);
+
+    expect(dbMocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('joins a lobby room and returns credentials with the new snapshot', async () => {
+    const host = player();
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const updatedRoom = room({ version: 2 });
+    queueSelect([room()], [host], [host, guest]);
+    dbMocks.insertResults.push([guest]);
+    dbMocks.updateResults.push([updatedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/abcd2/join')
+      .send({ nickname: 'Guest' })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      playerId: guestId,
+      token: 'guest-secret',
+      snapshot: {
+        code: 'ABCD2',
+        version: 2,
+        players: [{ nickname: 'Host' }, { nickname: 'Guest' }],
+      },
+    });
+    expect(response.body.snapshot.players[1]).not.toHaveProperty('token');
+  });
+
+  it.each([
+    ['missing room', [], 404, 'Room not found'],
+    [
+      'expired room',
+      [room({ expiresAt: new Date('2020-01-01T00:00:00.000Z') })],
+      404,
+      'Room expired',
+    ],
+    [
+      'started room',
+      [room({ status: 'active', phase: 'QUESTION' })],
+      409,
+      'Game has already started',
+    ],
+  ])('rejects join for a %s', async (_label, roomRows, status, message) => {
+    queueSelect(roomRows as unknown[]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/join')
+      .send({ nickname: 'Guest' })
+      .expect(status as number);
+
+    expect(response.body.message).toBe(message);
+  });
+
+  it('rejects a fifth player with a distinct conflict message', async () => {
+    queueSelect(
+      [room()],
+      [
+        player(),
+        player({ id: guestId, nickname: 'Two', joinOrder: 1 }),
+        player({ id: '44444444-4444-4444-8444-444444444444', nickname: 'Three', joinOrder: 2 }),
+        player({ id: '55555555-5555-4555-8555-555555555555', nickname: 'Four', joinOrder: 3 }),
+      ]
+    );
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/join')
+      .send({ nickname: 'Five' })
+      .expect(409);
+
+    expect(response.body.message).toBe('Room is full');
+  });
+
+  it('rejects a case-insensitive duplicate nickname', async () => {
+    queueSelect([room()], [player()]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/join')
+      .send({ nickname: 'host' })
+      .expect(409);
+
+    expect(response.body.message).toBe('Nickname is already taken');
+  });
+
+  it('maps a database nickname race to the nickname conflict', async () => {
+    queueSelect([room()], [player()]);
+    dbMocks.insert.mockImplementationOnce(() => {
+      throw postgresUniqueViolation('uq_room_players_room_nickname_ci');
+    });
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/join')
+      .send({ nickname: 'Guest' })
+      .expect(409);
+
+    expect(response.body.message).toBe('Nickname is already taken');
+  });
+
+  it('returns unchanged while still refreshing presence', async () => {
+    queueSelect([room()], [player()]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/rooms/ABCD2?sinceVersion=1')
+      .set('X-Player-Token', 'host-secret')
+      .expect(200);
+
+    expect(response.body).toEqual({ changed: false });
+    expect(dbMocks.update).toHaveBeenCalledOnce();
+  });
+
+  it('returns 422 for an invalid polling version', async () => {
+    const app = await buildTestApp();
+
+    await request(app).get('/api/rooms/ABCD2?sinceVersion=-1').expect(422);
+
+    expect(dbMocks.select).not.toHaveBeenCalled();
+  });
+
+  it('requires a valid player token to poll', async () => {
+    queueSelect([room()]);
+    const app = await buildTestApp();
+
+    const missing = await request(app).get('/api/rooms/ABCD2').expect(401);
+    expect(missing.body.message).toBe('Player token required');
+
+    queueSelect([room()], []);
+    const invalid = await request(app)
+      .get('/api/rooms/ABCD2')
+      .set('X-Player-Token', 'wrong')
+      .expect(401);
+    expect(invalid.body.message).toBe('Invalid player token');
+  });
+
+  it('returns distinct not-found and expired errors when polling', async () => {
+    const app = await buildTestApp();
+
+    queueSelect([]);
+    expect((await request(app).get('/api/rooms/ABCD2').expect(404)).body.message).toBe(
+      'Room not found'
+    );
+
+    queueSelect([room({ expiresAt: new Date('2020-01-01T00:00:00.000Z') })]);
+    expect((await request(app).get('/api/rooms/ABCD2').expect(404)).body.message).toBe(
+      'Room expired'
+    );
+  });
+
+  it('redacts answer and source fields during the QUESTION phase', async () => {
+    const questionRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      questionIds: ['question-1'],
+      activePlayerId: hostId,
+    });
+    const question = {
+      id: 'question-1',
+      category: 'History & Geography',
+      difficulty: 'Easy',
+      question: 'What is the capital of Canada?',
+      answer: 'Ottawa',
+      acceptableAnswers: ['Ottawa, Ontario'],
+      explanation: 'Ottawa is the federal capital.',
+      pillar: 'GlobalEh',
+      tags: ['Canada'],
+      sourceUrl: 'https://example.com/ottawa',
+      sourceName: 'Ottawa reference',
+    };
+    queueSelect([questionRoom], [player()], [player()], [question]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/rooms/ABCD2')
+      .set('X-Player-Token', 'host-secret')
+      .expect(200);
+
+    expect(response.body.currentQuestion).toMatchObject({
+      id: 'question-1',
+      sourceUrl: null,
+      sourceName: null,
+    });
+    expect(response.body.currentQuestion).not.toHaveProperty('answer');
+    expect(response.body.currentQuestion).not.toHaveProperty('acceptableAnswers');
+    expect(response.body.currentQuestion).not.toHaveProperty('explanation');
+  });
+
+  it('reveals answer fields during REVEAL', async () => {
+    const revealRoom = room({
+      status: 'active',
+      phase: 'REVEAL',
+      questionIds: ['question-1'],
+      activePlayerId: hostId,
+    });
+    const question = {
+      id: 'question-1',
+      category: 'History & Geography',
+      difficulty: 'Easy',
+      question: 'What is the capital of Canada?',
+      answer: 'Ottawa',
+      acceptableAnswers: ['Ottawa, Ontario'],
+      explanation: 'Ottawa is the federal capital.',
+      pillar: 'GlobalEh',
+      tags: ['Canada'],
+      sourceUrl: 'https://example.com/ottawa',
+      sourceName: 'Ottawa reference',
+    };
+    queueSelect([revealRoom], [player()], [player()], [question]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/rooms/ABCD2')
+      .set('X-Player-Token', 'host-secret')
+      .expect(200);
+
+    expect(response.body.currentQuestion).toMatchObject({
+      answer: 'Ottawa',
+      acceptableAnswers: ['Ottawa, Ontario'],
+      explanation: 'Ottawa is the federal capital.',
+    });
+  });
+});

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -189,7 +189,11 @@ export function registerRoomRoutes(app: Express): void {
       const input = createRoomRequestSchema.parse(req.body);
       const now = new Date();
 
-      await db.delete(rooms).where(lte(rooms.expiresAt, now));
+      // Only lobby rooms use the short two-hour expiry. Active rooms are
+      // extended by the start transition and must not be removed by this cleanup.
+      await db
+        .delete(rooms)
+        .where(and(eq(rooms.status, 'lobby'), eq(rooms.phase, 'LOBBY'), lte(rooms.expiresAt, now)));
 
       for (let attempt = 0; attempt < MAX_ROOM_CODE_ATTEMPTS; attempt++) {
         const code = generateRoomCode();
@@ -271,17 +275,19 @@ export function registerRoomRoutes(app: Express): void {
             throw new RoomRouteError(409, 'Game has already started');
           }
 
-          const existingPlayers = await tx
+          const allPlayers = await tx
             .select()
             .from(roomPlayers)
-            .where(and(eq(roomPlayers.roomId, room.id), isNull(roomPlayers.leftAt)))
+            .where(eq(roomPlayers.roomId, room.id))
             .orderBy(asc(roomPlayers.joinOrder));
 
-          if (existingPlayers.length >= MAX_PLAYERS) {
+          const activePlayers = allPlayers.filter((player) => player.leftAt === null);
+
+          if (activePlayers.length >= MAX_PLAYERS) {
             throw new RoomRouteError(409, 'Room is full');
           }
           if (
-            existingPlayers.some(
+            activePlayers.some(
               (player) => player.nickname.toLocaleLowerCase() === input.nickname.toLocaleLowerCase()
             )
           ) {
@@ -294,7 +300,7 @@ export function registerRoomRoutes(app: Express): void {
               roomId: room.id,
               nickname: input.nickname,
               token: generatePlayerToken(),
-              joinOrder: existingPlayers.length,
+              joinOrder: (allPlayers.at(-1)?.joinOrder ?? -1) + 1,
               isHost: false,
             })
             .returning();

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -1,0 +1,361 @@
+import { randomBytes, randomInt } from 'crypto';
+import type { Express, Request, Response } from 'express';
+import { and, asc, eq, isNull, lte, sql } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from './db';
+import {
+  createRoomRequestSchema,
+  createRoomResponseSchema,
+  joinRoomRequestSchema,
+  joinRoomResponseSchema,
+  pollRoomRequestSchema,
+  questions,
+  roomCodeParamsSchema,
+  roomPlayers,
+  roomSnapshotSchema,
+  rooms,
+  unchangedRoomPollResponseSchema,
+  type Room,
+  type RoomPlayer,
+  type RoomSnapshot,
+} from '@shared/schema';
+
+const ROOM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const MAX_ROOM_CODE_ATTEMPTS = 5;
+const MAX_PLAYERS = 4;
+const LOBBY_TTL_MS = 2 * 60 * 60 * 1000;
+const ROOM_CODE_CONSTRAINT = 'rooms_code_unique';
+const ROOM_NICKNAME_CONSTRAINT = 'uq_room_players_room_nickname_ci';
+
+type RoomReadDatabase = Pick<typeof db, 'select'>;
+
+class RoomRouteError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+type PostgresError = Error & { code?: string; constraint?: string };
+
+function hasConstraint(error: unknown, constraint: string): boolean {
+  const postgresError = error as PostgresError;
+  return postgresError?.code === '23505' && postgresError.constraint === constraint;
+}
+
+export function generateRoomCode(): string {
+  return Array.from(
+    { length: 5 },
+    () => ROOM_CODE_ALPHABET[randomInt(ROOM_CODE_ALPHABET.length)]
+  ).join('');
+}
+
+function generatePlayerToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function parseRoomCode(rawCode: string): string {
+  return roomCodeParamsSchema.parse({ code: rawCode.toUpperCase() }).code;
+}
+
+function isExpired(room: Room, now = new Date()): boolean {
+  return room.expiresAt.getTime() <= now.getTime();
+}
+
+function serializePlayer(player: RoomPlayer) {
+  return {
+    id: player.id,
+    nickname: player.nickname,
+    joinOrder: player.joinOrder,
+    score: player.score,
+    questionCount: player.questionCount,
+    lastRoundDelta: player.lastRoundDelta,
+    isHost: player.isHost,
+    lastSeenAt: player.lastSeenAt.toISOString(),
+    leftAt: player.leftAt?.toISOString() ?? null,
+  };
+}
+
+async function buildRoomSnapshot(database: RoomReadDatabase, room: Room): Promise<RoomSnapshot> {
+  const players = await database
+    .select()
+    .from(roomPlayers)
+    .where(eq(roomPlayers.roomId, room.id))
+    .orderBy(asc(roomPlayers.joinOrder));
+
+  let currentQuestion: Record<string, unknown> | null = null;
+  const questionId = room.questionIds[room.currentQuestionIndex];
+
+  if (room.phase !== 'LOBBY' && questionId) {
+    const [question] = await database
+      .select()
+      .from(questions)
+      .where(eq(questions.id, questionId))
+      .limit(1);
+
+    if (!question) {
+      throw new Error(`Room question not found: ${questionId}`);
+    }
+
+    const baseQuestion = {
+      id: question.id,
+      category: question.category,
+      difficulty: question.difficulty,
+      question: question.question,
+      pillar: question.pillar,
+      tags: question.tags ?? [],
+      // Raw source URLs and names can disclose the answer through an article title.
+      sourceUrl: null,
+      sourceName: null,
+    };
+
+    currentQuestion =
+      room.phase === 'QUESTION'
+        ? baseQuestion
+        : {
+            ...baseQuestion,
+            sourceUrl: question.sourceUrl,
+            sourceName: question.sourceName,
+            answer: question.answer,
+            acceptableAnswers: question.acceptableAnswers ?? [],
+            explanation: question.explanation,
+          };
+  }
+
+  return roomSnapshotSchema.parse({
+    id: room.id,
+    code: room.code,
+    status: room.status,
+    phase: room.phase,
+    version: room.version,
+    hostPlayerId: room.hostPlayerId,
+    category: room.category,
+    numRounds: room.numRounds,
+    currentQuestionIndex: room.currentQuestionIndex,
+    activePlayerId: room.activePlayerId,
+    currentAttempt: room.currentAttempt,
+    currentQuestion,
+    players: players.map(serializePlayer),
+    createdAt: room.createdAt.toISOString(),
+    updatedAt: room.updatedAt.toISOString(),
+    expiresAt: room.expiresAt.toISOString(),
+  });
+}
+
+export async function authenticateRoomPlayer(
+  req: Request,
+  roomId: string,
+  database: RoomReadDatabase = db
+): Promise<RoomPlayer> {
+  const token = req.get('X-Player-Token');
+  if (!token) {
+    throw new RoomRouteError(401, 'Player token required');
+  }
+
+  const [player] = await database
+    .select()
+    .from(roomPlayers)
+    .where(
+      and(eq(roomPlayers.roomId, roomId), eq(roomPlayers.token, token), isNull(roomPlayers.leftAt))
+    )
+    .limit(1);
+
+  if (!player) {
+    throw new RoomRouteError(401, 'Invalid player token');
+  }
+
+  return player;
+}
+
+function sendRoomError(res: Response, error: unknown, context: string) {
+  if (error instanceof z.ZodError) {
+    return res.status(422).json({ message: 'Invalid room data', errors: error.errors });
+  }
+
+  if (error instanceof RoomRouteError) {
+    return res.status(error.status).json({ message: error.message });
+  }
+
+  console.error(context, error);
+  return res.status(500).json({ message: 'Internal server error' });
+}
+
+export function registerRoomRoutes(app: Express): void {
+  app.post('/api/rooms', async (req, res) => {
+    try {
+      const input = createRoomRequestSchema.parse(req.body);
+      const now = new Date();
+
+      await db.delete(rooms).where(lte(rooms.expiresAt, now));
+
+      for (let attempt = 0; attempt < MAX_ROOM_CODE_ATTEMPTS; attempt++) {
+        const code = generateRoomCode();
+        const token = generatePlayerToken();
+
+        try {
+          const created = await db.transaction(async (tx) => {
+            const [room] = await tx
+              .insert(rooms)
+              .values({
+                code,
+                category: input.category,
+                numRounds: input.numRounds,
+                status: 'lobby',
+                phase: 'LOBBY',
+                expiresAt: new Date(now.getTime() + LOBBY_TTL_MS),
+              })
+              .returning();
+
+            const [host] = await tx
+              .insert(roomPlayers)
+              .values({
+                roomId: room.id,
+                nickname: input.nickname,
+                token,
+                joinOrder: 0,
+                isHost: true,
+              })
+              .returning();
+
+            await tx.update(rooms).set({ hostPlayerId: host.id }).where(eq(rooms.id, room.id));
+
+            return { room, host };
+          });
+
+          return res.status(201).json(
+            createRoomResponseSchema.parse({
+              code: created.room.code,
+              playerId: created.host.id,
+              token: created.host.token,
+            })
+          );
+        } catch (error) {
+          if (hasConstraint(error, ROOM_CODE_CONSTRAINT)) {
+            continue;
+          }
+          throw error;
+        }
+      }
+
+      throw new Error('Unable to generate a unique room code after five attempts');
+    } catch (error) {
+      return sendRoomError(res, error, 'Error creating room:');
+    }
+  });
+
+  app.post('/api/rooms/:code/join', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      const input = joinRoomRequestSchema.parse(req.body);
+
+      let joined: { player: RoomPlayer; room: Room };
+      try {
+        joined = await db.transaction(async (tx) => {
+          const [room] = await tx
+            .select()
+            .from(rooms)
+            .where(eq(rooms.code, code))
+            .limit(1)
+            .for('update');
+
+          if (!room) {
+            throw new RoomRouteError(404, 'Room not found');
+          }
+          if (isExpired(room)) {
+            throw new RoomRouteError(404, 'Room expired');
+          }
+          if (room.status !== 'lobby' || room.phase !== 'LOBBY') {
+            throw new RoomRouteError(409, 'Game has already started');
+          }
+
+          const existingPlayers = await tx
+            .select()
+            .from(roomPlayers)
+            .where(and(eq(roomPlayers.roomId, room.id), isNull(roomPlayers.leftAt)))
+            .orderBy(asc(roomPlayers.joinOrder));
+
+          if (existingPlayers.length >= MAX_PLAYERS) {
+            throw new RoomRouteError(409, 'Room is full');
+          }
+          if (
+            existingPlayers.some(
+              (player) => player.nickname.toLocaleLowerCase() === input.nickname.toLocaleLowerCase()
+            )
+          ) {
+            throw new RoomRouteError(409, 'Nickname is already taken');
+          }
+
+          const [player] = await tx
+            .insert(roomPlayers)
+            .values({
+              roomId: room.id,
+              nickname: input.nickname,
+              token: generatePlayerToken(),
+              joinOrder: existingPlayers.length,
+              isHost: false,
+            })
+            .returning();
+
+          const [updatedRoom] = await tx
+            .update(rooms)
+            .set({
+              version: sql`${rooms.version} + 1`,
+              updatedAt: new Date(),
+            })
+            .where(eq(rooms.id, room.id))
+            .returning();
+
+          return { player, room: updatedRoom };
+        });
+      } catch (error) {
+        if (hasConstraint(error, ROOM_NICKNAME_CONSTRAINT)) {
+          throw new RoomRouteError(409, 'Nickname is already taken');
+        }
+        throw error;
+      }
+
+      const snapshot = await buildRoomSnapshot(db, joined.room);
+      return res.json(
+        joinRoomResponseSchema.parse({
+          playerId: joined.player.id,
+          token: joined.player.token,
+          snapshot,
+        })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error joining room:');
+    }
+  });
+
+  app.get('/api/rooms/:code', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      const { sinceVersion } = pollRoomRequestSchema.parse(req.query);
+      const [room] = await db.select().from(rooms).where(eq(rooms.code, code)).limit(1);
+
+      if (!room) {
+        throw new RoomRouteError(404, 'Room not found');
+      }
+      if (isExpired(room)) {
+        throw new RoomRouteError(404, 'Room expired');
+      }
+
+      const player = await authenticateRoomPlayer(req, room.id);
+      await db
+        .update(roomPlayers)
+        .set({ lastSeenAt: new Date() })
+        .where(eq(roomPlayers.id, player.id));
+
+      if (sinceVersion === room.version) {
+        return res.json(unchangedRoomPollResponseSchema.parse({ changed: false }));
+      }
+
+      return res.json(await buildRoomSnapshot(db, room));
+    } catch (error) {
+      return sendRoomError(res, error, 'Error polling room:');
+    }
+  });
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -29,6 +29,7 @@ import { filterNovelQuestions } from './lib/novelty-filter';
 import { z } from 'zod';
 import { aiLimiter } from './middleware/rateLimiter';
 import type { AuthenticatedRequest } from './types';
+import { registerRoomRoutes } from './routes.rooms';
 
 const VALID_PILLARS = ['GlobalEh', 'FreshPrints', 'TimeCapsule', 'GreatOutdoors'] as const;
 type SinglePillar = (typeof VALID_PILLARS)[number];
@@ -200,6 +201,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   // Setup authentication (MUST be before other routes)
   await setupAuth(app);
   registerAuthRoutes(app);
+  registerRoomRoutes(app);
 
   // Disputes API - admin review routes are protected; player submissions are public.
   app.get('/api/disputes', isAuthenticated, isAdmin, async (req, res) => {


### PR DESCRIPTION
## Summary

- Adds `POST /api/rooms` for transactional room and host creation with secure five-character codes, collision retry, two-hour lobby expiry, and opportunistic expired-room cleanup.
- Adds `POST /api/rooms/:code/join` with row locking, four-player capacity, case-insensitive nickname protection, started/expired guards, token issuance, version bumps, and a typed snapshot response.
- Adds authenticated `GET /api/rooms/:code?sinceVersion=N` polling with reusable `X-Player-Token` authentication, presence refresh, unchanged-version responses, and typed snapshots.
- Redacts answer fields and raw source metadata during QUESTION; reveals the full question in REVEAL, ROUND_SCORE, and GAME_OVER to match the merged RoomSnapshot contract.
- Registers the isolated room router from `server/routes.ts`.

## Why

STE-204 provides the server lifecycle API required by the merged STE-205 polling hook and the multiplayer host/join/lobby client stories. The room row is locked during joins so concurrent requests cannot exceed capacity.

## Review focus for Opus

- Transaction boundaries and PostgreSQL unique-violation handling.
- Join concurrency behavior and version increments.
- Token scoping and presence updates.
- Snapshot answer/source redaction before reveal.
- Alignment between the ticket wording and the merged contract for ROUND_SCORE visibility.

## Validation

- `npx vitest run server/routes.rooms.test.ts --project server-and-shared --configLoader runner` — 17 passed.
- `npx vitest run --configLoader runner` — 29 files, 303 tests passed.
- `npx tsc --noEmit --pretty false --tsBuildInfoFile /tmp/ste-204-pr.tsbuildinfo` — passed.
- ESLint on the changed files — passed.
- Prettier check on the new files — passed.

Linear: STE-204