### PR TITLE
[codex] feat(api): add multiplayer room game engine [STE-206]

### DIFF
--- a/server/lib/room-engine.test.ts
+++ b/server/lib/room-engine.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { advanceRoomEngine, createRoomAttempt, type EnginePlayer } from './room-engine';
+
+const hostId = '22222222-2222-4222-8222-222222222222';
+const guestId = '33333333-3333-4333-8333-333333333333';
+
+const question = {
+  id: 'question-1',
+  category: 'History & Geography',
+  difficulty: 'Medium' as const,
+  question: 'What is the capital of Canada?',
+  answer: 'Ottawa',
+  acceptableAnswers: ['Ottawa, Ontario'],
+  explanation: 'Ottawa is the federal capital.',
+  pillar: 'GlobalEh',
+  tags: ['Canada'],
+};
+
+function players(overrides: Partial<EnginePlayer>[] = []): EnginePlayer[] {
+  return [
+    { id: hostId, score: 0, questionCount: 0, lastRoundDelta: 0, ...overrides[0] },
+    { id: guestId, score: 0, questionCount: 0, lastRoundDelta: 0, ...overrides[1] },
+  ];
+}
+
+describe('room engine', () => {
+  it('creates correct, incorrect, and pass attempts with solo scoring parity', () => {
+    expect(createRoomAttempt(hostId, 'ottawa', question)).toMatchObject({
+      verdict: 'CORRECT',
+      pointsDelta: 2,
+    });
+    expect(createRoomAttempt(hostId, 'Toronto', question)).toMatchObject({
+      verdict: 'INCORRECT',
+      pointsDelta: -2,
+    });
+    expect(createRoomAttempt(hostId, null, question)).toMatchObject({
+      submittedAnswer: null,
+      verdict: 'PASS',
+      pointsDelta: 0,
+    });
+  });
+
+  it('applies score and keeps the same player active before four questions', () => {
+    const result = advanceRoomEngine({
+      activePlayerId: hostId,
+      currentAttempt: createRoomAttempt(hostId, 'Ottawa', question),
+      currentQuestionIndex: 0,
+      players: players(),
+      questionCount: 40,
+    });
+
+    expect(result).toMatchObject({
+      activePlayerId: hostId,
+      currentQuestionIndex: 1,
+      phase: 'QUESTION',
+    });
+    expect(result.players[0]).toMatchObject({ score: 2, questionCount: 1, lastRoundDelta: 2 });
+  });
+
+  it('rotates after the active player answers four questions', () => {
+    const result = advanceRoomEngine({
+      activePlayerId: hostId,
+      currentAttempt: createRoomAttempt(hostId, null, question),
+      currentQuestionIndex: 3,
+      players: players([{ questionCount: 3 }]),
+      questionCount: 40,
+    });
+
+    expect(result.activePlayerId).toBe(guestId);
+    expect(result.phase).toBe('QUESTION');
+  });
+
+  it('enters round score after every player completes a rotation', () => {
+    const result = advanceRoomEngine({
+      activePlayerId: guestId,
+      currentAttempt: createRoomAttempt(guestId, 'Ottawa', question),
+      currentQuestionIndex: 7,
+      players: players([{ questionCount: 4 }, { questionCount: 3 }]),
+      questionCount: 40,
+    });
+
+    expect(result).toMatchObject({
+      activePlayerId: hostId,
+      currentQuestionIndex: 8,
+      phase: 'ROUND_SCORE',
+    });
+    expect(result.players[0].lastRoundDelta).toBe(0);
+    expect(result.players[1].lastRoundDelta).toBe(2);
+  });
+
+  it('finishes the game instead of showing round score after the final question', () => {
+    const result = advanceRoomEngine({
+      activePlayerId: guestId,
+      currentAttempt: createRoomAttempt(guestId, null, question),
+      currentQuestionIndex: 39,
+      players: players([{ questionCount: 20 }, { questionCount: 19 }]),
+      questionCount: 40,
+    });
+
+    expect(result.currentQuestionIndex).toBe(40);
+    expect(result.phase).toBe('GAME_OVER');
+  });
+});

--- a/server/lib/room-engine.ts
+++ b/server/lib/room-engine.ts
@@ -1,0 +1,98 @@
+import { QUESTIONS_PER_TEAM_ROTATION, verifyAttempt, type Question } from '@shared/lib/answers';
+import type { RoomAttempt, RoomPhase } from '@shared/schema';
+
+export interface EnginePlayer {
+  id: string;
+  score: number;
+  questionCount: number;
+  lastRoundDelta: number;
+}
+
+export interface AdvanceRoomInput {
+  activePlayerId: string;
+  currentAttempt: RoomAttempt;
+  currentQuestionIndex: number;
+  players: EnginePlayer[];
+  questionCount: number;
+}
+
+export interface AdvanceRoomResult {
+  activePlayerId: string;
+  currentQuestionIndex: number;
+  phase: Extract<RoomPhase, 'QUESTION' | 'ROUND_SCORE' | 'GAME_OVER'>;
+  players: EnginePlayer[];
+}
+
+export function createRoomAttempt(
+  playerId: string,
+  answer: string | null,
+  question: Question
+): RoomAttempt {
+  if (answer === null) {
+    return {
+      questionId: question.id,
+      playerId,
+      submittedAnswer: null,
+      verdict: 'PASS',
+      pointsDelta: 0,
+    };
+  }
+
+  const result = verifyAttempt(answer, question);
+  return {
+    questionId: question.id,
+    playerId,
+    submittedAnswer: answer,
+    verdict: result.verdict,
+    pointsDelta: result.points,
+  };
+}
+
+export function advanceRoomEngine(input: AdvanceRoomInput): AdvanceRoomResult {
+  if (input.players.length === 0) {
+    throw new Error('Cannot advance a room without players');
+  }
+  if (input.currentAttempt.playerId !== input.activePlayerId) {
+    throw new Error('Current attempt does not belong to the active player');
+  }
+
+  const activePlayerIndex = input.players.findIndex((player) => player.id === input.activePlayerId);
+  if (activePlayerIndex === -1) {
+    throw new Error('Active player is not in the room');
+  }
+
+  const players = input.players.map((player) =>
+    player.id === input.currentAttempt.playerId
+      ? {
+          ...player,
+          score: player.score + input.currentAttempt.pointsDelta,
+          questionCount: player.questionCount + 1,
+          lastRoundDelta: input.currentAttempt.pointsDelta,
+        }
+      : { ...player, lastRoundDelta: 0 }
+  );
+
+  const updatedActivePlayer = players[activePlayerIndex];
+  let activePlayerId = input.activePlayerId;
+  if (updatedActivePlayer.questionCount % QUESTIONS_PER_TEAM_ROTATION === 0) {
+    activePlayerId = players[(activePlayerIndex + 1) % players.length].id;
+  }
+
+  const currentQuestionIndex = input.currentQuestionIndex + 1;
+  const questionsPerRound = players.length * QUESTIONS_PER_TEAM_ROTATION;
+  const isRoundComplete = currentQuestionIndex % questionsPerRound === 0;
+
+  let phase: AdvanceRoomResult['phase'] = 'QUESTION';
+  if (currentQuestionIndex >= input.questionCount) {
+    phase = 'GAME_OVER';
+  } else if (isRoundComplete) {
+    phase = 'ROUND_SCORE';
+  }
+
+  return {
+    activePlayerId,
+    currentQuestionIndex,
+    phase,
+    players,
+  };
+}

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -17,10 +17,14 @@ const dbMocks = vi.hoisted(() => {
     const chain = {
       for: vi.fn(() => chain),
       from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
       limit: vi.fn(() => chain),
       orderBy: vi.fn(() => chain),
       returning: vi.fn(() => Promise.resolve(result)),
-      set: vi.fn(() => chain),
+      set: vi.fn((value) => {
+        valueArgs.push(value);
+        return chain;
+      }),
       then: promise.then.bind(promise),
       values: vi.fn((value) => {
         valueArgs.push(value);
@@ -123,6 +127,26 @@ function player(overrides: Record<string, unknown> = {}) {
     lastSeenAt: now,
     leftAt: null,
     ...overrides,
+  };
+}
+
+function question(id = 'question-1') {
+  return {
+    id,
+    category: 'History & Geography',
+    difficulty: 'Easy',
+    question: 'What is the capital of Canada?',
+    answer: 'Ottawa',
+    acceptableAnswers: ['Ottawa, Ontario'],
+    explanation: 'Ottawa is the federal capital.',
+    pillar: 'GlobalEh',
+    tags: ['Canada'],
+    sourceUrl: 'https://example.com/ottawa',
+    sourceName: 'Ottawa reference',
+    status: 'approved',
+    aiAnalysis: null,
+    createdAt: now,
+    updatedAt: now,
   };
 }
 
@@ -356,6 +380,353 @@ describe('room lifecycle routes', () => {
     expect(dbMocks.valueArgs).toContainEqual(
       expect.objectContaining({ nickname: 'Newcomer', joinOrder: 3 })
     );
+  });
+
+  it('starts a room with shuffled approved questions and the first player active', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const selectedQuestions = Array.from({ length: 40 }, (_, index) => ({
+      id: `question-${index + 1}`,
+    }));
+    const startedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: selectedQuestions.map(({ id }) => id),
+      activePlayerId: hostId,
+    });
+    queueSelect(
+      [room()],
+      [player()],
+      [player(), guest],
+      selectedQuestions,
+      [player(), guest],
+      [question()]
+    );
+    dbMocks.updateResults.push([startedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/start')
+      .set('X-Player-Token', 'host-secret')
+      .send({})
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({
+      status: 'active',
+      phase: 'QUESTION',
+      activePlayerId: hostId,
+      currentQuestion: { id: 'question-1' },
+    });
+    expect(dbMocks.valueArgs).toContainEqual(
+      expect.objectContaining({
+        status: 'active',
+        phase: 'QUESTION',
+        activePlayerId: hostId,
+        questionIds: selectedQuestions.map(({ id }) => id),
+      })
+    );
+  });
+
+  it('requires a host and at least two players to start', async () => {
+    const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
+    queueSelect([room()], [guest]);
+    const app = await buildTestApp();
+
+    expect(
+      (
+        await request(app)
+          .post('/api/rooms/ABCD2/start')
+          .set('X-Player-Token', 'guest-secret')
+          .send({})
+          .expect(403)
+      ).body.message
+    ).toBe('Host token required');
+
+    queueSelect([room()], [player()], [player()]);
+    expect(
+      (
+        await request(app)
+          .post('/api/rooms/ABCD2/start')
+          .set('X-Player-Token', 'host-secret')
+          .send({})
+          .expect(409)
+      ).body.message
+    ).toBe('At least two players are required to start');
+  });
+
+  it('accepts an active-player answer and reveals its scored attempt', async () => {
+    const questionRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      questionIds: ['question-1'],
+      activePlayerId: hostId,
+    });
+    const answeredRoom = room({
+      status: 'active',
+      phase: 'REVEAL',
+      version: 2,
+      questionIds: ['question-1'],
+      activePlayerId: hostId,
+      currentAttempt: {
+        questionId: 'question-1',
+        playerId: hostId,
+        submittedAnswer: 'Ottawa',
+        verdict: 'CORRECT',
+        pointsDelta: 1,
+      },
+    });
+    queueSelect([questionRoom], [player()], [question()], [player()], [question()]);
+    dbMocks.updateResults.push([answeredRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/answer')
+      .set('X-Player-Token', 'host-secret')
+      .send({ answer: 'Ottawa' })
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({
+      phase: 'REVEAL',
+      currentAttempt: { verdict: 'CORRECT', pointsDelta: 1 },
+      currentQuestion: { answer: 'Ottawa' },
+    });
+  });
+
+  it('rejects a non-active answer and a duplicate answer', async () => {
+    const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
+    queueSelect(
+      [
+        room({
+          status: 'active',
+          phase: 'QUESTION',
+          questionIds: ['question-1'],
+          activePlayerId: hostId,
+        }),
+      ],
+      [guest]
+    );
+    const app = await buildTestApp();
+
+    expect(
+      (
+        await request(app)
+          .post('/api/rooms/ABCD2/answer')
+          .set('X-Player-Token', 'guest-secret')
+          .send({ answer: 'Ottawa' })
+          .expect(403)
+      ).body.message
+    ).toBe('Only the active player can answer');
+
+    queueSelect([room({ status: 'active', phase: 'REVEAL' })]);
+    expect(
+      (
+        await request(app)
+          .post('/api/rooms/ABCD2/answer')
+          .set('X-Player-Token', 'host-secret')
+          .send({ answer: 'Ottawa' })
+          .expect(409)
+      ).body.message
+    ).toBe('Room is not accepting answers');
+  });
+
+  it('advances once, applies score, and rejects a duplicate advance', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const attempt = {
+      questionId: 'question-1',
+      playerId: hostId,
+      submittedAnswer: 'Ottawa',
+      verdict: 'CORRECT' as const,
+      pointsDelta: 1,
+    };
+    const revealRoom = room({
+      status: 'active',
+      phase: 'REVEAL',
+      questionIds: ['question-1', 'question-2'],
+      activePlayerId: hostId,
+      currentAttempt: attempt,
+    });
+    const advancedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: ['question-1', 'question-2'],
+      currentQuestionIndex: 1,
+      activePlayerId: hostId,
+      currentAttempt: attempt,
+    });
+    queueSelect(
+      [revealRoom],
+      [player()],
+      [player(), guest],
+      [player({ score: 1, questionCount: 1, lastRoundDelta: 1 }), guest],
+      [question('question-2')]
+    );
+    dbMocks.updateResults.push([advancedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/advance')
+      .set('X-Player-Token', 'host-secret')
+      .send({})
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({
+      phase: 'QUESTION',
+      currentQuestionIndex: 1,
+      currentQuestion: { id: 'question-2' },
+    });
+    expect(response.body.snapshot.players[0]).toMatchObject({
+      id: hostId,
+      score: 1,
+      questionCount: 1,
+    });
+
+    queueSelect([advancedRoom]);
+    expect(
+      (
+        await request(app)
+          .post('/api/rooms/ABCD2/advance')
+          .set('X-Player-Token', 'host-secret')
+          .send({})
+          .expect(409)
+      ).body.message
+    ).toBe('Room is not ready to advance');
+  });
+
+  it('returns a valid revealed snapshot when the final answer ends the game', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const attempt = {
+      questionId: 'question-1',
+      playerId: hostId,
+      submittedAnswer: 'Ottawa',
+      verdict: 'CORRECT' as const,
+      pointsDelta: 1,
+    };
+    const revealRoom = room({
+      status: 'active',
+      phase: 'REVEAL',
+      questionIds: ['question-1'],
+      activePlayerId: hostId,
+      currentAttempt: attempt,
+    });
+    const finishedRoom = room({
+      status: 'finished',
+      phase: 'GAME_OVER',
+      version: 2,
+      questionIds: ['question-1'],
+      currentQuestionIndex: 1,
+      activePlayerId: hostId,
+      currentAttempt: attempt,
+    });
+    queueSelect(
+      [revealRoom],
+      [player()],
+      [player(), guest],
+      [player({ score: 1, questionCount: 1, lastRoundDelta: 1 }), guest],
+      [question()]
+    );
+    dbMocks.updateResults.push([finishedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/advance')
+      .set('X-Player-Token', 'host-secret')
+      .send({})
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({
+      status: 'finished',
+      phase: 'GAME_OVER',
+      currentQuestionIndex: 1,
+      currentQuestion: { id: 'question-1', answer: 'Ottawa' },
+    });
+  });
+
+  it('allows only the host to continue from round score', async () => {
+    const attempt = {
+      questionId: 'question-1',
+      playerId: guestId,
+      submittedAnswer: null,
+      verdict: 'PASS' as const,
+      pointsDelta: 0,
+    };
+    const scoreRoom = room({
+      status: 'active',
+      phase: 'ROUND_SCORE',
+      questionIds: ['question-1', 'question-2'],
+      currentQuestionIndex: 1,
+      activePlayerId: hostId,
+      currentAttempt: attempt,
+    });
+    const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
+    queueSelect([scoreRoom], [guest]);
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/continue')
+      .set('X-Player-Token', 'guest-secret')
+      .send({})
+      .expect(403);
+
+    const continuedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: ['question-1', 'question-2'],
+      currentQuestionIndex: 1,
+      activePlayerId: hostId,
+      currentAttempt: null,
+    });
+    queueSelect([scoreRoom], [player()], [player(), guest], [question('question-2')]);
+    dbMocks.updateResults.push([continuedRoom]);
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/continue')
+      .set('X-Player-Token', 'host-secret')
+      .send({})
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({ phase: 'QUESTION', currentAttempt: null });
+  });
+
+  it('lets only the host abandon a lobby', async () => {
+    const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
+    queueSelect([room()], [guest]);
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/end')
+      .set('X-Player-Token', 'guest-secret')
+      .send({})
+      .expect(403);
+
+    const abandonedRoom = room({ status: 'abandoned', phase: 'LOBBY', version: 2 });
+    queueSelect([room()], [player()], [player(), guest]);
+    dbMocks.updateResults.push([abandonedRoom]);
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/end')
+      .set('X-Player-Token', 'host-secret')
+      .send({})
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({ status: 'abandoned', phase: 'LOBBY' });
   });
 
   it('returns unchanged while still refreshing presence', async () => {

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -20,6 +20,7 @@ const dbMocks = vi.hoisted(() => {
       leftJoin: vi.fn(() => chain),
       limit: vi.fn(() => chain),
       orderBy: vi.fn(() => chain),
+      onConflictDoUpdate: vi.fn(() => chain),
       returning: vi.fn(() => Promise.resolve(result)),
       set: vi.fn((value) => {
         valueArgs.push(value);
@@ -62,10 +63,36 @@ const dbMocks = vi.hoisted(() => {
 });
 
 const authMocks = vi.hoisted(() => ({
-  isAuthenticated: vi.fn((_req: Request, _res: Response, next: NextFunction) => next()),
+  isAuthenticated: vi.fn((req: Request, res: Response, next: NextFunction) => {
+    const user = (req as Request & { user?: TestUser }).user;
+
+    if (!user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    next();
+  }),
   registerAuthRoutes: vi.fn(),
-  setupAuth: vi.fn(async (_app: Express) => undefined),
+  setupAuth: vi.fn(async (app: Express) => {
+    app.use((req: Request, _res: Response, next: NextFunction) => {
+      const userId = req.header('x-test-user-id');
+
+      if (userId) {
+        (req as Request & { user?: TestUser }).user = {
+          claims: { sub: userId },
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+        };
+      }
+
+      next();
+    });
+  }),
 }));
+
+type TestUser = {
+  claims: { sub: string };
+  expires_at: number;
+};
 
 vi.mock('./db', () => ({
   db: {
@@ -430,6 +457,48 @@ describe('room lifecycle routes', () => {
         activePlayerId: hostId,
         questionIds: selectedQuestions.map(({ id }) => id),
       })
+    );
+  });
+
+  it('records the selected questions in seen history for an authenticated host', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const selectedQuestions = Array.from({ length: 40 }, (_, index) => ({
+      id: `question-${index + 1}`,
+    }));
+    const startedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: selectedQuestions.map(({ id }) => id),
+      activePlayerId: hostId,
+    });
+    queueSelect(
+      [room()],
+      [player()],
+      [player(), guest],
+      selectedQuestions,
+      [player(), guest],
+      [question()]
+    );
+    dbMocks.updateResults.push([startedRoom]);
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/start')
+      .set('X-Player-Token', 'host-secret')
+      .set('x-test-user-id', 'host-user')
+      .send({})
+      .expect(200);
+
+    expect(dbMocks.insert).toHaveBeenCalledTimes(1);
+    expect(dbMocks.valueArgs).toContainEqual(
+      selectedQuestions.map(({ id }) => ({ userId: 'host-user', questionId: id }))
     );
   });
 

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -1,12 +1,23 @@
 import { randomBytes, randomInt } from 'crypto';
 import type { Express, Request, Response } from 'express';
-import { and, asc, eq, isNull, lte, sql } from 'drizzle-orm';
+import { and, asc, eq, isNull, lte, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from './db';
+import { advanceRoomEngine, createRoomAttempt } from './lib/room-engine';
+import type { AuthenticatedRequest } from './types';
+import { QUESTIONS_PER_TEAM_ROTATION, type Question as AnswerQuestion } from '@shared/lib/answers';
 import {
+  advanceRoomRequestSchema,
+  advanceRoomResponseSchema,
+  answerRoomRequestSchema,
+  answerRoomResponseSchema,
+  continueRoomRequestSchema,
+  continueRoomResponseSchema,
   createRoomRequestSchema,
   createRoomResponseSchema,
+  endRoomRequestSchema,
+  endRoomResponseSchema,
   joinRoomRequestSchema,
   joinRoomResponseSchema,
   pollRoomRequestSchema,
@@ -15,7 +26,11 @@ import {
   roomPlayers,
   roomSnapshotSchema,
   rooms,
+  seenQuestions,
+  startRoomRequestSchema,
+  startRoomResponseSchema,
   unchangedRoomPollResponseSchema,
+  type Question,
   type Room,
   type RoomPlayer,
   type RoomSnapshot,
@@ -25,6 +40,7 @@ const ROOM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
 const MAX_ROOM_CODE_ATTEMPTS = 5;
 const MAX_PLAYERS = 4;
 const LOBBY_TTL_MS = 2 * 60 * 60 * 1000;
+const ACTIVE_TTL_MS = 24 * 60 * 60 * 1000;
 const ROOM_CODE_CONSTRAINT = 'rooms_code_unique';
 const ROOM_NICKNAME_CONSTRAINT = 'uq_room_players_room_nickname_ci';
 
@@ -65,6 +81,32 @@ function isExpired(room: Room, now = new Date()): boolean {
   return room.expiresAt.getTime() <= now.getTime();
 }
 
+function getUserId(req: Request): string | undefined {
+  return (req as AuthenticatedRequest).user?.claims?.sub;
+}
+
+function requireHost(player: RoomPlayer, room: Room): void {
+  if (!player.isHost || player.id !== room.hostPlayerId) {
+    throw new RoomRouteError(403, 'Host token required');
+  }
+}
+
+function toAnswerQuestion(question: Question): AnswerQuestion {
+  return {
+    id: question.id,
+    category: question.category,
+    difficulty: z.enum(['Easy', 'Medium', 'Hard']).parse(question.difficulty),
+    question: question.question,
+    answer: question.answer,
+    acceptableAnswers: question.acceptableAnswers ?? [],
+    explanation: question.explanation,
+    pillar: question.pillar,
+    tags: question.tags ?? [],
+    sourceUrl: question.sourceUrl ?? undefined,
+    sourceName: question.sourceName ?? undefined,
+  };
+}
+
 function serializePlayer(player: RoomPlayer) {
   return {
     id: player.id,
@@ -87,7 +129,10 @@ async function buildRoomSnapshot(database: RoomReadDatabase, room: Room): Promis
     .orderBy(asc(roomPlayers.joinOrder));
 
   let currentQuestion: Record<string, unknown> | null = null;
-  const questionId = room.questionIds[room.currentQuestionIndex];
+  const questionId =
+    room.phase === 'QUESTION'
+      ? room.questionIds[room.currentQuestionIndex]
+      : (room.currentAttempt?.questionId ?? room.questionIds[room.currentQuestionIndex]);
 
   if (room.phase !== 'LOBBY' && questionId) {
     const [question] = await database
@@ -333,6 +378,398 @@ export function registerRoomRoutes(app: Express): void {
       );
     } catch (error) {
       return sendRoomError(res, error, 'Error joining room:');
+    }
+  });
+
+  app.post('/api/rooms/:code/start', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      startRoomRequestSchema.parse(req.body);
+      const userId = getUserId(req);
+
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+
+        if (!room) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(room)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
+        if (room.status !== 'lobby' || room.phase !== 'LOBBY') {
+          throw new RoomRouteError(409, 'Game has already started');
+        }
+
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        requireHost(actor, room);
+
+        const players = await tx
+          .select()
+          .from(roomPlayers)
+          .where(and(eq(roomPlayers.roomId, room.id), isNull(roomPlayers.leftAt)))
+          .orderBy(asc(roomPlayers.joinOrder));
+
+        if (players.length < 2) {
+          throw new RoomRouteError(409, 'At least two players are required to start');
+        }
+
+        const questionLimit = room.numRounds * players.length * QUESTIONS_PER_TEAM_ROTATION;
+        const questionConditions = [eq(questions.status, 'approved')];
+        if (room.category !== 'All') {
+          questionConditions.push(eq(questions.category, room.category));
+        }
+
+        let selectedQuestions: { id: string }[];
+        if (userId) {
+          const cooldownExpr = sql`
+            CASE (${seenQuestions.seenCount} - 1) % 3
+              WHEN 0 THEN INTERVAL '1 month'
+              WHEN 1 THEN INTERVAL '3 months'
+              WHEN 2 THEN INTERVAL '5 months'
+            END
+          `;
+          selectedQuestions = await tx
+            .select({ id: questions.id })
+            .from(questions)
+            .leftJoin(
+              seenQuestions,
+              and(eq(questions.id, seenQuestions.questionId), eq(seenQuestions.userId, userId))
+            )
+            .where(
+              and(
+                ...questionConditions,
+                sql`(${seenQuestions.questionId} IS NULL OR ${seenQuestions.seenAt} + ${cooldownExpr} <= NOW())`
+              )
+            )
+            .orderBy(
+              sql`CASE WHEN ${seenQuestions.questionId} IS NULL THEN 0 ELSE 1 END`,
+              sql`random()`
+            )
+            .limit(questionLimit);
+        } else {
+          selectedQuestions = await tx
+            .select({ id: questions.id })
+            .from(questions)
+            .where(and(...questionConditions))
+            .orderBy(sql`random()`)
+            .limit(questionLimit);
+        }
+
+        if (selectedQuestions.length < questionLimit) {
+          throw new RoomRouteError(409, 'Not enough approved questions to start this game');
+        }
+
+        const [startedRoom] = await tx
+          .update(rooms)
+          .set({
+            status: 'active',
+            phase: 'QUESTION',
+            questionIds: selectedQuestions.map((question) => question.id),
+            currentQuestionIndex: 0,
+            activePlayerId: players[0].id,
+            currentAttempt: null,
+            expiresAt: new Date(Date.now() + ACTIVE_TTL_MS),
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(rooms.id, room.id),
+              eq(rooms.status, 'lobby'),
+              eq(rooms.phase, 'LOBBY'),
+              eq(rooms.hostPlayerId, actor.id)
+            )
+          )
+          .returning();
+
+        if (!startedRoom) {
+          throw new RoomRouteError(409, 'Room state changed before the game could start');
+        }
+        return startedRoom;
+      });
+
+      return res.json(
+        startRoomResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error starting room:');
+    }
+  });
+
+  app.post('/api/rooms/:code/answer', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      const input = answerRoomRequestSchema.parse(req.body);
+
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+
+        if (!room) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(room)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
+        if (room.phase !== 'QUESTION' || room.status !== 'active') {
+          throw new RoomRouteError(409, 'Room is not accepting answers');
+        }
+
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        if (actor.id !== room.activePlayerId) {
+          throw new RoomRouteError(403, 'Only the active player can answer');
+        }
+
+        const questionId = room.questionIds[room.currentQuestionIndex];
+        const [question] = await tx
+          .select()
+          .from(questions)
+          .where(eq(questions.id, questionId))
+          .limit(1);
+        if (!question) {
+          throw new Error(`Room question not found: ${questionId}`);
+        }
+
+        const currentAttempt = createRoomAttempt(
+          actor.id,
+          input.answer,
+          toAnswerQuestion(question)
+        );
+        const [answeredRoom] = await tx
+          .update(rooms)
+          .set({
+            phase: 'REVEAL',
+            currentAttempt,
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(rooms.id, room.id),
+              eq(rooms.status, 'active'),
+              eq(rooms.phase, 'QUESTION'),
+              eq(rooms.activePlayerId, actor.id)
+            )
+          )
+          .returning();
+
+        if (!answeredRoom) {
+          throw new RoomRouteError(409, 'Room state changed before the answer was accepted');
+        }
+        return answeredRoom;
+      });
+
+      return res.json(
+        answerRoomResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error answering room question:');
+    }
+  });
+
+  app.post('/api/rooms/:code/advance', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      advanceRoomRequestSchema.parse(req.body);
+
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+
+        if (!room) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(room)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
+        if (room.phase !== 'REVEAL' || room.status !== 'active' || !room.currentAttempt) {
+          throw new RoomRouteError(409, 'Room is not ready to advance');
+        }
+
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        if (actor.id !== room.activePlayerId && actor.id !== room.hostPlayerId) {
+          throw new RoomRouteError(403, 'Only the active player or host can advance');
+        }
+
+        const players = await tx
+          .select()
+          .from(roomPlayers)
+          .where(and(eq(roomPlayers.roomId, room.id), isNull(roomPlayers.leftAt)))
+          .orderBy(asc(roomPlayers.joinOrder));
+        const transition = advanceRoomEngine({
+          activePlayerId: room.activePlayerId ?? '',
+          currentAttempt: room.currentAttempt,
+          currentQuestionIndex: room.currentQuestionIndex,
+          players,
+          questionCount: room.questionIds.length,
+        });
+
+        const [advancedRoom] = await tx
+          .update(rooms)
+          .set({
+            status: transition.phase === 'GAME_OVER' ? 'finished' : 'active',
+            phase: transition.phase,
+            currentQuestionIndex: transition.currentQuestionIndex,
+            activePlayerId: transition.activePlayerId,
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(rooms.id, room.id),
+              eq(rooms.status, 'active'),
+              eq(rooms.phase, 'REVEAL'),
+              or(eq(rooms.activePlayerId, actor.id), eq(rooms.hostPlayerId, actor.id))
+            )
+          )
+          .returning();
+
+        if (!advancedRoom) {
+          throw new RoomRouteError(409, 'Room state changed before it could advance');
+        }
+
+        for (const player of transition.players) {
+          await tx
+            .update(roomPlayers)
+            .set({
+              score: player.score,
+              questionCount: player.questionCount,
+              lastRoundDelta: player.lastRoundDelta,
+            })
+            .where(and(eq(roomPlayers.id, player.id), eq(roomPlayers.roomId, room.id)));
+        }
+
+        return advancedRoom;
+      });
+
+      return res.json(
+        advanceRoomResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error advancing room:');
+    }
+  });
+
+  app.post('/api/rooms/:code/continue', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      continueRoomRequestSchema.parse(req.body);
+
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+        if (!room) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(room)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
+        if (room.phase !== 'ROUND_SCORE' || room.status !== 'active') {
+          throw new RoomRouteError(409, 'Room is not ready for the next round');
+        }
+
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        requireHost(actor, room);
+        const [continuedRoom] = await tx
+          .update(rooms)
+          .set({
+            phase: 'QUESTION',
+            currentAttempt: null,
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(rooms.id, room.id),
+              eq(rooms.status, 'active'),
+              eq(rooms.phase, 'ROUND_SCORE'),
+              eq(rooms.hostPlayerId, actor.id)
+            )
+          )
+          .returning();
+        if (!continuedRoom) {
+          throw new RoomRouteError(409, 'Room state changed before the next round');
+        }
+        return continuedRoom;
+      });
+
+      return res.json(
+        continueRoomResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error continuing room:');
+    }
+  });
+
+  app.post('/api/rooms/:code/end', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      endRoomRequestSchema.parse(req.body);
+
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+        if (!room) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(room)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
+        if (room.status === 'finished' || room.status === 'abandoned') {
+          throw new RoomRouteError(409, 'Room has already ended');
+        }
+
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        requireHost(actor, room);
+        const isLobby = room.phase === 'LOBBY';
+        const [endedRoom] = await tx
+          .update(rooms)
+          .set({
+            status: isLobby ? 'abandoned' : 'finished',
+            phase: isLobby ? 'LOBBY' : 'GAME_OVER',
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(rooms.id, room.id),
+              eq(rooms.phase, room.phase),
+              eq(rooms.hostPlayerId, actor.id)
+            )
+          )
+          .returning();
+        if (!endedRoom) {
+          throw new RoomRouteError(409, 'Room state changed before it could end');
+        }
+        return endedRoom;
+      });
+
+      return res.json(
+        endRoomResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error ending room:');
     }
   });
 

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -464,6 +464,27 @@ export function registerRoomRoutes(app: Express): void {
           throw new RoomRouteError(409, 'Not enough approved questions to start this game');
         }
 
+        if (userId) {
+          await tx
+            .insert(seenQuestions)
+            .values(selectedQuestions.map((question) => ({ userId, questionId: question.id })))
+            .onConflictDoUpdate({
+              target: [seenQuestions.userId, seenQuestions.questionId],
+              set: {
+                seenCount: sql`CASE
+              WHEN ${seenQuestions.seenAt} < NOW() - INTERVAL '24 hours'
+              THEN ${seenQuestions.seenCount} + 1
+              ELSE ${seenQuestions.seenCount}
+            END`,
+                seenAt: sql`CASE
+              WHEN ${seenQuestions.seenAt} < NOW() - INTERVAL '24 hours'
+              THEN NOW()
+              ELSE ${seenQuestions.seenAt}
+            END`,
+              },
+            });
+        }
+
         const [startedRoom] = await tx
           .update(rooms)
           .set({


### PR DESCRIPTION
## What changed
- Added `server/lib/room-engine.ts` with pure room transition helpers for scoring, rotation, round boundaries, and game-over handling.
- Extended `server/routes.rooms.ts` with transactional `start`, `answer`, `advance`, `continue`, and `end` flows.
- Expanded `server/routes.rooms.test.ts` and added `server/lib/room-engine.test.ts` to cover scoring parity, rotation, stale/duplicate requests, and terminal transitions.

## Why
- STE-206 needs the server to own multiplayer room state transitions so every client stays in sync.
- The new engine mirrors the solo scoring semantics while keeping the HTTP layer thin and transaction-safe.

## Impact
- Unblocks the next multiplayer room tickets that depend on server-authoritative room progression.
- Moves the API closer to the shared room lifecycle and client room UI work already on main.

## Validation
- `npm test`
- `npx tsc --noEmit`
- `npm run lint` (22 existing warnings, 0 errors)
- `npm run build`