### PR TITLE
feat(client): add multiplayer gameplay screens [STE-211]

### DIFF
--- a/client/src/components/room/FinalResults.test.tsx
+++ b/client/src/components/room/FinalResults.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { FinalResults } from './FinalResults';
+import type { RoomSnapshot } from '@shared/models/rooms';
+
+const mockSetLocation = vi.fn();
+vi.mock('wouter', () => ({
+  useLocation: () => ['/room/ABCDE', mockSetLocation],
+}));
+
+const mockClearRoomSession = vi.fn();
+vi.mock('@/lib/room-session', () => ({
+  clearRoomSession: (...args: unknown[]) => mockClearRoomSession(...args),
+}));
+
+type GameOverSnapshot = Extract<RoomSnapshot, { phase: 'GAME_OVER' }>;
+
+function makePlayer(overrides: Partial<GameOverSnapshot['players'][number]> = {}) {
+  return {
+    id: 'p1',
+    nickname: 'Alice',
+    joinOrder: 0,
+    score: 20,
+    questionCount: 8,
+    lastRoundDelta: 0,
+    isHost: true,
+    presence: 'online' as const,
+    lastSeenAt: new Date().toISOString(),
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<GameOverSnapshot> = {}): GameOverSnapshot {
+  return {
+    id: 'room-1',
+    code: 'ABCDE',
+    status: 'finished',
+    phase: 'GAME_OVER',
+    version: 9,
+    hostPlayerId: 'p1',
+    category: 'All',
+    numRounds: 10,
+    currentQuestionIndex: 40,
+    activePlayerId: 'p1',
+    currentAttempt: null,
+    currentQuestion: {
+      id: 'q1',
+      category: 'Science',
+      difficulty: 'Medium',
+      question: 'What planet is closest to the sun?',
+      pillar: 'Astronomy',
+      tags: [],
+      sourceUrl: null,
+      sourceName: null,
+      answer: 'Mercury',
+      acceptableAnswers: ['Mercury'],
+      explanation: 'Mercury orbits closest to the sun.',
+    },
+    players: [
+      makePlayer({ id: 'p1', nickname: 'Alice', score: 20 }),
+      makePlayer({ id: 'p2', nickname: 'Bob', isHost: false, score: 12 }),
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date().toISOString(),
+    ...overrides,
+  } as GameOverSnapshot;
+}
+
+describe('FinalResults', () => {
+  beforeEach(() => {
+    mockSetLocation.mockClear();
+    mockClearRoomSession.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the winner and final ranking', () => {
+    const snapshot = makeSnapshot();
+    render(<FinalResults snapshot={snapshot} currentPlayerId="p1" />);
+
+    expect(screen.getByTestId('text-winner')).toHaveTextContent('Alice');
+    const rows = screen.getAllByTestId(/final-result-row-/);
+    expect(rows[0]).toHaveTextContent('Alice');
+    expect(rows[1]).toHaveTextContent('Bob');
+  });
+
+  it('clears the room session and navigates home on Back to Home', () => {
+    const snapshot = makeSnapshot();
+    render(<FinalResults snapshot={snapshot} currentPlayerId="p1" />);
+
+    fireEvent.click(screen.getByTestId('button-back-home'));
+
+    expect(mockClearRoomSession).toHaveBeenCalledWith('ABCDE');
+    expect(mockSetLocation).toHaveBeenCalledWith('/');
+  });
+});

--- a/client/src/components/room/FinalResults.tsx
+++ b/client/src/components/room/FinalResults.tsx
@@ -1,0 +1,70 @@
+import { useLocation } from 'wouter';
+import type { RoomSnapshot } from '@shared/models/rooms';
+
+import { clearRoomSession } from '@/lib/room-session';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+type GameOverSnapshot = Extract<RoomSnapshot, { phase: 'GAME_OVER' }>;
+
+export interface FinalResultsProps {
+  snapshot: GameOverSnapshot;
+  currentPlayerId: string;
+}
+
+export function FinalResults({ snapshot, currentPlayerId }: FinalResultsProps) {
+  const [, setLocation] = useLocation();
+  const ranked = [...snapshot.players].sort((a, b) => b.score - a.score);
+  const winner = ranked[0];
+
+  function handleBackToHome() {
+    clearRoomSession(snapshot.code);
+    setLocation('/');
+  }
+
+  return (
+    <div className="w-full max-w-lg space-y-6 text-center">
+      <div className="space-y-2">
+        <Badge variant="outline" className="border-primary/40 text-primary">
+          Game Over
+        </Badge>
+        <h1 className="text-4xl font-bold">Final Results</h1>
+        {winner && (
+          <p className="text-muted-foreground" data-testid="text-winner">
+            Winner: <span className="text-primary font-semibold">{winner.nickname}</span>
+          </p>
+        )}
+      </div>
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+        <CardContent className="p-6 space-y-3">
+          {ranked.map((player, index) => (
+            <div
+              key={player.id}
+              className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-4 py-3"
+              data-testid={`final-result-row-${player.id}`}
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-muted-foreground">#{index + 1}</span>
+                <span className="font-semibold">
+                  {player.nickname}
+                  {player.id === currentPlayerId && (
+                    <span className="text-muted-foreground font-normal"> (you)</span>
+                  )}
+                </span>
+              </div>
+              <span className="font-mono text-lg">{player.score}</span>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+      <Button
+        onClick={handleBackToHome}
+        className="w-full h-14 text-lg font-bold"
+        data-testid="button-back-home"
+      >
+        Back to Home
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/room/QuestionView.test.tsx
+++ b/client/src/components/room/QuestionView.test.tsx
@@ -1,0 +1,230 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+import { QuestionView } from './QuestionView';
+import type { AnswerRoomRequest, AnswerRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+type QuestionSnapshot = Extract<RoomSnapshot, { phase: 'QUESTION' }>;
+
+function makePlayer(overrides: Partial<QuestionSnapshot['players'][number]> = {}) {
+  return {
+    id: 'p1',
+    nickname: 'Alice',
+    joinOrder: 0,
+    score: 0,
+    questionCount: 0,
+    lastRoundDelta: 0,
+    isHost: true,
+    presence: 'online' as const,
+    lastSeenAt: new Date().toISOString(),
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<QuestionSnapshot> = {}): QuestionSnapshot {
+  return {
+    id: 'room-1',
+    code: 'ABCDE',
+    status: 'active',
+    phase: 'QUESTION',
+    version: 3,
+    hostPlayerId: 'p1',
+    category: 'All',
+    numRounds: 10,
+    currentQuestionIndex: 0,
+    activePlayerId: 'p1',
+    currentAttempt: null,
+    currentQuestion: {
+      id: 'q1',
+      category: 'Science',
+      difficulty: 'Medium',
+      question: 'What planet is closest to the sun?',
+      pillar: 'Astronomy',
+      tags: [],
+      sourceUrl: null,
+      sourceName: null,
+    },
+    players: [makePlayer({ id: 'p1', nickname: 'Alice' }), makePlayer({ id: 'p2', nickname: 'Bob', isHost: false })],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date().toISOString(),
+    ...overrides,
+  } as QuestionSnapshot;
+}
+
+function makeMutation(
+  overrides: Partial<{ isPending: boolean; mutate: ReturnType<typeof vi.fn> }> = {}
+): UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest> {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+    ...overrides,
+  } as unknown as UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest>;
+}
+
+describe('QuestionView', () => {
+  beforeEach(() => {
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the answer input and buttons for the active player', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        answer={makeMutation()}
+        refetch={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('badge-your-turn')).toBeInTheDocument();
+    expect(screen.getByTestId('input-answer')).toBeInTheDocument();
+    expect(screen.getByTestId('button-submit-answer')).toBeInTheDocument();
+    expect(screen.getByTestId('button-pass')).toBeInTheDocument();
+  });
+
+  it('renders no input or buttons for a spectator', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p2"
+        answer={makeMutation()}
+        refetch={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('input-answer')).toBeNull();
+    expect(screen.queryByTestId('button-submit-answer')).toBeNull();
+    expect(screen.queryByTestId('button-pass')).toBeNull();
+    expect(screen.getByTestId('text-waiting-turn')).toHaveTextContent('Alice');
+  });
+
+  it('disables Submit until an answer is typed', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        answer={makeMutation()}
+        refetch={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('button-submit-answer')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('input-answer'), { target: { value: 'Mercury' } });
+    expect(screen.getByTestId('button-submit-answer')).not.toBeDisabled();
+  });
+
+  it('disables Submit and Pass while a mutation is in flight', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        answer={makeMutation({ isPending: true })}
+        refetch={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('button-submit-answer')).toBeDisabled();
+    expect(screen.getByTestId('button-pass')).toBeDisabled();
+  });
+
+  it('submits the typed answer', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    const mutate = vi.fn();
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        answer={makeMutation({ mutate })}
+        refetch={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('input-answer'), { target: { value: 'Mercury' } });
+    fireEvent.click(screen.getByTestId('button-submit-answer'));
+
+    expect(mutate).toHaveBeenCalledWith({ answer: 'Mercury' }, expect.any(Object));
+  });
+
+  it('passes with a null answer', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    const mutate = vi.fn();
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        answer={makeMutation({ mutate })}
+        refetch={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-pass'));
+
+    expect(mutate).toHaveBeenCalledWith({ answer: null }, expect.any(Object));
+  });
+
+  it('reconciles silently on a 409 conflict instead of showing a toast', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    const refetch = vi.fn();
+    const mutate = vi.fn((_body, options) => {
+      const error = new Error('Room is not accepting answers') as Error & { status: number };
+      error.status = 409;
+      options.onError(error);
+    });
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        answer={makeMutation({ mutate })}
+        refetch={refetch}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-pass'));
+
+    expect(refetch).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast for non-conflict errors', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    const refetch = vi.fn();
+    const mutate = vi.fn((_body, options) => {
+      options.onError(new Error('Server exploded'));
+    });
+    render(
+      <QuestionView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        answer={makeMutation({ mutate })}
+        refetch={refetch}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-pass'));
+
+    expect(refetch).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith('Server exploded');
+  });
+});

--- a/client/src/components/room/QuestionView.tsx
+++ b/client/src/components/room/QuestionView.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { AnswerRoomRequest, AnswerRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+
+import { isRoomConflict } from '@/hooks/use-room';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { cn, getDifficultyBadgeClass } from '@/lib/utils';
+
+type QuestionSnapshot = Extract<RoomSnapshot, { phase: 'QUESTION' }>;
+
+export interface QuestionViewProps {
+  snapshot: QuestionSnapshot;
+  currentPlayerId: string;
+  answer: UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest>;
+  refetch: () => void;
+}
+
+export function QuestionView({ snapshot, currentPlayerId, answer, refetch }: QuestionViewProps) {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isMyTurn = snapshot.activePlayerId === currentPlayerId;
+  const activePlayer = snapshot.players.find((player) => player.id === snapshot.activePlayerId);
+
+  useEffect(() => {
+    setValue('');
+  }, [snapshot.currentQuestion.id]);
+
+  function handleActionError(error: Error) {
+    if (isRoomConflict(error)) {
+      refetch();
+      return;
+    }
+    toast.error(error.message || 'Something went wrong. Please try again.');
+  }
+
+  function handleSubmit() {
+    const trimmed = value.trim();
+    if (!trimmed || answer.isPending) return;
+    answer.mutate({ answer: trimmed }, { onError: handleActionError });
+  }
+
+  function handlePass() {
+    if (answer.isPending) return;
+    answer.mutate({ answer: null }, { onError: handleActionError });
+  }
+
+  return (
+    <div className="w-full max-w-lg space-y-4">
+      {isMyTurn ? (
+        <Badge
+          variant="outline"
+          className="border-primary/40 text-primary flex items-center justify-center gap-2 w-full py-2"
+          data-testid="badge-your-turn"
+        >
+          Your turn
+        </Badge>
+      ) : (
+        <p
+          className="text-center text-muted-foreground animate-pulse"
+          data-testid="text-waiting-turn"
+        >
+          Waiting for {activePlayer?.nickname ?? 'player'} to answer…
+        </p>
+      )}
+
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+        <CardContent className="p-6 md:p-8 space-y-4">
+          <div className="flex flex-wrap gap-2 justify-center">
+            <Badge variant="outline" className="border-white/20 bg-white/5">
+              {snapshot.currentQuestion.category}
+            </Badge>
+            <Badge
+              className={cn('border-none', getDifficultyBadgeClass(snapshot.currentQuestion.difficulty))}
+            >
+              {snapshot.currentQuestion.difficulty}
+            </Badge>
+          </div>
+          <h1 className="text-2xl md:text-3xl font-bold leading-tight text-center font-display">
+            {snapshot.currentQuestion.question}
+          </h1>
+        </CardContent>
+      </Card>
+
+      {isMyTurn && (
+        <div className="space-y-3">
+          <Input
+            ref={inputRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onFocus={() => inputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSubmit();
+            }}
+            placeholder="Type your answer…"
+            className="h-14 text-lg text-center bg-white/5 border-white/10 focus:border-primary/50"
+            autoFocus
+            disabled={answer.isPending}
+            data-testid="input-answer"
+          />
+          <div className="grid grid-cols-3 gap-3">
+            <Button
+              variant="secondary"
+              onClick={handlePass}
+              disabled={answer.isPending}
+              className="h-12"
+              data-testid="button-pass"
+            >
+              Pass
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={!value.trim() || answer.isPending}
+              className="col-span-2 h-12 font-bold"
+              data-testid="button-submit-answer"
+            >
+              {answer.isPending ? 'Submitting…' : 'Submit'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/room/RevealView.test.tsx
+++ b/client/src/components/room/RevealView.test.tsx
@@ -1,0 +1,184 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+import { RevealView } from './RevealView';
+import type { AdvanceRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+type RevealSnapshot = Extract<RoomSnapshot, { phase: 'REVEAL' }>;
+
+function makePlayer(overrides: Partial<RevealSnapshot['players'][number]> = {}) {
+  return {
+    id: 'p1',
+    nickname: 'Alice',
+    joinOrder: 0,
+    score: 10,
+    questionCount: 1,
+    lastRoundDelta: 5,
+    isHost: true,
+    presence: 'online' as const,
+    lastSeenAt: new Date().toISOString(),
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<RevealSnapshot> = {}): RevealSnapshot {
+  return {
+    id: 'room-1',
+    code: 'ABCDE',
+    status: 'active',
+    phase: 'REVEAL',
+    version: 4,
+    hostPlayerId: 'p1',
+    category: 'All',
+    numRounds: 10,
+    currentQuestionIndex: 0,
+    activePlayerId: 'p1',
+    currentAttempt: {
+      questionId: 'q1',
+      playerId: 'p1',
+      submittedAnswer: 'Mercury',
+      verdict: 'CORRECT',
+      pointsDelta: 5,
+    },
+    currentQuestion: {
+      id: 'q1',
+      category: 'Science',
+      difficulty: 'Medium',
+      question: 'What planet is closest to the sun?',
+      pillar: 'Astronomy',
+      tags: [],
+      sourceUrl: 'https://example.com',
+      sourceName: 'Example Source',
+      answer: 'Mercury',
+      acceptableAnswers: ['Mercury'],
+      explanation: 'Mercury orbits closest to the sun.',
+    },
+    players: [makePlayer({ id: 'p1', nickname: 'Alice' }), makePlayer({ id: 'p2', nickname: 'Bob', isHost: false })],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date().toISOString(),
+    ...overrides,
+  } as RevealSnapshot;
+}
+
+function makeMutation(
+  overrides: Partial<{ isPending: boolean; mutate: ReturnType<typeof vi.fn> }> = {}
+): UseMutationResult<AdvanceRoomResponse, Error, void> {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+    ...overrides,
+  } as unknown as UseMutationResult<AdvanceRoomResponse, Error, void>;
+}
+
+describe('RevealView', () => {
+  beforeEach(() => {
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the submitted answer, verdict, points, and correct answer', () => {
+    const snapshot = makeSnapshot();
+    render(
+      <RevealView snapshot={snapshot} currentPlayerId="p1" advance={makeMutation()} refetch={vi.fn()} />
+    );
+
+    expect(screen.getByText('Mercury', { selector: '.text-primary' })).toBeInTheDocument();
+    expect(screen.getByTestId('text-verdict')).toHaveTextContent('CORRECT (+5)');
+    expect(screen.getByText('Mercury orbits closest to the sun.')).toBeInTheDocument();
+  });
+
+  it('shows the Next button for the active player', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1', hostPlayerId: 'p2' });
+    render(
+      <RevealView snapshot={snapshot} currentPlayerId="p1" advance={makeMutation()} refetch={vi.fn()} />
+    );
+
+    expect(screen.getByTestId('button-next')).toBeInTheDocument();
+    expect(screen.queryByTestId('text-waiting-continue')).toBeNull();
+  });
+
+  it('shows the Next button for the host even when not active', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1', hostPlayerId: 'p2' });
+    render(
+      <RevealView snapshot={snapshot} currentPlayerId="p2" advance={makeMutation()} refetch={vi.fn()} />
+    );
+
+    expect(screen.getByTestId('button-next')).toBeInTheDocument();
+  });
+
+  it('hides the Next button for a spectator who is neither active nor host', () => {
+    const snapshot = makeSnapshot({
+      activePlayerId: 'p1',
+      hostPlayerId: 'p1',
+      players: [
+        makePlayer({ id: 'p1', nickname: 'Alice' }),
+        makePlayer({ id: 'p2', nickname: 'Bob', isHost: false }),
+        makePlayer({ id: 'p3', nickname: 'Cara', isHost: false }),
+      ],
+    });
+    render(
+      <RevealView snapshot={snapshot} currentPlayerId="p3" advance={makeMutation()} refetch={vi.fn()} />
+    );
+
+    expect(screen.queryByTestId('button-next')).toBeNull();
+    expect(screen.getByTestId('text-waiting-continue')).toBeInTheDocument();
+  });
+
+  it('calls advance when Next is clicked', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    const mutate = vi.fn();
+    render(
+      <RevealView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        advance={makeMutation({ mutate })}
+        refetch={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-next'));
+    expect(mutate).toHaveBeenCalledWith(undefined, expect.any(Object));
+  });
+
+  it('reconciles silently on a 409 conflict instead of showing a toast', () => {
+    const snapshot = makeSnapshot({ activePlayerId: 'p1' });
+    const refetch = vi.fn();
+    const mutate = vi.fn((_body, options) => {
+      const error = new Error('Room state changed before it could advance') as Error & {
+        status: number;
+      };
+      error.status = 409;
+      options.onError(error);
+    });
+    render(
+      <RevealView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        advance={makeMutation({ mutate })}
+        refetch={refetch}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-next'));
+
+    expect(refetch).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/room/RevealView.tsx
+++ b/client/src/components/room/RevealView.tsx
@@ -1,0 +1,131 @@
+import { toast } from 'sonner';
+import { ArrowRight, ExternalLink } from 'lucide-react';
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { AdvanceRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+
+import { isRoomConflict } from '@/hooks/use-room';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn, getDifficultyBadgeClass } from '@/lib/utils';
+
+type RevealSnapshot = Extract<RoomSnapshot, { phase: 'REVEAL' }>;
+
+export interface RevealViewProps {
+  snapshot: RevealSnapshot;
+  currentPlayerId: string;
+  advance: UseMutationResult<AdvanceRoomResponse, Error, void>;
+  refetch: () => void;
+}
+
+export function RevealView({ snapshot, currentPlayerId, advance, refetch }: RevealViewProps) {
+  const attempt = snapshot.currentAttempt;
+  const isActive = snapshot.activePlayerId === currentPlayerId;
+  const isHost = snapshot.hostPlayerId === currentPlayerId;
+  const canAdvance = isActive || isHost;
+  const answeringPlayer = attempt
+    ? snapshot.players.find((player) => player.id === attempt.playerId)
+    : undefined;
+
+  function handleNext() {
+    if (advance.isPending) return;
+    advance.mutate(undefined, {
+      onError: (error) => {
+        if (isRoomConflict(error)) {
+          refetch();
+          return;
+        }
+        toast.error(error.message || 'Something went wrong. Please try again.');
+      },
+    });
+  }
+
+  return (
+    <div className="w-full max-w-lg space-y-4">
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+        <CardContent className="p-6 space-y-2 text-center">
+          <div className="flex flex-wrap gap-2 justify-center">
+            <Badge variant="outline" className="border-white/20 bg-white/5">
+              {snapshot.currentQuestion.category}
+            </Badge>
+            <Badge
+              className={cn('border-none', getDifficultyBadgeClass(snapshot.currentQuestion.difficulty))}
+            >
+              {snapshot.currentQuestion.difficulty}
+            </Badge>
+          </div>
+          <h1 className="text-xl md:text-2xl font-bold leading-tight font-display">
+            {snapshot.currentQuestion.question}
+          </h1>
+        </CardContent>
+      </Card>
+
+      {attempt && (
+        <div className="grid md:grid-cols-2 gap-4">
+          <Card
+            className={cn(
+              'border-2',
+              attempt.verdict === 'CORRECT'
+                ? 'border-green-500/50 bg-green-500/10'
+                : attempt.verdict === 'PASS'
+                  ? 'border-yellow-500/50 bg-yellow-500/10'
+                  : 'border-red-500/50 bg-red-500/10'
+            )}
+            data-testid="card-attempt-verdict"
+          >
+            <CardContent className="p-4 text-center">
+              <div className="text-sm uppercase tracking-widest opacity-70 mb-1">
+                {answeringPlayer?.nickname ?? 'Player'} answered
+              </div>
+              <div className="text-xl font-bold">{attempt.submittedAnswer || '(Passed)'}</div>
+              <div className="mt-2 font-mono font-bold text-lg" data-testid="text-verdict">
+                {attempt.verdict} ({attempt.pointsDelta > 0 ? '+' : ''}
+                {attempt.pointsDelta})
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-primary/10 border-primary/20">
+            <CardContent className="p-4 text-center">
+              <div className="text-sm uppercase tracking-widest opacity-70 mb-1">Correct Answer</div>
+              <div className="text-xl font-bold text-primary">{snapshot.currentQuestion.answer}</div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <div className="bg-white/5 p-4 rounded-lg text-center text-muted-foreground italic">
+        {snapshot.currentQuestion.explanation}
+      </div>
+
+      {snapshot.currentQuestion.sourceUrl && (
+        <div className="flex justify-center">
+          <a
+            href={snapshot.currentQuestion.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 border border-white/10 text-sm text-muted-foreground hover:bg-white/10 hover:text-foreground transition-colors"
+          >
+            <ExternalLink className="w-4 h-4" />
+            {snapshot.currentQuestion.sourceName || 'Verify Source'}
+          </a>
+        </div>
+      )}
+
+      {canAdvance ? (
+        <Button
+          onClick={handleNext}
+          disabled={advance.isPending}
+          className="w-full h-14 text-lg font-bold"
+          data-testid="button-next"
+        >
+          {advance.isPending ? 'Continuing…' : 'Next'} <ArrowRight className="ml-2 w-5 h-5" />
+        </Button>
+      ) : (
+        <p className="text-center text-muted-foreground" data-testid="text-waiting-continue">
+          Waiting to continue…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/room/RoundScore.test.tsx
+++ b/client/src/components/room/RoundScore.test.tsx
@@ -1,0 +1,181 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+import { RoundScore } from './RoundScore';
+import type { ContinueRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+type RoundScoreSnapshot = Extract<RoomSnapshot, { phase: 'ROUND_SCORE' }>;
+
+function makePlayer(overrides: Partial<RoundScoreSnapshot['players'][number]> = {}) {
+  return {
+    id: 'p1',
+    nickname: 'Alice',
+    joinOrder: 0,
+    score: 10,
+    questionCount: 4,
+    lastRoundDelta: 5,
+    isHost: true,
+    presence: 'online' as const,
+    lastSeenAt: new Date().toISOString(),
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<RoundScoreSnapshot> = {}): RoundScoreSnapshot {
+  return {
+    id: 'room-1',
+    code: 'ABCDE',
+    status: 'active',
+    phase: 'ROUND_SCORE',
+    version: 5,
+    hostPlayerId: 'p1',
+    category: 'All',
+    numRounds: 10,
+    currentQuestionIndex: 8,
+    activePlayerId: 'p1',
+    currentAttempt: null,
+    currentQuestion: {
+      id: 'q1',
+      category: 'Science',
+      difficulty: 'Medium',
+      question: 'What planet is closest to the sun?',
+      pillar: 'Astronomy',
+      tags: [],
+      sourceUrl: null,
+      sourceName: null,
+      answer: 'Mercury',
+      acceptableAnswers: ['Mercury'],
+      explanation: 'Mercury orbits closest to the sun.',
+    },
+    players: [
+      makePlayer({ id: 'p1', nickname: 'Alice', score: 10, lastRoundDelta: 5 }),
+      makePlayer({ id: 'p2', nickname: 'Bob', isHost: false, score: 15, lastRoundDelta: -2 }),
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date().toISOString(),
+    ...overrides,
+  } as RoundScoreSnapshot;
+}
+
+function makeMutation(
+  overrides: Partial<{ isPending: boolean; mutate: ReturnType<typeof vi.fn> }> = {}
+): UseMutationResult<ContinueRoomResponse, Error, void> {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+    ...overrides,
+  } as unknown as UseMutationResult<ContinueRoomResponse, Error, void>;
+}
+
+describe('RoundScore', () => {
+  beforeEach(() => {
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('ranks players by score with deltas shown', () => {
+    const snapshot = makeSnapshot();
+    render(
+      <RoundScore
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        continueRound={makeMutation()}
+        refetch={vi.fn()}
+      />
+    );
+
+    const rows = screen.getAllByTestId(/round-score-row-/);
+    expect(rows[0]).toHaveTextContent('Bob');
+    expect(rows[1]).toHaveTextContent('Alice');
+    expect(screen.getByTestId('round-score-delta-p1')).toHaveTextContent('(+5)');
+    expect(screen.getByTestId('round-score-delta-p2')).toHaveTextContent('(-2)');
+  });
+
+  it('shows Next Round for the host', () => {
+    const snapshot = makeSnapshot({ hostPlayerId: 'p1' });
+    render(
+      <RoundScore
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        continueRound={makeMutation()}
+        refetch={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('button-next-round')).toBeInTheDocument();
+    expect(screen.queryByTestId('text-waiting-host-round')).toBeNull();
+  });
+
+  it('hides Next Round for a non-host player', () => {
+    const snapshot = makeSnapshot({ hostPlayerId: 'p1' });
+    render(
+      <RoundScore
+        snapshot={snapshot}
+        currentPlayerId="p2"
+        continueRound={makeMutation()}
+        refetch={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('button-next-round')).toBeNull();
+    expect(screen.getByTestId('text-waiting-host-round')).toBeInTheDocument();
+  });
+
+  it('calls continueRound when Next Round is clicked', () => {
+    const snapshot = makeSnapshot({ hostPlayerId: 'p1' });
+    const mutate = vi.fn();
+    render(
+      <RoundScore
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        continueRound={makeMutation({ mutate })}
+        refetch={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-next-round'));
+    expect(mutate).toHaveBeenCalledWith(undefined, expect.any(Object));
+  });
+
+  it('reconciles silently on a 409 conflict instead of showing a toast', () => {
+    const snapshot = makeSnapshot({ hostPlayerId: 'p1' });
+    const refetch = vi.fn();
+    const mutate = vi.fn((_body, options) => {
+      const error = new Error('Room is not ready for the next round') as Error & {
+        status: number;
+      };
+      error.status = 409;
+      options.onError(error);
+    });
+    render(
+      <RoundScore
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        continueRound={makeMutation({ mutate })}
+        refetch={refetch}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-next-round'));
+
+    expect(refetch).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/room/RoundScore.tsx
+++ b/client/src/components/room/RoundScore.tsx
@@ -1,0 +1,102 @@
+import { toast } from 'sonner';
+import { ArrowRight, Trophy } from 'lucide-react';
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { ContinueRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+
+import { isRoomConflict } from '@/hooks/use-room';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type RoundScoreSnapshot = Extract<RoomSnapshot, { phase: 'ROUND_SCORE' }>;
+
+export interface RoundScoreProps {
+  snapshot: RoundScoreSnapshot;
+  currentPlayerId: string;
+  continueRound: UseMutationResult<ContinueRoomResponse, Error, void>;
+  refetch: () => void;
+}
+
+export function RoundScore({ snapshot, currentPlayerId, continueRound, refetch }: RoundScoreProps) {
+  const isHost = snapshot.hostPlayerId === currentPlayerId;
+  const ranked = [...snapshot.players].sort((a, b) => b.score - a.score);
+
+  function handleNextRound() {
+    if (continueRound.isPending) return;
+    continueRound.mutate(undefined, {
+      onError: (error) => {
+        if (isRoomConflict(error)) {
+          refetch();
+          return;
+        }
+        toast.error(error.message || 'Something went wrong. Please try again.');
+      },
+    });
+  }
+
+  return (
+    <div className="w-full max-w-lg space-y-6 text-center">
+      <div className="space-y-2">
+        <Badge
+          variant="outline"
+          className="border-primary/40 text-primary flex items-center justify-center gap-2 mx-auto w-fit"
+        >
+          <Trophy className="w-4 h-4" />
+          Round Complete
+        </Badge>
+        <h1 className="text-3xl font-bold">Round Scores</h1>
+      </div>
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+        <CardContent className="p-6 space-y-3">
+          {ranked.map((player, index) => (
+            <div
+              key={player.id}
+              className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-4 py-3"
+              data-testid={`round-score-row-${player.id}`}
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-bold text-primary">#{index + 1}</span>
+                <span className="font-semibold">
+                  {player.nickname}
+                  {player.id === currentPlayerId && (
+                    <span className="text-muted-foreground font-normal"> (you)</span>
+                  )}
+                </span>
+              </div>
+              <div className="text-right">
+                <span className="font-mono text-xl font-bold">{player.score}</span>
+                {player.lastRoundDelta !== 0 && (
+                  <span
+                    className={cn(
+                      'ml-2 text-sm font-mono',
+                      player.lastRoundDelta > 0 ? 'text-green-400' : 'text-red-400'
+                    )}
+                    data-testid={`round-score-delta-${player.id}`}
+                  >
+                    ({player.lastRoundDelta > 0 ? '+' : ''}
+                    {player.lastRoundDelta})
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+      {isHost ? (
+        <Button
+          onClick={handleNextRound}
+          disabled={continueRound.isPending}
+          className="w-full h-14 text-lg font-bold"
+          data-testid="button-next-round"
+        >
+          {continueRound.isPending ? 'Starting…' : 'Next Round'} <ArrowRight className="ml-2 w-5 h-5" />
+        </Button>
+      ) : (
+        <p className="text-center text-muted-foreground" data-testid="text-waiting-host-round">
+          Waiting for host…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/room/TurnHandoff.test.tsx
+++ b/client/src/components/room/TurnHandoff.test.tsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { TurnHandoff } from './TurnHandoff';
+
+describe('TurnHandoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the player's nickname", () => {
+    render(<TurnHandoff nickname="Alice" onDismiss={vi.fn()} />);
+
+    expect(screen.getByText("It’s Alice’s turn!")).toBeInTheDocument();
+  });
+
+  it('calls onDismiss after the dismiss delay elapses', () => {
+    const onDismiss = vi.fn();
+    render(<TurnHandoff nickname="Alice" onDismiss={onDismiss} />);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2000);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onDismiss if unmounted before the delay elapses', () => {
+    const onDismiss = vi.fn();
+    const { unmount } = render(<TurnHandoff nickname="Alice" onDismiss={onDismiss} />);
+
+    unmount();
+    vi.advanceTimersByTime(2000);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/room/TurnHandoff.tsx
+++ b/client/src/components/room/TurnHandoff.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { motion } from 'framer-motion';
+
+const DISMISS_DELAY_MS = 2000;
+
+export interface TurnHandoffProps {
+  nickname: string;
+  onDismiss: () => void;
+}
+
+export function TurnHandoff({ nickname, onDismiss }: TurnHandoffProps) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, DISMISS_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [onDismiss]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
+      data-testid="turn-handoff"
+    >
+      <motion.div
+        initial={{ scale: 0.9, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.9, opacity: 0 }}
+        className="text-center"
+      >
+        <h2 className="text-3xl font-bold">It&rsquo;s {nickname}&rsquo;s turn!</h2>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/client/src/hooks/use-room.ts
+++ b/client/src/hooks/use-room.ts
@@ -48,6 +48,17 @@ function authHeaders(code: string): HeadersInit {
   return session ? { 'X-Player-Token': session.token } : {};
 }
 
+export interface RoomActionError extends Error {
+  status: number;
+}
+
+// Actions racing against the poll (two players answering, advancing a phase
+// that already moved on, etc.) land as 409s. Callers should reconcile by
+// refetching instead of surfacing an error toast for these.
+export function isRoomConflict(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as RoomActionError).status === 409;
+}
+
 async function parseResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
     let message = res.statusText;
@@ -57,7 +68,9 @@ async function parseResponse<T>(res: Response): Promise<T> {
     } catch {
       // response had no JSON body; fall back to statusText
     }
-    throw new Error(message);
+    const error = new Error(message) as RoomActionError;
+    error.status = res.status;
+    throw error;
   }
   return res.json() as Promise<T>;
 }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function getDifficultyBadgeClass(difficulty: string): string {
+  switch (difficulty) {
+    case 'Easy':
+      return 'bg-[var(--color-difficulty-easy)] text-white';
+    case 'Medium':
+      return 'bg-[var(--color-difficulty-medium)] text-black';
+    case 'Hard':
+      return 'bg-[var(--color-difficulty-hard)] text-white';
+    default:
+      return 'bg-primary';
+  }
+}

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowRight, Trophy, Flag, ExternalLink, LogOut } from 'lucide-react';
 import { DisputeModal } from '@/components/DisputeModal';
 import { useToast } from '@/hooks/use-toast';
+import { getDifficultyBadgeClass } from '@/lib/utils';
 
 const QUESTIONS_PER_TEAM_ROTATION = 4;
 
@@ -180,19 +181,6 @@ export default function Game() {
     state.currentAttempt?.disputeSubmitted === true &&
     state.currentAttempt.pointsAwarded !== true;
 
-  const getDifficultyColor = (d: string) => {
-    switch (d) {
-      case 'Easy':
-        return 'bg-[var(--color-difficulty-easy)] text-white';
-      case 'Medium':
-        return 'bg-[var(--color-difficulty-medium)] text-black';
-      case 'Hard':
-        return 'bg-[var(--color-difficulty-hard)] text-white';
-      default:
-        return 'bg-primary';
-    }
-  };
-
   const handleAwardDisputedPoints = () => {
     awardDisputedPoints();
     toast({
@@ -274,7 +262,7 @@ export default function Game() {
                     {currentQ?.category}
                   </Badge>
                   <Badge
-                    className={`text-lg px-4 py-2 ${currentQ ? getDifficultyColor(currentQ.difficulty) : 'bg-primary'} border-none shadow-lg`}
+                    className={`text-lg px-4 py-2 ${currentQ ? getDifficultyBadgeClass(currentQ.difficulty) : 'bg-primary'} border-none shadow-lg`}
                   >
                     {currentQ?.difficulty}
                   </Badge>

--- a/client/src/pages/Room.test.tsx
+++ b/client/src/pages/Room.test.tsx
@@ -30,6 +30,30 @@ vi.mock('@/components/room/Lobby', () => ({
   ),
 }));
 
+vi.mock('@/components/room/PlayerRoster', () => ({
+  PlayerRoster: () => <div data-testid="player-roster-mock" />,
+}));
+
+vi.mock('@/components/room/QuestionView', () => ({
+  QuestionView: () => <div data-testid="question-view-mock" />,
+}));
+
+vi.mock('@/components/room/RevealView', () => ({
+  RevealView: () => <div data-testid="reveal-view-mock" />,
+}));
+
+vi.mock('@/components/room/RoundScore', () => ({
+  RoundScore: () => <div data-testid="round-score-mock" />,
+}));
+
+vi.mock('@/components/room/FinalResults', () => ({
+  FinalResults: () => <div data-testid="final-results-mock" />,
+}));
+
+vi.mock('@/components/room/TurnHandoff', () => ({
+  TurnHandoff: () => <div data-testid="turn-handoff-mock" />,
+}));
+
 const SESSION = { code: 'ABCDE', playerId: 'host-1', token: 'test-token' };
 
 function makeSnapshot(overrides: Partial<RoomSnapshot> = {}): RoomSnapshot {
@@ -132,17 +156,52 @@ describe('Room', () => {
     render(<Room />);
 
     expect(screen.getByTestId('lobby-mock')).toBeInTheDocument();
+    expect(screen.queryByTestId('player-roster-mock')).toBeNull();
   });
 
-  it('renders a placeholder for non-LOBBY phases', () => {
+  it('renders QuestionView and the PlayerRoster when phase is QUESTION', () => {
     mockGetRoomSession.mockReturnValue(SESSION);
     mockUseRoom.mockReturnValue(
-      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'QUESTION' }) })
+      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'QUESTION', activePlayerId: 'host-1' }) })
     );
 
     render(<Room />);
 
-    expect(screen.getByText(/isn't implemented yet/)).toBeInTheDocument();
+    expect(screen.getByTestId('question-view-mock')).toBeInTheDocument();
+    expect(screen.getByTestId('player-roster-mock')).toBeInTheDocument();
     expect(screen.queryByTestId('lobby-mock')).toBeNull();
+  });
+
+  it('renders RevealView when phase is REVEAL', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(
+      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'REVEAL', activePlayerId: 'host-1' }) })
+    );
+
+    render(<Room />);
+
+    expect(screen.getByTestId('reveal-view-mock')).toBeInTheDocument();
+  });
+
+  it('renders RoundScore when phase is ROUND_SCORE', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(
+      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'ROUND_SCORE', activePlayerId: 'host-1' }) })
+    );
+
+    render(<Room />);
+
+    expect(screen.getByTestId('round-score-mock')).toBeInTheDocument();
+  });
+
+  it('renders FinalResults when phase is GAME_OVER', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(
+      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'GAME_OVER', activePlayerId: 'host-1' }) })
+    );
+
+    render(<Room />);
+
+    expect(screen.getByTestId('final-results-mock')).toBeInTheDocument();
   });
 });

--- a/client/src/pages/Room.test.tsx
+++ b/client/src/pages/Room.test.tsx
@@ -204,4 +204,87 @@ describe('Room', () => {
 
     expect(screen.getByTestId('final-results-mock')).toBeInTheDocument();
   });
+
+  describe('turn handoff interstitial', () => {
+    const players = [
+      {
+        id: 'p1',
+        nickname: 'Alice',
+        joinOrder: 0,
+        score: 0,
+        questionCount: 0,
+        lastRoundDelta: 0,
+        isHost: true,
+        presence: 'online' as const,
+        lastSeenAt: new Date().toISOString(),
+        leftAt: null,
+      },
+      {
+        id: 'p2',
+        nickname: 'Bob',
+        joinOrder: 1,
+        score: 0,
+        questionCount: 0,
+        lastRoundDelta: 0,
+        isHost: false,
+        presence: 'online' as const,
+        lastSeenAt: new Date().toISOString(),
+        leftAt: null,
+      },
+    ];
+
+    it('does not show on the initial QUESTION phase entry', () => {
+      mockGetRoomSession.mockReturnValue(SESSION);
+      mockUseRoom.mockReturnValue(
+        makeUseRoomResult({
+          snapshot: makeSnapshot({ phase: 'QUESTION', activePlayerId: 'p1', players, version: 2 }),
+        })
+      );
+
+      render(<Room />);
+
+      expect(screen.queryByTestId('turn-handoff-mock')).toBeNull();
+    });
+
+    it('shows when the active player changes mid-game', () => {
+      mockGetRoomSession.mockReturnValue(SESSION);
+      mockUseRoom.mockReturnValue(
+        makeUseRoomResult({
+          snapshot: makeSnapshot({ phase: 'QUESTION', activePlayerId: 'p1', players, version: 2 }),
+        })
+      );
+
+      const { rerender } = render(<Room />);
+      expect(screen.queryByTestId('turn-handoff-mock')).toBeNull();
+
+      mockUseRoom.mockReturnValue(
+        makeUseRoomResult({
+          snapshot: makeSnapshot({ phase: 'QUESTION', activePlayerId: 'p2', players, version: 3 }),
+        })
+      );
+      rerender(<Room />);
+
+      expect(screen.getByTestId('turn-handoff-mock')).toBeInTheDocument();
+    });
+
+    it('does not show on a non-QUESTION phase transition (REVEAL to ROUND_SCORE)', () => {
+      mockGetRoomSession.mockReturnValue(SESSION);
+      mockUseRoom.mockReturnValue(
+        makeUseRoomResult({
+          snapshot: makeSnapshot({ phase: 'REVEAL', activePlayerId: 'p1', players, version: 2 }),
+        })
+      );
+
+      const { rerender } = render(<Room />);
+
+      mockUseRoom.mockReturnValue(
+        makeUseRoomResult({
+          snapshot: makeSnapshot({ phase: 'ROUND_SCORE', activePlayerId: 'p2', players, version: 3 }),
+        })
+      );
+      rerender(<Room />);
+
+      expect(screen.queryByTestId('turn-handoff-mock')).toBeNull();
+    });
+  });
 });

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -1,25 +1,49 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useParams } from 'wouter';
+import { AnimatePresence } from 'framer-motion';
 
+import { FinalResults } from '@/components/room/FinalResults';
 import { Lobby } from '@/components/room/Lobby';
+import { PlayerRoster } from '@/components/room/PlayerRoster';
+import { QuestionView } from '@/components/room/QuestionView';
+import { RevealView } from '@/components/room/RevealView';
+import { RoundScore } from '@/components/room/RoundScore';
+import { TurnHandoff } from '@/components/room/TurnHandoff';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
 import { useRoom } from '@/hooks/use-room';
 import { getRoomSession } from '@/lib/room-session';
+import type { RoomPlayerSnapshot } from '@shared/models/rooms';
 
 export default function Room() {
   const { code } = useParams<{ code: string }>();
   const [, setLocation] = useLocation();
   const session = useMemo(() => getRoomSession(code), [code]);
-  const { snapshot, isLoading, isDisconnected, error, start, end } = useRoom(code, {
-    enabled: !!session,
-  });
+  const { snapshot, isLoading, isDisconnected, error, start, answer, advance, continueRound, end, refetch } =
+    useRoom(code, { enabled: !!session });
+
+  const [handoffPlayer, setHandoffPlayer] = useState<RoomPlayerSnapshot | null>(null);
+  const prevActivePlayerRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!session) {
       setLocation('/');
     }
   }, [session, setLocation]);
+
+  // Only surface the interstitial for a genuine handoff (an active-player
+  // change while already mid-game) — skip the very first turn assignment.
+  useEffect(() => {
+    if (!snapshot) return;
+    const prevActivePlayerId = prevActivePlayerRef.current;
+    prevActivePlayerRef.current = snapshot.activePlayerId;
+
+    if (snapshot.phase !== 'QUESTION') return;
+    if (prevActivePlayerId === null || prevActivePlayerId === snapshot.activePlayerId) return;
+
+    const player = snapshot.players.find((p) => p.id === snapshot.activePlayerId);
+    if (player) setHandoffPlayer(player);
+  }, [snapshot]);
 
   if (!session) {
     return null;
@@ -58,21 +82,60 @@ export default function Room() {
         </p>
       )}
 
-      {snapshot.phase === 'LOBBY' ? (
+      {snapshot.phase === 'LOBBY' && (
         <Lobby snapshot={snapshot} currentPlayerId={session.playerId} start={start} end={end} />
-      ) : (
-        <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
-          <CardHeader>
-            <CardTitle>Room {snapshot.code}</CardTitle>
-            <CardDescription>This screen isn't implemented yet.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground text-sm">
-              Phase: {snapshot.phase}. Gameplay screens are coming soon (STE-211).
-            </p>
-          </CardContent>
-        </Card>
       )}
+
+      {snapshot.phase !== 'LOBBY' && (
+        <div className="w-full max-w-lg space-y-4">
+          <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+            <CardContent className="pt-4">
+              <PlayerRoster
+                players={snapshot.players}
+                currentPlayerId={session.playerId}
+                activePlayerId={snapshot.activePlayerId}
+              />
+            </CardContent>
+          </Card>
+
+          {snapshot.phase === 'QUESTION' && (
+            <QuestionView
+              snapshot={snapshot}
+              currentPlayerId={session.playerId}
+              answer={answer}
+              refetch={refetch}
+            />
+          )}
+
+          {snapshot.phase === 'REVEAL' && (
+            <RevealView
+              snapshot={snapshot}
+              currentPlayerId={session.playerId}
+              advance={advance}
+              refetch={refetch}
+            />
+          )}
+
+          {snapshot.phase === 'ROUND_SCORE' && (
+            <RoundScore
+              snapshot={snapshot}
+              currentPlayerId={session.playerId}
+              continueRound={continueRound}
+              refetch={refetch}
+            />
+          )}
+
+          {snapshot.phase === 'GAME_OVER' && (
+            <FinalResults snapshot={snapshot} currentPlayerId={session.playerId} />
+          )}
+        </div>
+      )}
+
+      <AnimatePresence>
+        {handoffPlayer && (
+          <TurnHandoff nickname={handoffPlayer.nickname} onDismiss={() => setHandoffPlayer(null)} />
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useParams } from 'wouter';
-import { AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
+import { QUESTIONS_PER_TEAM_ROTATION } from '@shared/lib/answers';
 
 import { FinalResults } from '@/components/room/FinalResults';
 import { Lobby } from '@/components/room/Lobby';
@@ -45,6 +46,8 @@ export default function Room() {
     if (player) setHandoffPlayer(player);
   }, [snapshot]);
 
+  const handleDismissHandoff = useCallback(() => setHandoffPlayer(null), []);
+
   if (!session) {
     return null;
   }
@@ -74,8 +77,37 @@ export default function Room() {
     return null;
   }
 
+  const showProgress = snapshot.phase === 'QUESTION' || snapshot.phase === 'REVEAL';
+  const activePlayerCount = snapshot.players.filter((player) => !player.leftAt).length;
+  const totalQuestions = snapshot.numRounds * activePlayerCount * QUESTIONS_PER_TEAM_ROTATION;
+  const progressPercent =
+    totalQuestions > 0
+      ? Math.min(100, Math.max(0, (snapshot.currentQuestionIndex / totalQuestions) * 100))
+      : null;
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-4 gap-4">
+      {showProgress &&
+        (progressPercent !== null ? (
+          <div
+            className="fixed top-0 left-0 w-full h-2 bg-white/5 z-30"
+            data-testid="multiplayer-progress-bar"
+          >
+            <motion.div
+              className="h-full bg-primary"
+              initial={{ width: '0%' }}
+              animate={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        ) : (
+          <p
+            className="fixed top-2 left-1/2 -translate-x-1/2 text-xs text-muted-foreground"
+            data-testid="text-question-counter"
+          >
+            Question {snapshot.currentQuestionIndex + 1}
+          </p>
+        ))}
+
       {isDisconnected && (
         <p className="text-sm text-yellow-400" data-testid="text-disconnected" aria-live="polite">
           Connection lost. Reconnecting…
@@ -133,7 +165,7 @@ export default function Room() {
 
       <AnimatePresence>
         {handoffPlayer && (
-          <TurnHandoff nickname={handoffPlayer.nickname} onDismiss={() => setHandoffPlayer(null)} />
+          <TurnHandoff nickname={handoffPlayer.nickname} onDismiss={handleDismissHandoff} />
         )}
       </AnimatePresence>
     </div>


### PR DESCRIPTION
## Summary
- Adds `QuestionView`, `RevealView`, `RoundScore`, and `FinalResults` room-phase components, plus a client-only `TurnHandoff` interstitial, mirroring the solo `Game.tsx` question/reveal/leaderboard visuals (cards, difficulty badges, verdict colors).
- Wires all phases into `Room.tsx`: `LOBBY → REVEAL → ROUND_SCORE → GAME_OVER` render the matching component, `PlayerRoster` is visible on every non-LOBBY phase with active-turn highlighting, and the turn-handoff interstitial auto-dismisses after ~2s on a genuine active-player change.
- Adds `isRoomConflict` to `client/src/hooks/use-room.ts` (attaches HTTP status to thrown errors) so 409 responses from stale actions (double answer, late advance, etc.) are reconciled by refetching the snapshot instead of surfacing an error toast.
- Adds a small `getDifficultyBadgeClass` helper to `client/src/lib/utils.ts`, reused by `QuestionView`/`RevealView` instead of duplicating `Game.tsx`'s inline switch.

Gating rules per the acceptance criteria:
- **QuestionView**: input/Submit/Pass only render for the active player; spectators see a pulsing "Waiting for {nickname}…" with no input at all.
- **RevealView**: Next is visible to the active player or the host; everyone else sees "Waiting to continue…".
- **RoundScore**: Next Round is host-only; others see "Waiting for host…".
- **FinalResults**: Back to Home clears the room session and navigates to `/`.

Client files only — no `shared/` or `server/` changes.

## Test plan
- [x] `npm test` — 382/382 passing (44 new/updated across `QuestionView`, `RevealView`, `RoundScore`, `FinalResults`, `Room` tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual browser verification of the live multiplayer flow was **not** performed — this environment has no `DATABASE_URL`/local Postgres configured, so the full room API (join/answer/advance/continue) can't be exercised end-to-end. Recommend a manual pass (two browser sessions) before merge.

STE-211