### PR TITLE
feat(client): add lobby screen and shared PlayerRoster component [STE-209]

### DIFF
--- a/client/src/components/room/Lobby.test.tsx
+++ b/client/src/components/room/Lobby.test.tsx
@@ -72,6 +72,8 @@ function makeMutation<TData, TVariables>(
 }
 
 describe('Lobby', () => {
+  const originalClipboard = navigator.clipboard;
+
   beforeEach(() => {
     toastSuccess.mockClear();
     toastError.mockClear();
@@ -83,6 +85,7 @@ describe('Lobby', () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    Object.assign(navigator, { clipboard: originalClipboard });
   });
 
   it('disables Start Game with fewer than 2 players', () => {
@@ -97,7 +100,7 @@ describe('Lobby', () => {
     );
 
     expect(screen.getByTestId('button-start-game')).toBeDisabled();
-    expect(screen.getByTestId('text-need-players')).toBeDefined();
+    expect(screen.getByTestId('text-need-players')).toBeInTheDocument();
   });
 
   it('enables Start Game with 2 or more active players', () => {
@@ -146,8 +149,8 @@ describe('Lobby', () => {
       />
     );
 
-    expect(screen.getByTestId('button-start-game')).toBeDefined();
-    expect(screen.getByTestId('button-close-room')).toBeDefined();
+    expect(screen.getByTestId('button-start-game')).toBeInTheDocument();
+    expect(screen.getByTestId('button-close-room')).toBeInTheDocument();
     expect(screen.queryByTestId('text-waiting-host')).toBeNull();
   });
 
@@ -162,7 +165,7 @@ describe('Lobby', () => {
       />
     );
 
-    expect(screen.getByTestId('text-waiting-host')).toBeDefined();
+    expect(screen.getByTestId('text-waiting-host')).toBeInTheDocument();
     expect(screen.queryByTestId('button-start-game')).toBeNull();
     expect(screen.queryByTestId('button-close-room')).toBeNull();
   });
@@ -199,8 +202,8 @@ describe('Lobby', () => {
       />
     );
 
-    expect(screen.getByTestId('lobby-closed')).toBeDefined();
-    expect(screen.getByTestId('link-home')).toBeDefined();
+    expect(screen.getByTestId('lobby-closed')).toBeInTheDocument();
+    expect(screen.getByTestId('link-home')).toBeInTheDocument();
     expect(screen.queryByTestId('text-room-code')).toBeNull();
   });
 });

--- a/client/src/components/room/Lobby.test.tsx
+++ b/client/src/components/room/Lobby.test.tsx
@@ -1,0 +1,206 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+import { Lobby } from './Lobby';
+import type { EndRoomResponse, RoomSnapshot, StartRoomResponse } from '@shared/models/rooms';
+
+vi.mock('wouter', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+type LobbySnapshot = Extract<RoomSnapshot, { phase: 'LOBBY' }>;
+
+function makePlayer(overrides: Partial<LobbySnapshot['players'][number]> = {}) {
+  return {
+    id: 'host-1',
+    nickname: 'Steph',
+    joinOrder: 0,
+    score: 0,
+    questionCount: 0,
+    lastRoundDelta: 0,
+    isHost: true,
+    lastSeenAt: new Date().toISOString(),
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<LobbySnapshot> = {}): LobbySnapshot {
+  return {
+    id: 'room-1',
+    code: 'ABCDE',
+    status: 'lobby',
+    phase: 'LOBBY',
+    version: 1,
+    hostPlayerId: 'host-1',
+    category: 'All',
+    numRounds: 10,
+    currentQuestionIndex: 0,
+    activePlayerId: null,
+    currentAttempt: null,
+    currentQuestion: null,
+    players: [makePlayer()],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeMutation<TData, TVariables>(
+  overrides: Partial<{ isPending: boolean }> = {}
+): UseMutationResult<TData, Error, TVariables> {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+    ...overrides,
+  } as unknown as UseMutationResult<TData, Error, TVariables>;
+}
+
+describe('Lobby', () => {
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('disables Start Game with fewer than 2 players', () => {
+    const snapshot = makeSnapshot();
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="host-1"
+        start={makeMutation<StartRoomResponse, void>()}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    expect(screen.getByTestId('button-start-game')).toBeDisabled();
+    expect(screen.getByTestId('text-need-players')).toBeDefined();
+  });
+
+  it('enables Start Game with 2 or more active players', () => {
+    const snapshot = makeSnapshot({
+      players: [makePlayer({ id: 'host-1' }), makePlayer({ id: 'p2', isHost: false, joinOrder: 1 })],
+    });
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="host-1"
+        start={makeMutation<StartRoomResponse, void>()}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    expect(screen.getByTestId('button-start-game')).not.toBeDisabled();
+  });
+
+  it('does not count players who have left toward the start-game gate', () => {
+    const snapshot = makeSnapshot({
+      players: [
+        makePlayer({ id: 'host-1' }),
+        makePlayer({ id: 'p2', isHost: false, joinOrder: 1, leftAt: new Date().toISOString() }),
+      ],
+    });
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="host-1"
+        start={makeMutation<StartRoomResponse, void>()}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    expect(screen.getByTestId('button-start-game')).toBeDisabled();
+  });
+
+  it('shows host controls for the host', () => {
+    const snapshot = makeSnapshot();
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="host-1"
+        start={makeMutation<StartRoomResponse, void>()}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    expect(screen.getByTestId('button-start-game')).toBeDefined();
+    expect(screen.getByTestId('button-close-room')).toBeDefined();
+    expect(screen.queryByTestId('text-waiting-host')).toBeNull();
+  });
+
+  it('shows a waiting message for guests instead of host controls', () => {
+    const snapshot = makeSnapshot();
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="guest-1"
+        start={makeMutation<StartRoomResponse, void>()}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    expect(screen.getByTestId('text-waiting-host')).toBeDefined();
+    expect(screen.queryByTestId('button-start-game')).toBeNull();
+    expect(screen.queryByTestId('button-close-room')).toBeNull();
+  });
+
+  it('copies the join link to the clipboard and confirms via toast', async () => {
+    const snapshot = makeSnapshot();
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="host-1"
+        start={makeMutation<StartRoomResponse, void>()}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-copy-link'));
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/join/ABCDE`
+      )
+    );
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+  });
+
+  it('shows a closed message with a link home when the room is no longer in the lobby status', () => {
+    const snapshot = makeSnapshot({ status: 'abandoned' });
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="guest-1"
+        start={makeMutation<StartRoomResponse, void>()}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    expect(screen.getByTestId('lobby-closed')).toBeDefined();
+    expect(screen.getByTestId('link-home')).toBeDefined();
+    expect(screen.queryByTestId('text-room-code')).toBeNull();
+  });
+});

--- a/client/src/components/room/Lobby.tsx
+++ b/client/src/components/room/Lobby.tsx
@@ -1,0 +1,150 @@
+import { Link } from 'wouter';
+import { toast } from 'sonner';
+import { Copy, DoorOpen, Play } from 'lucide-react';
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { EndRoomResponse, RoomSnapshot, StartRoomResponse } from '@shared/models/rooms';
+
+import { PlayerRoster } from './PlayerRoster';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+type LobbySnapshot = Extract<RoomSnapshot, { phase: 'LOBBY' }>;
+
+export interface LobbyProps {
+  snapshot: LobbySnapshot;
+  currentPlayerId: string;
+  start: UseMutationResult<StartRoomResponse, Error, void>;
+  end: UseMutationResult<EndRoomResponse, Error, void>;
+}
+
+export function Lobby({ snapshot, currentPlayerId, start, end }: LobbyProps) {
+  const isHost = snapshot.hostPlayerId === currentPlayerId;
+  const activePlayers = snapshot.players.filter((player) => !player.leftAt);
+  const canStart = activePlayers.length >= 2;
+
+  const handleCopyLink = async () => {
+    const link = `${window.location.origin}/join/${snapshot.code}`;
+    try {
+      await navigator.clipboard.writeText(link);
+      toast.success('Join link copied to clipboard!');
+    } catch {
+      toast.error('Could not copy link. Please copy it manually.');
+    }
+  };
+
+  const handleStart = () => {
+    if (!canStart || start.isPending) return;
+    start.mutate(undefined, {
+      onError: (error) => toast.error(error.message || 'Failed to start game. Please try again.'),
+    });
+  };
+
+  const handleClose = () => {
+    if (end.isPending) return;
+    end.mutate(undefined, {
+      onError: (error) => toast.error(error.message || 'Failed to close room. Please try again.'),
+    });
+  };
+
+  if (snapshot.status !== 'lobby') {
+    return (
+      <Card
+        className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md"
+        data-testid="lobby-closed"
+      >
+        <CardHeader>
+          <CardTitle>Room Closed</CardTitle>
+          <CardDescription>The host has closed this room.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Link href="/">
+            <Button className="w-full" data-testid="link-home">
+              Back to Home
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-md space-y-6">
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+        <CardHeader className="text-center">
+          <CardDescription>Room Code</CardDescription>
+          <CardTitle
+            className="text-5xl font-extrabold tracking-[0.3em] py-2"
+            data-testid="text-room-code"
+          >
+            {snapshot.code}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="outline"
+            className="w-full border-white/10 hover:bg-white/10"
+            onClick={handleCopyLink}
+            data-testid="button-copy-link"
+          >
+            <Copy className="w-4 h-4 mr-2" />
+            Copy Join Link
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Settings</CardTitle>
+          <CardDescription>
+            {snapshot.category} &middot; {snapshot.numRounds} rounds
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Players ({activePlayers.length}/4)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PlayerRoster players={snapshot.players} currentPlayerId={currentPlayerId} />
+        </CardContent>
+      </Card>
+
+      {isHost ? (
+        <div className="space-y-3">
+          <Button
+            className="w-full h-14 text-lg font-bold"
+            disabled={!canStart || start.isPending}
+            onClick={handleStart}
+            data-testid="button-start-game"
+          >
+            <Play className="w-5 h-5 mr-2" />
+            {start.isPending ? 'Starting...' : 'Start Game'}
+          </Button>
+          {!canStart && (
+            <p
+              className="text-center text-sm text-muted-foreground"
+              data-testid="text-need-players"
+            >
+              Need at least 2 players
+            </p>
+          )}
+          <Button
+            variant="outline"
+            className="w-full border-destructive/30 text-destructive hover:bg-destructive/10"
+            disabled={end.isPending}
+            onClick={handleClose}
+            data-testid="button-close-room"
+          >
+            <DoorOpen className="w-4 h-4 mr-2" />
+            Close Room
+          </Button>
+        </div>
+      ) : (
+        <p className="text-center text-muted-foreground" data-testid="text-waiting-host">
+          Waiting for host to start…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/room/Lobby.tsx
+++ b/client/src/components/room/Lobby.tsx
@@ -2,7 +2,7 @@ import { Link } from 'wouter';
 import { toast } from 'sonner';
 import { Copy, DoorOpen, Play } from 'lucide-react';
 import type { UseMutationResult } from '@tanstack/react-query';
-import type { EndRoomResponse, RoomSnapshot, StartRoomResponse } from '@shared/models/rooms';
+import { MAX_PLAYERS, type EndRoomResponse, type RoomSnapshot, type StartRoomResponse } from '@shared/models/rooms';
 
 import { PlayerRoster } from './PlayerRoster';
 import { Button } from '@/components/ui/button';
@@ -103,7 +103,9 @@ export function Lobby({ snapshot, currentPlayerId, start, end }: LobbyProps) {
 
       <Card className="border-white/10 bg-white/5 backdrop-blur-md">
         <CardHeader className="pb-3">
-          <CardTitle className="text-lg">Players ({activePlayers.length}/4)</CardTitle>
+          <CardTitle className="text-lg">
+            Players ({activePlayers.length}/{MAX_PLAYERS})
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <PlayerRoster players={snapshot.players} currentPlayerId={currentPlayerId} />

--- a/client/src/components/room/PlayerRoster.test.tsx
+++ b/client/src/components/room/PlayerRoster.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { PlayerRoster } from './PlayerRoster';
+import type { RoomPlayerSnapshot } from '@shared/models/rooms';
+
+const NOW = new Date('2026-01-01T00:00:00.000Z').getTime();
+
+function makePlayer(overrides: Partial<RoomPlayerSnapshot> = {}): RoomPlayerSnapshot {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    nickname: 'Steph',
+    joinOrder: 0,
+    score: 0,
+    questionCount: 0,
+    lastRoundDelta: 0,
+    isHost: false,
+    lastSeenAt: new Date(NOW).toISOString(),
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+describe('PlayerRoster', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders every player with nickname and score', () => {
+    const players = [
+      makePlayer({ id: 'p1', nickname: 'Alice', score: 10, joinOrder: 0 }),
+      makePlayer({ id: 'p2', nickname: 'Bob', score: 5, joinOrder: 1 }),
+    ];
+    render(<PlayerRoster players={players} now={NOW} />);
+
+    expect(screen.getByText('Alice')).toBeDefined();
+    expect(screen.getByText('10')).toBeDefined();
+    expect(screen.getByText('Bob')).toBeDefined();
+    expect(screen.getByText('5')).toBeDefined();
+  });
+
+  it('marks the current player with a (you) label', () => {
+    const players = [makePlayer({ id: 'p1', nickname: 'Alice' })];
+    render(<PlayerRoster players={players} currentPlayerId="p1" now={NOW} />);
+
+    expect(screen.getByText('(you)')).toBeDefined();
+  });
+
+  it('shows an online presence dot for players seen recently', () => {
+    const players = [makePlayer({ id: 'p1', lastSeenAt: new Date(NOW - 2000).toISOString() })];
+    render(<PlayerRoster players={players} now={NOW} />);
+
+    expect(screen.getByTestId('presence-dot-p1')).toHaveAttribute('aria-label', 'Online');
+  });
+
+  it('shows an offline presence dot for players not seen recently', () => {
+    const players = [makePlayer({ id: 'p1', lastSeenAt: new Date(NOW - 15000).toISOString() })];
+    render(<PlayerRoster players={players} now={NOW} />);
+
+    expect(screen.getByTestId('presence-dot-p1')).toHaveAttribute('aria-label', 'Offline');
+  });
+
+  it('highlights the active player', () => {
+    const players = [makePlayer({ id: 'p1' }), makePlayer({ id: 'p2', joinOrder: 1 })];
+    render(<PlayerRoster players={players} activePlayerId="p1" now={NOW} />);
+
+    expect(screen.getByTestId('player-row-p1').className).toContain('ring-2');
+    expect(screen.getByTestId('player-row-p2').className).not.toContain('ring-2');
+  });
+
+  it('shows a crown for the host', () => {
+    const players = [makePlayer({ id: 'p1', isHost: true })];
+    const { container } = render(<PlayerRoster players={players} now={NOW} />);
+
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/client/src/components/room/PlayerRoster.test.tsx
+++ b/client/src/components/room/PlayerRoster.test.tsx
@@ -34,17 +34,17 @@ describe('PlayerRoster', () => {
     ];
     render(<PlayerRoster players={players} now={NOW} />);
 
-    expect(screen.getByText('Alice')).toBeDefined();
-    expect(screen.getByText('10')).toBeDefined();
-    expect(screen.getByText('Bob')).toBeDefined();
-    expect(screen.getByText('5')).toBeDefined();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
   });
 
   it('marks the current player with a (you) label', () => {
     const players = [makePlayer({ id: 'p1', nickname: 'Alice' })];
     render(<PlayerRoster players={players} currentPlayerId="p1" now={NOW} />);
 
-    expect(screen.getByText('(you)')).toBeDefined();
+    expect(screen.getByText('(you)')).toBeInTheDocument();
   });
 
   it('shows an online presence dot for players seen recently', () => {

--- a/client/src/components/room/PlayerRoster.tsx
+++ b/client/src/components/room/PlayerRoster.tsx
@@ -1,0 +1,71 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { Crown } from 'lucide-react';
+import type { RoomPlayerSnapshot } from '@shared/models/rooms';
+
+import { cn } from '@/lib/utils';
+
+const ONLINE_THRESHOLD_MS = 10_000;
+
+export interface PlayerRosterProps {
+  players: RoomPlayerSnapshot[];
+  currentPlayerId?: string | null;
+  activePlayerId?: string | null;
+  now?: number;
+}
+
+function isOnline(lastSeenAt: string, now: number): boolean {
+  return now - new Date(lastSeenAt).getTime() < ONLINE_THRESHOLD_MS;
+}
+
+export function PlayerRoster({
+  players,
+  currentPlayerId,
+  activePlayerId,
+  now = Date.now(),
+}: PlayerRosterProps) {
+  const sorted = [...players].sort((a, b) => a.joinOrder - b.joinOrder);
+
+  return (
+    <div className="space-y-2" data-testid="player-roster">
+      <AnimatePresence mode="popLayout">
+        {sorted.map((player) => {
+          const online = isOnline(player.lastSeenAt, now);
+          const isYou = player.id === currentPlayerId;
+          const isActive = player.id === activePlayerId;
+
+          return (
+            <motion.div
+              key={player.id}
+              layout
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              data-testid={`player-row-${player.id}`}
+              className={cn(
+                'flex items-center justify-between p-3 rounded-lg bg-white/5 border border-white/5',
+                isActive && 'ring-2 ring-primary'
+              )}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span
+                  data-testid={`presence-dot-${player.id}`}
+                  aria-label={online ? 'Online' : 'Offline'}
+                  className={cn(
+                    'w-2 h-2 rounded-full shrink-0',
+                    online ? 'bg-green-500' : 'bg-muted-foreground/40'
+                  )}
+                />
+                {player.isHost && <Crown className="w-4 h-4 text-yellow-400 shrink-0" />}
+                <span className="font-medium truncate">
+                  {player.nickname}
+                  {isYou && <span className="text-muted-foreground font-normal"> (you)</span>}
+                </span>
+              </div>
+              <span className="font-bold tabular-nums">{player.score}</span>
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/client/src/hooks/use-room.ts
+++ b/client/src/hooks/use-room.ts
@@ -109,13 +109,19 @@ export interface UseRoomResult {
   end: UseMutationResult<EndRoomResponse, Error, void>;
 }
 
-export function useRoom(code: string): UseRoomResult {
+export interface UseRoomOptions {
+  enabled?: boolean;
+}
+
+export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResult {
+  const { enabled = true } = options;
   const queryClient = useQueryClient();
   const queryKey = roomQueryKey(code);
   const [failureCount, setFailureCount] = useState(0);
 
   const query = useQuery<RoomSnapshot>({
     queryKey,
+    enabled,
     queryFn: async () => {
       const basis = queryClient.getQueryData<RoomSnapshot>(queryKey);
 

--- a/client/src/pages/Room.test.tsx
+++ b/client/src/pages/Room.test.tsx
@@ -1,0 +1,148 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import Room from './Room';
+import type { RoomSnapshot } from '@shared/models/rooms';
+
+const mockSetLocation = vi.fn();
+let mockParams: { code: string } = { code: 'ABCDE' };
+
+vi.mock('wouter', () => ({
+  useParams: () => mockParams,
+  useLocation: () => ['/room/ABCDE', mockSetLocation],
+}));
+
+const mockGetRoomSession = vi.fn();
+vi.mock('@/lib/room-session', () => ({
+  getRoomSession: (...args: unknown[]) => mockGetRoomSession(...args),
+}));
+
+const mockUseRoom = vi.fn();
+vi.mock('@/hooks/use-room', () => ({
+  useRoom: (...args: unknown[]) => mockUseRoom(...args),
+}));
+
+vi.mock('@/components/room/Lobby', () => ({
+  Lobby: ({ snapshot }: { snapshot: RoomSnapshot }) => (
+    <div data-testid="lobby-mock">Lobby for {snapshot.code}</div>
+  ),
+}));
+
+const SESSION = { code: 'ABCDE', playerId: 'host-1', token: 'test-token' };
+
+function makeSnapshot(overrides: Partial<RoomSnapshot> = {}): RoomSnapshot {
+  return {
+    id: 'room-1',
+    code: 'ABCDE',
+    status: 'lobby',
+    phase: 'LOBBY',
+    version: 1,
+    hostPlayerId: 'host-1',
+    category: 'All',
+    numRounds: 10,
+    currentQuestionIndex: 0,
+    activePlayerId: null,
+    currentAttempt: null,
+    currentQuestion: null,
+    players: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date().toISOString(),
+    ...overrides,
+  } as unknown as RoomSnapshot;
+}
+
+function makeUseRoomResult(overrides: Record<string, unknown> = {}) {
+  return {
+    snapshot: undefined,
+    isLoading: false,
+    isDisconnected: false,
+    error: null,
+    refetch: vi.fn(),
+    join: {},
+    start: {},
+    answer: {},
+    advance: {},
+    continueRound: {},
+    skip: {},
+    end: {},
+    ...overrides,
+  };
+}
+
+describe('Room', () => {
+  beforeEach(() => {
+    mockSetLocation.mockClear();
+    mockGetRoomSession.mockReset();
+    mockUseRoom.mockReset();
+    mockParams = { code: 'ABCDE' };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects to home when no room session exists', () => {
+    mockGetRoomSession.mockReturnValue(null);
+    mockUseRoom.mockReturnValue(makeUseRoomResult());
+
+    render(<Room />);
+
+    expect(mockSetLocation).toHaveBeenCalledWith('/');
+  });
+
+  it('shows a loading state while useRoom is loading', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(makeUseRoomResult({ isLoading: true }));
+
+    render(<Room />);
+
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+  });
+
+  it('shows an error state when useRoom errors', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(makeUseRoomResult({ error: new Error('Room not found') }));
+
+    render(<Room />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('Room not found')).toBeInTheDocument();
+  });
+
+  it('shows a disconnection banner when isDisconnected is true', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(
+      makeUseRoomResult({ snapshot: makeSnapshot(), isDisconnected: true })
+    );
+
+    render(<Room />);
+
+    expect(screen.getByTestId('text-disconnected')).toBeInTheDocument();
+  });
+
+  it('renders the Lobby component when phase is LOBBY', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'LOBBY' }) }));
+
+    render(<Room />);
+
+    expect(screen.getByTestId('lobby-mock')).toBeInTheDocument();
+  });
+
+  it('renders a placeholder for non-LOBBY phases', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(
+      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'QUESTION' }) })
+    );
+
+    render(<Room />);
+
+    expect(screen.getByText(/isn't implemented yet/)).toBeInTheDocument();
+    expect(screen.queryByTestId('lobby-mock')).toBeNull();
+  });
+});

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -11,7 +11,9 @@ export default function Room() {
   const { code } = useParams<{ code: string }>();
   const [, setLocation] = useLocation();
   const session = useMemo(() => getRoomSession(code), [code]);
-  const { snapshot, isLoading, isDisconnected, error, start, end } = useRoom(code);
+  const { snapshot, isLoading, isDisconnected, error, start, end } = useRoom(code, {
+    enabled: !!session,
+  });
 
   useEffect(() => {
     if (!session) {
@@ -51,7 +53,7 @@ export default function Room() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-4 gap-4">
       {isDisconnected && (
-        <p className="text-sm text-yellow-400" data-testid="text-disconnected">
+        <p className="text-sm text-yellow-400" data-testid="text-disconnected" aria-live="polite">
           Connection lost. Reconnecting…
         </p>
       )}

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -1,20 +1,76 @@
-import { useParams } from 'wouter';
+import { useEffect, useMemo } from 'react';
+import { useLocation, useParams } from 'wouter';
+
+import { Lobby } from '@/components/room/Lobby';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Spinner } from '@/components/ui/spinner';
+import { useRoom } from '@/hooks/use-room';
+import { getRoomSession } from '@/lib/room-session';
 
 export default function Room() {
   const { code } = useParams<{ code: string }>();
+  const [, setLocation] = useLocation();
+  const session = useMemo(() => getRoomSession(code), [code]);
+  const { snapshot, isLoading, isDisconnected, error, start, end } = useRoom(code);
+
+  useEffect(() => {
+    if (!session) {
+      setLocation('/');
+    }
+  }, [session, setLocation]);
+
+  if (!session) {
+    return null;
+  }
+
+  if (isLoading && !snapshot) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+        <Spinner className="size-8" />
+      </div>
+    );
+  }
+
+  if (error && !snapshot) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+        <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
+          <CardHeader>
+            <CardTitle>Something went wrong</CardTitle>
+            <CardDescription>{error.message}</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!snapshot) {
+    return null;
+  }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4">
-      <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
-        <CardHeader>
-          <CardTitle>Room {code}</CardTitle>
-          <CardDescription>Multiplayer gameplay is coming soon.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground text-sm">This screen is a placeholder for STE-209 / STE-211.</p>
-        </CardContent>
-      </Card>
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 gap-4">
+      {isDisconnected && (
+        <p className="text-sm text-yellow-400" data-testid="text-disconnected">
+          Connection lost. Reconnecting…
+        </p>
+      )}
+
+      {snapshot.phase === 'LOBBY' ? (
+        <Lobby snapshot={snapshot} currentPlayerId={session.playerId} start={start} end={end} />
+      ) : (
+        <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
+          <CardHeader>
+            <CardTitle>Room {snapshot.code}</CardTitle>
+            <CardDescription>This screen isn't implemented yet.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground text-sm">
+              Phase: {snapshot.phase}. Gameplay screens are coming soon (STE-211).
+            </p>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/shared/models/rooms.ts
+++ b/shared/models/rooms.ts
@@ -22,6 +22,7 @@ export const ROOM_PHASES = ['LOBBY', 'QUESTION', 'REVEAL', 'ROUND_SCORE', 'GAME_
 export const ROOM_VERDICTS = ['CORRECT', 'INCORRECT', 'PASS'] as const;
 export const ROOM_ROUND_OPTIONS = [5, 10, 15, 20] as const;
 export const ROOM_CODE_PATTERN = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{5}$/;
+export const MAX_PLAYERS = 4;
 
 export const roomStatusEnum = pgEnum('room_status', ROOM_STATUSES);
 export const roomPhaseEnum = pgEnum('room_phase', ROOM_PHASES);
@@ -181,7 +182,7 @@ const roomSnapshotBaseSchema = z.object({
   currentQuestionIndex: z.number().int().nonnegative(),
   activePlayerId: z.string().uuid().nullable(),
   currentAttempt: roomAttemptSchema.nullable(),
-  players: z.array(roomPlayerSnapshotSchema).max(4),
+  players: z.array(roomPlayerSnapshotSchema).max(MAX_PLAYERS),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   expiresAt: z.string().datetime(),


### PR DESCRIPTION
## Summary
- Adds `PlayerRoster`, a phase-agnostic shared component (`client/src/components/room/PlayerRoster.tsx`) showing nickname, score, an online/offline presence dot (`lastSeenAt < 10s`), a "(you)" marker, and an optional active-turn highlight. Players joining/leaving animate via the same `AnimatePresence` pattern used for the solo team list in `Home.tsx`.
- Adds `Lobby` (`client/src/components/room/Lobby.tsx`) with host and guest variants: large join-code display, copy-join-link button (copies `<origin>/join/<code>`, confirmed via a Sonner toast), settings summary (category/rounds), and a Start Game button gated on ≥2 active players with a "Need at least 2 players" hint. Host can also close the room; if the room's `status` is no longer `lobby`, guests and host alike see a "Room Closed" message with a link home.
- Replaces the `Room.tsx` placeholder with phase-aware rendering via `useRoom`: loading/error/disconnected states, redirect to `/` when no room session exists for the code, `LOBBY` phase renders `Lobby`, other phases keep a placeholder for STE-211.

## Tests
- `PlayerRoster.test.tsx`: rendering, presence dots, "(you)" marker, turn highlight, host crown.
- `Lobby.test.tsx`: start-button gating (including players who left not counting), host vs guest variants, copy-link, closed-room state.
- `npm test` — 326/326 passing.
- `npx tsc --noEmit` — clean.

## Note
No `DATABASE_URL` is configured in this environment, so the full server couldn't be started to manually click through create-room → lobby in a browser. Verified via the component/unit tests above and `tsc` instead.

Linear: STE-209