### PR TITLE
feat(client): add join room flow [STE-208]

### DIFF
--- a/client/src/pages/JoinGame.test.tsx
+++ b/client/src/pages/JoinGame.test.tsx
@@ -1,0 +1,272 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import JoinGame from './JoinGame';
+import { getRoomSession } from '@/lib/room-session';
+
+// Stub localStorage for jsdom compatibility
+const storage: Record<string, string> = {};
+function stubLocalStorage() {
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+    clear: () => {
+      for (const key of Object.keys(storage)) delete storage[key];
+    },
+  });
+}
+
+const mockSetLocation = vi.fn();
+let mockParams: { code?: string } = {};
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/join', mockSetLocation],
+  useParams: () => mockParams,
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: React.forwardRef(
+      (props: React.HTMLAttributes<HTMLDivElement>, ref: React.Ref<HTMLDivElement>) => (
+        <div ref={ref} {...props} />
+      )
+    ),
+  },
+}));
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+function createFetchMock(overrides?: { joinRoom?: () => Promise<Response> }) {
+  return vi.fn((input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+    if (url.includes('/join')) {
+      if (overrides?.joinRoom) return overrides.joinRoom();
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            playerId: '11111111-1111-4111-8111-111111111111',
+            token: 'test-token',
+            snapshot: {},
+          }),
+      } as Response);
+    }
+
+    return Promise.reject(new Error(`Unhandled fetch: ${url}`));
+  });
+}
+
+function renderJoinGame() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <JoinGame />
+    </QueryClientProvider>
+  );
+}
+
+describe('JoinGame', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    localStorage.clear();
+    mockSetLocation.mockClear();
+    toastError.mockClear();
+    mockParams = {};
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('disables the join button until code and nickname are valid', async () => {
+    vi.stubGlobal('fetch', createFetchMock());
+    renderJoinGame();
+
+    const joinButton = await screen.findByTestId('button-join-room');
+    expect(joinButton).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('input-code'), { target: { value: 'ABCD' } });
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    expect(joinButton).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('input-code'), { target: { value: 'ABCDE' } });
+    expect(joinButton).not.toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: '   ' } });
+    expect(joinButton).toBeDisabled();
+  });
+
+  it('auto-uppercases the room code as the user types', async () => {
+    vi.stubGlobal('fetch', createFetchMock());
+    renderJoinGame();
+
+    const codeInput = (await screen.findByTestId('input-code')) as HTMLInputElement;
+    fireEvent.change(codeInput, { target: { value: 'abcde' } });
+
+    expect(codeInput.value).toBe('ABCDE');
+  });
+
+  it('prefills the room code from the route param', async () => {
+    mockParams = { code: 'wxyz2' };
+    vi.stubGlobal('fetch', createFetchMock());
+    renderJoinGame();
+
+    const codeInput = (await screen.findByTestId('input-code')) as HTMLInputElement;
+    expect(codeInput.value).toBe('WXYZ2');
+  });
+
+  it('shows a spinner while the join request is in flight', async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    const pending = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.stubGlobal('fetch', createFetchMock({ joinRoom: () => pending }));
+    renderJoinGame();
+
+    fireEvent.change(await screen.findByTestId('input-code'), { target: { value: 'ABCDE' } });
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-join-room'));
+
+    expect(await screen.findByRole('status', { name: 'Loading' })).toBeDefined();
+    expect(screen.getByTestId('button-join-room')).toBeDisabled();
+
+    resolveFetch({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          playerId: '11111111-1111-4111-8111-111111111111',
+          token: 'test-token',
+          snapshot: {},
+        }),
+    } as Response);
+
+    await waitFor(() => expect(mockSetLocation).toHaveBeenCalled());
+  });
+
+  it('shows a toast and keeps the form editable when the room is not found', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        joinRoom: () =>
+          Promise.resolve({
+            ok: false,
+            statusText: 'Not Found',
+            json: () => Promise.resolve({ message: 'Room not found' }),
+          } as Response),
+      })
+    );
+    renderJoinGame();
+
+    fireEvent.change(await screen.findByTestId('input-code'), { target: { value: 'ABCDE' } });
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-join-room'));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Room not found'));
+
+    const nicknameInput = screen.getByTestId('input-nickname') as HTMLInputElement;
+    expect(nicknameInput).not.toBeDisabled();
+    expect(nicknameInput.value).toBe('Steph');
+    expect(screen.getByTestId('button-join-room')).not.toBeDisabled();
+    expect(mockSetLocation).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast when the room is full', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        joinRoom: () =>
+          Promise.resolve({
+            ok: false,
+            statusText: 'Conflict',
+            json: () => Promise.resolve({ message: 'Room is full' }),
+          } as Response),
+      })
+    );
+    renderJoinGame();
+
+    fireEvent.change(await screen.findByTestId('input-code'), { target: { value: 'ABCDE' } });
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-join-room'));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Room is full'));
+    expect(mockSetLocation).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast when the nickname is already taken', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        joinRoom: () =>
+          Promise.resolve({
+            ok: false,
+            statusText: 'Conflict',
+            json: () => Promise.resolve({ message: 'Nickname is already taken' }),
+          } as Response),
+      })
+    );
+    renderJoinGame();
+
+    fireEvent.change(await screen.findByTestId('input-code'), { target: { value: 'ABCDE' } });
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-join-room'));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Nickname is already taken'));
+    expect(mockSetLocation).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast when the game has already started', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        joinRoom: () =>
+          Promise.resolve({
+            ok: false,
+            statusText: 'Conflict',
+            json: () => Promise.resolve({ message: 'Game has already started' }),
+          } as Response),
+      })
+    );
+    renderJoinGame();
+
+    fireEvent.change(await screen.findByTestId('input-code'), { target: { value: 'ABCDE' } });
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-join-room'));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Game has already started'));
+    expect(mockSetLocation).not.toHaveBeenCalled();
+  });
+
+  it('saves the room session and redirects to /room/:code on success', async () => {
+    vi.stubGlobal('fetch', createFetchMock());
+    renderJoinGame();
+
+    fireEvent.change(await screen.findByTestId('input-code'), { target: { value: 'ABCDE' } });
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-join-room'));
+
+    await waitFor(() => expect(mockSetLocation).toHaveBeenCalledWith('/room/ABCDE'));
+    expect(getRoomSession('ABCDE')).toEqual({
+      code: 'ABCDE',
+      playerId: '11111111-1111-4111-8111-111111111111',
+      token: 'test-token',
+    });
+  });
+});

--- a/client/src/pages/JoinGame.tsx
+++ b/client/src/pages/JoinGame.tsx
@@ -1,24 +1,156 @@
-import { useParams } from 'wouter';
+import { useState } from 'react';
+import { useLocation, useParams } from 'wouter';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { motion } from 'framer-motion';
+import { LogIn, UserPlus } from 'lucide-react';
+import { roomCodeSchema, type JoinRoomRequest, type JoinRoomResponse } from '@shared/models/rooms';
+
+import { saveRoomSession } from '@/lib/room-session';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Spinner } from '@/components/ui/spinner';
+
+async function joinRoom(code: string, body: JoinRoomRequest): Promise<JoinRoomResponse> {
+  const res = await fetch(`/api/rooms/${encodeURIComponent(code)}/join`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      if (typeof data?.message === 'string') message = data.message;
+    } catch {
+      // response had no JSON body; fall back to statusText
+    }
+    throw new Error(message);
+  }
+
+  return res.json() as Promise<JoinRoomResponse>;
+}
 
 export default function JoinGame() {
-  const { code } = useParams<{ code?: string }>();
+  const { code: codeFromRoute } = useParams<{ code?: string }>();
+  const [, setLocation] = useLocation();
+  const [code, setCode] = useState((codeFromRoute ?? '').toUpperCase());
+  const [nickname, setNickname] = useState('');
+
+  const joinRoomMutation = useMutation({
+    mutationFn: (body: JoinRoomRequest) => joinRoom(code, body),
+    onSuccess: (response) => {
+      saveRoomSession({ code, playerId: response.playerId, token: response.token });
+      setLocation(`/room/${code}`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to join room. Please try again.');
+    },
+  });
+
+  const trimmedNickname = nickname.trim();
+  const isNicknameValid = trimmedNickname.length > 0;
+  const isCodeValid = roomCodeSchema.safeParse(code).success;
+
+  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCode(e.target.value.toUpperCase());
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isCodeValid || !isNicknameValid || joinRoomMutation.isPending) return;
+
+    joinRoomMutation.mutate({ nickname: trimmedNickname });
+  };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4">
-      <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
-        <CardHeader>
-          <CardTitle>Join a Game</CardTitle>
-          <CardDescription>Multiplayer joining is coming soon.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground text-sm">
-            {code
-              ? `This screen is a placeholder for STE-208 (room code: ${code}).`
-              : 'This screen is a placeholder for STE-208.'}
-          </p>
-        </CardContent>
-      </Card>
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-900 via-background to-background">
+      <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-primary/20 rounded-full blur-[120px] opacity-50" />
+        <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] bg-blue-500/10 rounded-full blur-[120px] opacity-50" />
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="w-full max-w-md z-10 space-y-8"
+      >
+        <div className="text-center space-y-2">
+          <h1 className="text-6xl font-extrabold tracking-tighter bg-gradient-to-br from-white to-white/50 bg-clip-text text-transparent drop-shadow-sm">
+            JOIN A
+            <br />
+            GAME
+          </h1>
+          <p className="text-muted-foreground font-medium tracking-wide">ENTER YOUR ROOM CODE</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-8">
+          <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <LogIn className="w-5 h-5 text-primary" />
+                Room Code
+              </CardTitle>
+              <CardDescription>Ask the host for the 5-character code.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Input
+                placeholder="ABCDE"
+                value={code}
+                onChange={handleCodeChange}
+                className="bg-white/5 border-white/10 focus:border-primary/50 text-lg py-6 tracking-[0.3em] text-center uppercase"
+                autoFocus
+                maxLength={5}
+                disabled={joinRoomMutation.isPending}
+                data-testid="input-code"
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <UserPlus className="w-5 h-5 text-primary" />
+                Your Nickname
+              </CardTitle>
+              <CardDescription>Shown to other players in the room.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Input
+                placeholder="Enter your nickname..."
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                className="bg-white/5 border-white/10 focus:border-primary/50 text-lg py-6"
+                maxLength={20}
+                disabled={joinRoomMutation.isPending}
+                data-testid="input-nickname"
+              />
+            </CardContent>
+          </Card>
+
+          <Button
+            type="submit"
+            className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
+            disabled={!isCodeValid || !isNicknameValid || joinRoomMutation.isPending}
+            data-testid="button-join-room"
+          >
+            {joinRoomMutation.isPending ? (
+              <>
+                <Spinner className="mr-2" />
+                Joining Room...
+              </>
+            ) : (
+              <>
+                <LogIn className="w-5 h-5 mr-2" />
+                Join Room
+              </>
+            )}
+          </Button>
+        </form>
+      </motion.div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the `JoinGame.tsx` placeholder with the full join flow for `/join` (manual entry) and `/join/:code` (prefilled from a link/QR).
- Room code input auto-uppercases and validates against the 5-char room code format (`roomCodeSchema`); nickname input follows the same pattern established in `HostGame.tsx`.
- Join button is disabled until both code and nickname are valid, shows a spinner while the `POST /api/rooms/:code/join` request is in flight, and surfaces server errors (room not found, room full, nickname taken, game already started) via Sonner toasts while keeping the form editable for retry.
- On success, stores the player token via `room-session.ts` and navigates to `/room/:code`.

## Test plan
- [x] `npm test` — 313 tests passing, including 9 new tests in `client/src/pages/JoinGame.test.tsx` covering validation, auto-uppercase, code prefill from route param, loading state, success redirect, and each server error case (404, room full, nickname taken, game started).
- [x] `npx tsc --noEmit` — passes with no errors.

Linear: STE-208

🤖 Generated with [Claude Code](https://claude.com/claude-code)