### PR TITLE
feat(api): handle room presence and stale players [STE-210]

### DIFF
--- a/client/src/components/room/Lobby.test.tsx
+++ b/client/src/components/room/Lobby.test.tsx
@@ -33,6 +33,7 @@ function makePlayer(overrides: Partial<LobbySnapshot['players'][number]> = {}) {
     questionCount: 0,
     lastRoundDelta: 0,
     isHost: true,
+    presence: 'online' as const,
     lastSeenAt: new Date().toISOString(),
     leftAt: null,
     ...overrides,
@@ -105,7 +106,10 @@ describe('Lobby', () => {
 
   it('enables Start Game with 2 or more active players', () => {
     const snapshot = makeSnapshot({
-      players: [makePlayer({ id: 'host-1' }), makePlayer({ id: 'p2', isHost: false, joinOrder: 1 })],
+      players: [
+        makePlayer({ id: 'host-1' }),
+        makePlayer({ id: 'p2', isHost: false, joinOrder: 1 }),
+      ],
     });
     render(
       <Lobby

--- a/client/src/components/room/PlayerRoster.test.tsx
+++ b/client/src/components/room/PlayerRoster.test.tsx
@@ -16,6 +16,7 @@ function makePlayer(overrides: Partial<RoomPlayerSnapshot> = {}): RoomPlayerSnap
     questionCount: 0,
     lastRoundDelta: 0,
     isHost: false,
+    presence: 'online',
     lastSeenAt: new Date(NOW).toISOString(),
     leftAt: null,
     ...overrides,
@@ -32,7 +33,7 @@ describe('PlayerRoster', () => {
       makePlayer({ id: 'p1', nickname: 'Alice', score: 10, joinOrder: 0 }),
       makePlayer({ id: 'p2', nickname: 'Bob', score: 5, joinOrder: 1 }),
     ];
-    render(<PlayerRoster players={players} now={NOW} />);
+    render(<PlayerRoster players={players} />);
 
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText('10')).toBeInTheDocument();
@@ -42,28 +43,36 @@ describe('PlayerRoster', () => {
 
   it('marks the current player with a (you) label', () => {
     const players = [makePlayer({ id: 'p1', nickname: 'Alice' })];
-    render(<PlayerRoster players={players} currentPlayerId="p1" now={NOW} />);
+    render(<PlayerRoster players={players} currentPlayerId="p1" />);
 
     expect(screen.getByText('(you)')).toBeInTheDocument();
   });
 
   it('shows an online presence dot for players seen recently', () => {
-    const players = [makePlayer({ id: 'p1', lastSeenAt: new Date(NOW - 2000).toISOString() })];
-    render(<PlayerRoster players={players} now={NOW} />);
+    const players = [makePlayer({ id: 'p1', presence: 'online' })];
+    render(<PlayerRoster players={players} />);
 
     expect(screen.getByTestId('presence-dot-p1')).toHaveAttribute('aria-label', 'Online');
   });
 
-  it('shows an offline presence dot for players not seen recently', () => {
-    const players = [makePlayer({ id: 'p1', lastSeenAt: new Date(NOW - 15000).toISOString() })];
-    render(<PlayerRoster players={players} now={NOW} />);
+  it('shows an away presence dot for players between the online and stale thresholds', () => {
+    const players = [makePlayer({ id: 'p1', presence: 'away' })];
+    render(<PlayerRoster players={players} />);
 
-    expect(screen.getByTestId('presence-dot-p1')).toHaveAttribute('aria-label', 'Offline');
+    expect(screen.getByTestId('presence-dot-p1')).toHaveAttribute('aria-label', 'Away');
+  });
+
+  it('greys out stale players', () => {
+    const players = [makePlayer({ id: 'p1', presence: 'stale' })];
+    render(<PlayerRoster players={players} />);
+
+    expect(screen.getByTestId('presence-dot-p1')).toHaveAttribute('aria-label', 'Stale');
+    expect(screen.getByTestId('player-row-p1').className).toContain('opacity-50');
   });
 
   it('highlights the active player', () => {
     const players = [makePlayer({ id: 'p1' }), makePlayer({ id: 'p2', joinOrder: 1 })];
-    render(<PlayerRoster players={players} activePlayerId="p1" now={NOW} />);
+    render(<PlayerRoster players={players} activePlayerId="p1" />);
 
     expect(screen.getByTestId('player-row-p1').className).toContain('ring-2');
     expect(screen.getByTestId('player-row-p2').className).not.toContain('ring-2');
@@ -71,7 +80,7 @@ describe('PlayerRoster', () => {
 
   it('shows a crown for the host', () => {
     const players = [makePlayer({ id: 'p1', isHost: true })];
-    const { container } = render(<PlayerRoster players={players} now={NOW} />);
+    const { container } = render(<PlayerRoster players={players} />);
 
     expect(container.querySelector('svg')).not.toBeNull();
   });

--- a/client/src/components/room/PlayerRoster.tsx
+++ b/client/src/components/room/PlayerRoster.tsx
@@ -4,32 +4,21 @@ import type { RoomPlayerSnapshot } from '@shared/models/rooms';
 
 import { cn } from '@/lib/utils';
 
-const ONLINE_THRESHOLD_MS = 10_000;
-
 export interface PlayerRosterProps {
   players: RoomPlayerSnapshot[];
   currentPlayerId?: string | null;
   activePlayerId?: string | null;
-  now?: number;
 }
 
-function isOnline(lastSeenAt: string, now: number): boolean {
-  return now - new Date(lastSeenAt).getTime() < ONLINE_THRESHOLD_MS;
-}
-
-export function PlayerRoster({
-  players,
-  currentPlayerId,
-  activePlayerId,
-  now = Date.now(),
-}: PlayerRosterProps) {
+export function PlayerRoster({ players, currentPlayerId, activePlayerId }: PlayerRosterProps) {
   const sorted = [...players].sort((a, b) => a.joinOrder - b.joinOrder);
 
   return (
     <div className="space-y-2" data-testid="player-roster">
       <AnimatePresence mode="popLayout">
         {sorted.map((player) => {
-          const online = isOnline(player.lastSeenAt, now);
+          const online = player.presence === 'online';
+          const stale = player.presence === 'stale';
           const isYou = player.id === currentPlayerId;
           const isActive = player.id === activePlayerId;
 
@@ -43,16 +32,17 @@ export function PlayerRoster({
               data-testid={`player-row-${player.id}`}
               className={cn(
                 'flex items-center justify-between p-3 rounded-lg bg-white/5 border border-white/5',
+                stale && 'opacity-50',
                 isActive && 'ring-2 ring-primary'
               )}
             >
               <div className="flex items-center gap-2 min-w-0">
                 <span
                   data-testid={`presence-dot-${player.id}`}
-                  aria-label={online ? 'Online' : 'Offline'}
+                  aria-label={online ? 'Online' : stale ? 'Stale' : 'Away'}
                   className={cn(
                     'w-2 h-2 rounded-full shrink-0',
-                    online ? 'bg-green-500' : 'bg-muted-foreground/40'
+                    online ? 'bg-green-500' : stale ? 'bg-muted-foreground/40' : 'bg-yellow-400'
                   )}
                 />
                 {player.isHost && <Crown className="w-4 h-4 text-yellow-400 shrink-0" />}

--- a/server/lib/room-engine.test.ts
+++ b/server/lib/room-engine.test.ts
@@ -71,6 +71,20 @@ describe('room engine', () => {
     expect(result.phase).toBe('QUESTION');
   });
 
+  it('forces the next player active when a stale turn is skipped', () => {
+    const result = advanceRoomEngine({
+      activePlayerId: hostId,
+      currentAttempt: createRoomAttempt(hostId, null, question),
+      currentQuestionIndex: 0,
+      players: players(),
+      questionCount: 40,
+      forceNextPlayer: true,
+    });
+
+    expect(result.activePlayerId).toBe(guestId);
+    expect(result.players[0]).toMatchObject({ score: 0, questionCount: 1 });
+  });
+
   it('enters round score after every player completes a rotation', () => {
     const result = advanceRoomEngine({
       activePlayerId: guestId,

--- a/server/lib/room-engine.ts
+++ b/server/lib/room-engine.ts
@@ -14,6 +14,7 @@ export interface AdvanceRoomInput {
   currentQuestionIndex: number;
   players: EnginePlayer[];
   questionCount: number;
+  forceNextPlayer?: boolean;
 }
 
 export interface AdvanceRoomResult {
@@ -74,7 +75,10 @@ export function advanceRoomEngine(input: AdvanceRoomInput): AdvanceRoomResult {
 
   const updatedActivePlayer = players[activePlayerIndex];
   let activePlayerId = input.activePlayerId;
-  if (updatedActivePlayer.questionCount % QUESTIONS_PER_TEAM_ROTATION === 0) {
+  if (
+    input.forceNextPlayer ||
+    updatedActivePlayer.questionCount % QUESTIONS_PER_TEAM_ROTATION === 0
+  ) {
     activePlayerId = players[(activePlayerIndex + 1) % players.length].id;
   }
 

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -4,6 +4,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildTestApp } from './test/testApp';
+import { deriveRoomPresence } from './routes.rooms';
 
 const dbMocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
@@ -211,6 +212,15 @@ describe('room lifecycle routes', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it('derives online, away, and stale presence at the exact thresholds', () => {
+    const observedAt = new Date('2026-07-03T15:00:30.000Z');
+
+    expect(deriveRoomPresence(new Date('2026-07-03T15:00:20.001Z'), observedAt)).toBe('online');
+    expect(deriveRoomPresence(new Date('2026-07-03T15:00:20.000Z'), observedAt)).toBe('away');
+    expect(deriveRoomPresence(new Date('2026-07-03T15:00:00.000Z'), observedAt)).toBe('away');
+    expect(deriveRoomPresence(new Date('2026-07-03T14:59:59.999Z'), observedAt)).toBe('stale');
+  });
+
   it('creates a lobby room and its host atomically after cleaning up expired rooms', async () => {
     dbMocks.insertResults.push([room({ hostPlayerId: null })], [player()]);
     const app = await buildTestApp();
@@ -228,10 +238,8 @@ describe('room lifecycle routes', () => {
 
     const cleanupCondition = dbMocks.whereArgs[0] as Parameters<PgDialect['sqlToQuery']>[0];
     const cleanupQuery = new PgDialect().sqlToQuery(cleanupCondition);
-    expect(cleanupQuery.sql).toContain('"rooms"."status" = $1');
-    expect(cleanupQuery.sql).toContain('"rooms"."phase" = $2');
-    expect(cleanupQuery.sql).toContain('"rooms"."expires_at" <= $3');
-    expect(cleanupQuery.params.slice(0, 2)).toEqual(['lobby', 'LOBBY']);
+    expect(cleanupQuery.sql).toContain('"rooms"."expires_at" <= $1');
+    expect(cleanupQuery.params).toHaveLength(1);
   });
 
   it('retries a room-code collision', async () => {
@@ -798,8 +806,231 @@ describe('room lifecycle routes', () => {
     expect(response.body.snapshot).toMatchObject({ status: 'abandoned', phase: 'LOBBY' });
   });
 
+  it('lets the host skip an active player stale for more than sixty seconds', async () => {
+    const observedAt = Date.now();
+    const host = player({ lastSeenAt: new Date(observedAt) });
+    const staleGuest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+      lastSeenAt: new Date(observedAt - 60_001),
+    });
+    const questionRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      questionIds: ['question-1', 'question-2'],
+      activePlayerId: guestId,
+    });
+    const skippedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: ['question-1', 'question-2'],
+      currentQuestionIndex: 1,
+      activePlayerId: hostId,
+      currentAttempt: {
+        questionId: 'question-1',
+        playerId: guestId,
+        submittedAnswer: null,
+        verdict: 'PASS',
+        pointsDelta: 0,
+      },
+    });
+    queueSelect(
+      [questionRoom],
+      [host],
+      [host, staleGuest],
+      [host, { ...staleGuest, questionCount: 1 }],
+      [question('question-2')]
+    );
+    dbMocks.updateResults.push([skippedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/skip')
+      .set('X-Player-Token', 'host-secret')
+      .send({})
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({
+      phase: 'QUESTION',
+      currentQuestionIndex: 1,
+      activePlayerId: hostId,
+      currentAttempt: { playerId: guestId, verdict: 'PASS', pointsDelta: 0 },
+      currentQuestion: { id: 'question-2' },
+    });
+    expect(response.body.snapshot.players[1]).toMatchObject({ score: 0, questionCount: 1 });
+  });
+
+  it('rejects skip from a non-host and while the active player is not stale enough', async () => {
+    const observedAt = Date.now();
+    const host = player({ lastSeenAt: new Date(observedAt) });
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+      lastSeenAt: new Date(observedAt - 30_000),
+    });
+    const questionRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      questionIds: ['question-1'],
+      activePlayerId: guestId,
+    });
+    queueSelect([questionRoom], [guest]);
+    const app = await buildTestApp();
+
+    expect(
+      (
+        await request(app)
+          .post('/api/rooms/ABCD2/skip')
+          .set('X-Player-Token', 'guest-secret')
+          .send({})
+          .expect(403)
+      ).body.message
+    ).toBe('Host token required');
+
+    queueSelect([questionRoom], [host], [host, guest]);
+    expect(
+      (
+        await request(app)
+          .post('/api/rooms/ABCD2/skip')
+          .set('X-Player-Token', 'host-secret')
+          .send({})
+          .expect(409)
+      ).body.message
+    ).toBe('Active player is not stale enough to skip');
+  });
+
+  it('abandons a lobby lazily when a guest polls after the host is stale for five minutes', async () => {
+    const observedAt = Date.now();
+    const staleHost = player({ lastSeenAt: new Date(observedAt - 300_001) });
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+      lastSeenAt: new Date(observedAt),
+    });
+    const abandonedRoom = room({ status: 'abandoned', version: 2 });
+    queueSelect([room()], [guest], [staleHost, guest], [staleHost, guest]);
+    dbMocks.updateResults.push([], [abandonedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/rooms/ABCD2')
+      .set('X-Player-Token', 'guest-secret')
+      .expect(200);
+
+    expect(response.body).toMatchObject({ status: 'abandoned', phase: 'LOBBY', version: 2 });
+  });
+
+  it('promotes the oldest connected player once when the host is stale mid-game', async () => {
+    const observedAt = Date.now();
+    const staleHost = player({ lastSeenAt: new Date(observedAt - 120_001) });
+    const oldestConnected = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+      lastSeenAt: new Date(observedAt),
+    });
+    const newerConnected = player({
+      id: '44444444-4444-4444-8444-444444444444',
+      nickname: 'Newer',
+      token: 'newer-secret',
+      joinOrder: 2,
+      isHost: false,
+      lastSeenAt: new Date(observedAt),
+    });
+    const activeRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      questionIds: ['question-1'],
+      activePlayerId: hostId,
+    });
+    const promotedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      hostPlayerId: guestId,
+      questionIds: ['question-1'],
+      activePlayerId: hostId,
+    });
+    const promotedPlayers = [
+      { ...staleHost, isHost: false },
+      { ...oldestConnected, isHost: true },
+      newerConnected,
+    ];
+    queueSelect(
+      [activeRoom],
+      [oldestConnected],
+      [staleHost, oldestConnected, newerConnected],
+      promotedPlayers,
+      [question()]
+    );
+    dbMocks.updateResults.push([], [promotedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/rooms/ABCD2')
+      .set('X-Player-Token', 'guest-secret')
+      .expect(200);
+
+    expect(response.body).toMatchObject({ hostPlayerId: guestId, version: 2 });
+    expect(response.body.players).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: hostId, isHost: false }),
+        expect.objectContaining({ id: guestId, isHost: true }),
+      ])
+    );
+    expect(
+      dbMocks.valueArgs.filter(
+        (value) => typeof value === 'object' && value !== null && 'hostPlayerId' in value
+      )
+    ).toHaveLength(1);
+  });
+
+  it('keeps abandoned and finished rooms readable', async () => {
+    const abandonedRoom = room({ status: 'abandoned' });
+    queueSelect([abandonedRoom], [player()], [player()]);
+    const app = await buildTestApp();
+
+    expect(
+      (await request(app).get('/api/rooms/ABCD2').set('X-Player-Token', 'host-secret').expect(200))
+        .body.status
+    ).toBe('abandoned');
+
+    const attempt = {
+      questionId: 'question-1',
+      playerId: hostId,
+      submittedAnswer: null,
+      verdict: 'PASS' as const,
+      pointsDelta: 0,
+    };
+    const finishedRoom = room({
+      status: 'finished',
+      phase: 'GAME_OVER',
+      questionIds: ['question-1'],
+      currentQuestionIndex: 1,
+      activePlayerId: hostId,
+      currentAttempt: attempt,
+    });
+    queueSelect([finishedRoom], [player()], [player()], [question()]);
+    expect(
+      (await request(app).get('/api/rooms/ABCD2').set('X-Player-Token', 'host-secret').expect(200))
+        .body
+    ).toMatchObject({ status: 'finished', phase: 'GAME_OVER' });
+  });
+
   it('returns unchanged while still refreshing presence', async () => {
-    queueSelect([room()], [player()]);
+    queueSelect([room()], [player()], [player()]);
     const app = await buildTestApp();
 
     const response = await request(app)
@@ -868,7 +1099,7 @@ describe('room lifecycle routes', () => {
       sourceUrl: 'https://example.com/ottawa',
       sourceName: 'Ottawa reference',
     };
-    queueSelect([questionRoom], [player()], [player()], [question]);
+    queueSelect([questionRoom], [player()], [player()], [player()], [question]);
     const app = await buildTestApp();
 
     const response = await request(app)
@@ -906,7 +1137,7 @@ describe('room lifecycle routes', () => {
       sourceUrl: 'https://example.com/ottawa',
       sourceName: 'Ottawa reference',
     };
-    queueSelect([revealRoom], [player()], [player()], [question]);
+    queueSelect([revealRoom], [player()], [player()], [player()], [question]);
     const app = await buildTestApp();
 
     const response = await request(app)

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -1029,8 +1029,26 @@ describe('room lifecycle routes', () => {
     ).toMatchObject({ status: 'finished', phase: 'GAME_OVER' });
   });
 
-  it('returns unchanged while still refreshing presence', async () => {
-    queueSelect([room()], [player()], [player()]);
+  it('returns a fresh live-room snapshot when only presence changed', async () => {
+    const refreshedHost = player({ lastSeenAt: new Date() });
+    queueSelect([room()], [player()], [player()], [refreshedHost]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/rooms/ABCD2?sinceVersion=1')
+      .set('X-Player-Token', 'host-secret')
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      status: 'lobby',
+      version: 1,
+      players: [{ id: hostId, presence: 'online' }],
+    });
+    expect(dbMocks.update).toHaveBeenCalledOnce();
+  });
+
+  it('returns unchanged for a terminal room at the current version', async () => {
+    queueSelect([room({ status: 'abandoned' })], [player()]);
     const app = await buildTestApp();
 
     const response = await request(app)

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -29,6 +29,8 @@ import {
   seenQuestions,
   startRoomRequestSchema,
   startRoomResponseSchema,
+  skipRoomRequestSchema,
+  skipRoomResponseSchema,
   unchangedRoomPollResponseSchema,
   type Question,
   type Room,
@@ -43,6 +45,11 @@ const LOBBY_TTL_MS = 2 * 60 * 60 * 1000;
 const ACTIVE_TTL_MS = 24 * 60 * 60 * 1000;
 const ROOM_CODE_CONSTRAINT = 'rooms_code_unique';
 const ROOM_NICKNAME_CONSTRAINT = 'uq_room_players_room_nickname_ci';
+const ONLINE_THRESHOLD_MS = 10 * 1000;
+const STALE_THRESHOLD_MS = 30 * 1000;
+const SKIP_THRESHOLD_MS = 60 * 1000;
+const HOST_PROMOTION_THRESHOLD_MS = 2 * 60 * 1000;
+const LOBBY_ABANDONMENT_THRESHOLD_MS = 5 * 60 * 1000;
 
 type RoomReadDatabase = Pick<typeof db, 'select'>;
 
@@ -107,7 +114,14 @@ function toAnswerQuestion(question: Question): AnswerQuestion {
   };
 }
 
-function serializePlayer(player: RoomPlayer) {
+export function deriveRoomPresence(lastSeenAt: Date, now = new Date()) {
+  const ageMs = now.getTime() - lastSeenAt.getTime();
+  if (ageMs < ONLINE_THRESHOLD_MS) return 'online' as const;
+  if (ageMs > STALE_THRESHOLD_MS) return 'stale' as const;
+  return 'away' as const;
+}
+
+function serializePlayer(player: RoomPlayer, now: Date) {
   return {
     id: player.id,
     nickname: player.nickname,
@@ -116,12 +130,17 @@ function serializePlayer(player: RoomPlayer) {
     questionCount: player.questionCount,
     lastRoundDelta: player.lastRoundDelta,
     isHost: player.isHost,
+    presence: deriveRoomPresence(player.lastSeenAt, now),
     lastSeenAt: player.lastSeenAt.toISOString(),
     leftAt: player.leftAt?.toISOString() ?? null,
   };
 }
 
-async function buildRoomSnapshot(database: RoomReadDatabase, room: Room): Promise<RoomSnapshot> {
+async function buildRoomSnapshot(
+  database: RoomReadDatabase,
+  room: Room,
+  now = new Date()
+): Promise<RoomSnapshot> {
   const players = await database
     .select()
     .from(roomPlayers)
@@ -183,7 +202,7 @@ async function buildRoomSnapshot(database: RoomReadDatabase, room: Room): Promis
     activePlayerId: room.activePlayerId,
     currentAttempt: room.currentAttempt,
     currentQuestion,
-    players: players.map(serializePlayer),
+    players: players.map((player) => serializePlayer(player, now)),
     createdAt: room.createdAt.toISOString(),
     updatedAt: room.updatedAt.toISOString(),
     expiresAt: room.expiresAt.toISOString(),
@@ -234,11 +253,9 @@ export function registerRoomRoutes(app: Express): void {
       const input = createRoomRequestSchema.parse(req.body);
       const now = new Date();
 
-      // Only lobby rooms use the short two-hour expiry. Active rooms are
-      // extended by the start transition and must not be removed by this cleanup.
-      await db
-        .delete(rooms)
-        .where(and(eq(rooms.status, 'lobby'), eq(rooms.phase, 'LOBBY'), lte(rooms.expiresAt, now)));
+      // Lobby rooms use a short expiry; active rooms receive a longer expiry
+      // when started. Creation opportunistically cleans up either kind.
+      await db.delete(rooms).where(lte(rooms.expiresAt, now));
 
       for (let attempt = 0; attempt < MAX_ROOM_CODE_ATTEMPTS; attempt++) {
         const code = generateRoomCode();
@@ -739,6 +756,111 @@ export function registerRoomRoutes(app: Express): void {
     }
   });
 
+  app.post('/api/rooms/:code/skip', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      skipRoomRequestSchema.parse(req.body);
+
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+        if (!room) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(room)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
+        if (room.phase !== 'QUESTION' || room.status !== 'active' || !room.activePlayerId) {
+          throw new RoomRouteError(409, 'Room is not ready to skip');
+        }
+
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        requireHost(actor, room);
+
+        const players = await tx
+          .select()
+          .from(roomPlayers)
+          .where(and(eq(roomPlayers.roomId, room.id), isNull(roomPlayers.leftAt)))
+          .orderBy(asc(roomPlayers.joinOrder));
+        const activePlayer = players.find((player) => player.id === room.activePlayerId);
+        if (!activePlayer) {
+          throw new RoomRouteError(409, 'Active player is no longer in the room');
+        }
+        if (Date.now() - activePlayer.lastSeenAt.getTime() <= SKIP_THRESHOLD_MS) {
+          throw new RoomRouteError(409, 'Active player is not stale enough to skip');
+        }
+
+        const questionId = room.questionIds[room.currentQuestionIndex];
+        if (!questionId) {
+          throw new Error(`Room question not found at index ${room.currentQuestionIndex}`);
+        }
+        const currentAttempt = {
+          questionId,
+          playerId: activePlayer.id,
+          submittedAnswer: null,
+          verdict: 'PASS' as const,
+          pointsDelta: 0,
+        };
+        const transition = advanceRoomEngine({
+          activePlayerId: activePlayer.id,
+          currentAttempt,
+          currentQuestionIndex: room.currentQuestionIndex,
+          players,
+          questionCount: room.questionIds.length,
+          forceNextPlayer: true,
+        });
+
+        const [skippedRoom] = await tx
+          .update(rooms)
+          .set({
+            status: transition.phase === 'GAME_OVER' ? 'finished' : 'active',
+            phase: transition.phase,
+            currentQuestionIndex: transition.currentQuestionIndex,
+            activePlayerId: transition.activePlayerId,
+            currentAttempt,
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(rooms.id, room.id),
+              eq(rooms.status, 'active'),
+              eq(rooms.phase, 'QUESTION'),
+              eq(rooms.activePlayerId, activePlayer.id),
+              eq(rooms.hostPlayerId, actor.id)
+            )
+          )
+          .returning();
+        if (!skippedRoom) {
+          throw new RoomRouteError(409, 'Room state changed before the turn could be skipped');
+        }
+
+        for (const player of transition.players) {
+          await tx
+            .update(roomPlayers)
+            .set({
+              score: player.score,
+              questionCount: player.questionCount,
+              lastRoundDelta: player.lastRoundDelta,
+            })
+            .where(and(eq(roomPlayers.id, player.id), eq(roomPlayers.roomId, room.id)));
+        }
+
+        return skippedRoom;
+      });
+
+      return res.json(
+        skipRoomResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error skipping room turn:');
+    }
+  });
+
   app.post('/api/rooms/:code/end', async (req, res) => {
     try {
       const code = parseRoomCode(req.params.code);
@@ -798,26 +920,119 @@ export function registerRoomRoutes(app: Express): void {
     try {
       const code = parseRoomCode(req.params.code);
       const { sinceVersion } = pollRoomRequestSchema.parse(req.query);
-      const [room] = await db.select().from(rooms).where(eq(rooms.code, code)).limit(1);
+      const now = new Date();
+      const room = await db.transaction(async (tx) => {
+        const [currentRoom] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
 
-      if (!room) {
-        throw new RoomRouteError(404, 'Room not found');
-      }
-      if (isExpired(room)) {
-        throw new RoomRouteError(404, 'Room expired');
-      }
+        if (!currentRoom) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(currentRoom, now)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
 
-      const player = await authenticateRoomPlayer(req, room.id);
-      await db
-        .update(roomPlayers)
-        .set({ lastSeenAt: new Date() })
-        .where(eq(roomPlayers.id, player.id));
+        const player = await authenticateRoomPlayer(req, currentRoom.id, tx);
+        await tx.update(roomPlayers).set({ lastSeenAt: now }).where(eq(roomPlayers.id, player.id));
+
+        if (currentRoom.status !== 'lobby' && currentRoom.status !== 'active') {
+          return currentRoom;
+        }
+
+        const players = await tx
+          .select()
+          .from(roomPlayers)
+          .where(and(eq(roomPlayers.roomId, currentRoom.id), isNull(roomPlayers.leftAt)))
+          .orderBy(asc(roomPlayers.joinOrder));
+        const effectivePlayers = players.map((roomPlayer) =>
+          roomPlayer.id === player.id ? { ...roomPlayer, lastSeenAt: now } : roomPlayer
+        );
+        const host = effectivePlayers.find(
+          (roomPlayer) => roomPlayer.id === currentRoom.hostPlayerId
+        );
+        if (!host) {
+          return currentRoom;
+        }
+
+        const hostAgeMs = now.getTime() - host.lastSeenAt.getTime();
+        if (
+          currentRoom.status === 'lobby' &&
+          currentRoom.phase === 'LOBBY' &&
+          hostAgeMs > LOBBY_ABANDONMENT_THRESHOLD_MS
+        ) {
+          const [abandonedRoom] = await tx
+            .update(rooms)
+            .set({
+              status: 'abandoned',
+              version: sql`${rooms.version} + 1`,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(rooms.id, currentRoom.id),
+                eq(rooms.status, 'lobby'),
+                eq(rooms.phase, 'LOBBY'),
+                eq(rooms.hostPlayerId, host.id)
+              )
+            )
+            .returning();
+          return abandonedRoom ?? currentRoom;
+        }
+
+        if (currentRoom.status === 'active' && hostAgeMs > HOST_PROMOTION_THRESHOLD_MS) {
+          const promotedHost = effectivePlayers.find(
+            (candidate) =>
+              candidate.id !== host.id &&
+              now.getTime() - candidate.lastSeenAt.getTime() <= STALE_THRESHOLD_MS
+          );
+          if (!promotedHost) {
+            return currentRoom;
+          }
+
+          const [promotedRoom] = await tx
+            .update(rooms)
+            .set({
+              hostPlayerId: promotedHost.id,
+              version: sql`${rooms.version} + 1`,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(rooms.id, currentRoom.id),
+                eq(rooms.status, 'active'),
+                eq(rooms.hostPlayerId, host.id)
+              )
+            )
+            .returning();
+          if (!promotedRoom) {
+            return currentRoom;
+          }
+
+          await tx
+            .update(roomPlayers)
+            .set({ isHost: false })
+            .where(and(eq(roomPlayers.id, host.id), eq(roomPlayers.roomId, currentRoom.id)));
+          await tx
+            .update(roomPlayers)
+            .set({ isHost: true })
+            .where(
+              and(eq(roomPlayers.id, promotedHost.id), eq(roomPlayers.roomId, currentRoom.id))
+            );
+          return promotedRoom;
+        }
+
+        return currentRoom;
+      });
 
       if (sinceVersion === room.version) {
         return res.json(unchangedRoomPollResponseSchema.parse({ changed: false }));
       }
 
-      return res.json(await buildRoomSnapshot(db, room));
+      return res.json(await buildRoomSnapshot(db, room, now));
     } catch (error) {
       return sendRoomError(res, error, 'Error polling room:');
     }

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -1028,7 +1028,13 @@ export function registerRoomRoutes(app: Express): void {
         return currentRoom;
       });
 
-      if (sinceVersion === room.version) {
+      // Presence is derived from lastSeenAt rather than the gameplay version.
+      // Live rooms therefore need a fresh snapshot even when no gameplay state
+      // changed, otherwise clients keep stale roster presence indefinitely.
+      if (
+        sinceVersion === room.version &&
+        (room.status === 'finished' || room.status === 'abandoned')
+      ) {
         return res.json(unchangedRoomPollResponseSchema.parse({ changed: false }));
       }
 

--- a/shared/models/rooms.ts
+++ b/shared/models/rooms.ts
@@ -20,6 +20,7 @@ import { VALID_CATEGORIES } from '../constants/categories';
 export const ROOM_STATUSES = ['lobby', 'active', 'finished', 'abandoned'] as const;
 export const ROOM_PHASES = ['LOBBY', 'QUESTION', 'REVEAL', 'ROUND_SCORE', 'GAME_OVER'] as const;
 export const ROOM_VERDICTS = ['CORRECT', 'INCORRECT', 'PASS'] as const;
+export const ROOM_PRESENCES = ['online', 'away', 'stale'] as const;
 export const ROOM_ROUND_OPTIONS = [5, 10, 15, 20] as const;
 export const ROOM_CODE_PATTERN = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{5}$/;
 export const MAX_PLAYERS = 4;
@@ -92,6 +93,7 @@ export const roomPlayers = pgTable(
 export const roomStatusSchema = z.enum(ROOM_STATUSES);
 export const roomPhaseSchema = z.enum(ROOM_PHASES);
 export const roomVerdictSchema = z.enum(ROOM_VERDICTS);
+export const roomPresenceSchema = z.enum(ROOM_PRESENCES);
 export const roomCodeSchema = z.string().regex(ROOM_CODE_PATTERN);
 export const roomNicknameSchema = z.string().trim().min(1).max(20);
 export const roomCategorySchema = z.enum(['All', ...VALID_CATEGORIES]);
@@ -105,6 +107,7 @@ export const roomRoundsSchema = z.union([
 export type RoomStatus = z.infer<typeof roomStatusSchema>;
 export type RoomPhase = z.infer<typeof roomPhaseSchema>;
 export type RoomVerdict = z.infer<typeof roomVerdictSchema>;
+export type RoomPresence = z.infer<typeof roomPresenceSchema>;
 export type RoomCategory = z.infer<typeof roomCategorySchema>;
 export type RoomRounds = z.infer<typeof roomRoundsSchema>;
 
@@ -143,6 +146,7 @@ export const roomPlayerSnapshotSchema = z.object({
   questionCount: z.number().int().nonnegative(),
   lastRoundDelta: z.number().int(),
   isHost: z.boolean(),
+  presence: roomPresenceSchema,
   lastSeenAt: z.string().datetime(),
   leftAt: z.string().datetime().nullable(),
 });

--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -94,6 +94,7 @@ const validSnapshot = {
       questionCount: 0,
       lastRoundDelta: 0,
       isHost: true,
+      presence: 'online' as const,
       lastSeenAt: timestamp,
       leftAt: null,
     },
@@ -215,6 +216,18 @@ describe('RoomSnapshot contract', () => {
     expect(snapshot.currentQuestion).not.toHaveProperty('acceptableAnswers');
     expect(snapshot.currentQuestion).not.toHaveProperty('explanation');
   });
+
+  it.each(['online', 'away', 'stale'] as const)(
+    'accepts %s as a derived player presence state',
+    (presence) => {
+      expect(
+        roomSnapshotSchema.safeParse({
+          ...validSnapshot,
+          players: [{ ...validSnapshot.players[0], presence }],
+        }).success
+      ).toBe(true);
+    }
+  );
 
   it('accepts revealed answer fields for a REVEAL snapshot', () => {
     expect(


### PR DESCRIPTION
## Summary

- add derived `online` / `away` / `stale` presence to room snapshots and render stale roster entries distinctly
- add host-only `POST /api/rooms/:code/skip` with QUESTION-phase and >60-second active-player staleness guards; record a zero-point pass and rotate immediately
- lazily abandon lobbies after a >5-minute stale host and promote the oldest connected player after a >2-minute stale in-game host
- keep abandoned/finished snapshots readable and clean all expired room rows opportunistically on room creation
- add integration and contract coverage for thresholds, skip guards, promotion, abandonment, terminal snapshots, and expired cleanup

## Why

STE-210 provides the server-side recovery paths needed when a multiplayer host or active player disconnects, and unblocks STE-213's disconnect/rejoin UI.

## Validation

- `npm test` — 34 files, 357 tests passed
- `npm run check`
- targeted ESLint on all changed TypeScript files

Linear: https://linear.app/stephs-vibe-coding/issue/STE-210/featapi-presence-abandoned-rooms-host-promotion-skip-turn-lane-a-m