### PR TITLE
feat(client): disconnect, rejoin, and host-left handling [STE-213]

### DIFF
--- a/client/src/components/room/QuestionView.test.tsx
+++ b/client/src/components/room/QuestionView.test.tsx
@@ -5,7 +5,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { UseMutationResult } from '@tanstack/react-query';
 
 import { QuestionView } from './QuestionView';
-import type { AnswerRoomRequest, AnswerRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+import type {
+  AnswerRoomRequest,
+  AnswerRoomResponse,
+  RoomSnapshot,
+  SkipRoomResponse,
+} from '@shared/models/rooms';
 
 const toastError = vi.fn();
 vi.mock('sonner', () => ({
@@ -55,7 +60,10 @@ function makeSnapshot(overrides: Partial<QuestionSnapshot> = {}): QuestionSnapsh
       sourceUrl: null,
       sourceName: null,
     },
-    players: [makePlayer({ id: 'p1', nickname: 'Alice' }), makePlayer({ id: 'p2', nickname: 'Bob', isHost: false })],
+    players: [
+      makePlayer({ id: 'p1', nickname: 'Alice' }),
+      makePlayer({ id: 'p2', nickname: 'Bob', isHost: false }),
+    ],
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     expiresAt: new Date().toISOString(),
@@ -63,14 +71,26 @@ function makeSnapshot(overrides: Partial<QuestionSnapshot> = {}): QuestionSnapsh
   } as QuestionSnapshot;
 }
 
-function makeMutation(
+function makeMutation<TData, TVars>(
   overrides: Partial<{ isPending: boolean; mutate: ReturnType<typeof vi.fn> }> = {}
-): UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest> {
+): UseMutationResult<TData, Error, TVars> {
   return {
     mutate: vi.fn(),
     isPending: false,
     ...overrides,
-  } as unknown as UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest>;
+  } as unknown as UseMutationResult<TData, Error, TVars>;
+}
+
+function makeAnswerMutation(
+  overrides: Partial<{ isPending: boolean; mutate: ReturnType<typeof vi.fn> }> = {}
+) {
+  return makeMutation<AnswerRoomResponse, AnswerRoomRequest>(overrides);
+}
+
+function makeSkipMutation(
+  overrides: Partial<{ isPending: boolean; mutate: ReturnType<typeof vi.fn> }> = {}
+) {
+  return makeMutation<SkipRoomResponse, void>(overrides);
 }
 
 describe('QuestionView', () => {
@@ -90,7 +110,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p1"
-        answer={makeMutation()}
+        answer={makeAnswerMutation()}
+        skip={makeSkipMutation()}
         refetch={vi.fn()}
       />
     );
@@ -107,7 +128,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p2"
-        answer={makeMutation()}
+        answer={makeAnswerMutation()}
+        skip={makeSkipMutation()}
         refetch={vi.fn()}
       />
     );
@@ -124,7 +146,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p1"
-        answer={makeMutation()}
+        answer={makeAnswerMutation()}
+        skip={makeSkipMutation()}
         refetch={vi.fn()}
       />
     );
@@ -140,7 +163,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p1"
-        answer={makeMutation({ isPending: true })}
+        answer={makeAnswerMutation({ isPending: true })}
+        skip={makeSkipMutation()}
         refetch={vi.fn()}
       />
     );
@@ -156,7 +180,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p1"
-        answer={makeMutation({ mutate })}
+        answer={makeAnswerMutation({ mutate })}
+        skip={makeSkipMutation()}
         refetch={vi.fn()}
       />
     );
@@ -174,7 +199,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p1"
-        answer={makeMutation({ mutate })}
+        answer={makeAnswerMutation({ mutate })}
+        skip={makeSkipMutation()}
         refetch={vi.fn()}
       />
     );
@@ -196,7 +222,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p1"
-        answer={makeMutation({ mutate })}
+        answer={makeAnswerMutation({ mutate })}
+        skip={makeSkipMutation()}
         refetch={refetch}
       />
     );
@@ -217,7 +244,8 @@ describe('QuestionView', () => {
       <QuestionView
         snapshot={snapshot}
         currentPlayerId="p1"
-        answer={makeMutation({ mutate })}
+        answer={makeAnswerMutation({ mutate })}
+        skip={makeSkipMutation()}
         refetch={refetch}
       />
     );
@@ -226,5 +254,144 @@ describe('QuestionView', () => {
 
     expect(refetch).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalledWith('Server exploded');
+  });
+
+  describe('skip turn button', () => {
+    function staleTimestamp(msAgo: number) {
+      return new Date(Date.now() - msAgo).toISOString();
+    }
+
+    it('shows the skip button for the host when the active player is stale beyond the threshold', () => {
+      const snapshot = makeSnapshot({
+        activePlayerId: 'p2',
+        players: [
+          makePlayer({ id: 'p1', nickname: 'Alice', isHost: true }),
+          makePlayer({
+            id: 'p2',
+            nickname: 'Bob',
+            isHost: false,
+            lastSeenAt: staleTimestamp(61_000),
+          }),
+        ],
+      });
+      render(
+        <QuestionView
+          snapshot={snapshot}
+          currentPlayerId="p1"
+          answer={makeAnswerMutation()}
+          skip={makeSkipMutation()}
+          refetch={vi.fn()}
+        />
+      );
+
+      expect(screen.getByTestId('button-skip-turn')).toBeInTheDocument();
+    });
+
+    it('hides the skip button when the active player is not stale enough', () => {
+      const snapshot = makeSnapshot({
+        activePlayerId: 'p2',
+        players: [
+          makePlayer({ id: 'p1', nickname: 'Alice', isHost: true }),
+          makePlayer({
+            id: 'p2',
+            nickname: 'Bob',
+            isHost: false,
+            lastSeenAt: staleTimestamp(5_000),
+          }),
+        ],
+      });
+      render(
+        <QuestionView
+          snapshot={snapshot}
+          currentPlayerId="p1"
+          answer={makeAnswerMutation()}
+          skip={makeSkipMutation()}
+          refetch={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId('button-skip-turn')).toBeNull();
+    });
+
+    it('hides the skip button for non-hosts even when the active player is stale', () => {
+      const snapshot = makeSnapshot({
+        activePlayerId: 'p2',
+        players: [
+          makePlayer({ id: 'p1', nickname: 'Alice', isHost: true }),
+          makePlayer({
+            id: 'p2',
+            nickname: 'Bob',
+            isHost: false,
+            lastSeenAt: staleTimestamp(61_000),
+          }),
+        ],
+      });
+      render(
+        <QuestionView
+          snapshot={snapshot}
+          currentPlayerId="p2"
+          answer={makeAnswerMutation()}
+          skip={makeSkipMutation()}
+          refetch={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId('button-skip-turn')).toBeNull();
+    });
+
+    it('calls skip.mutate when the host clicks the skip button', () => {
+      const mutate = vi.fn();
+      const snapshot = makeSnapshot({
+        activePlayerId: 'p2',
+        players: [
+          makePlayer({ id: 'p1', nickname: 'Alice', isHost: true }),
+          makePlayer({
+            id: 'p2',
+            nickname: 'Bob',
+            isHost: false,
+            lastSeenAt: staleTimestamp(61_000),
+          }),
+        ],
+      });
+      render(
+        <QuestionView
+          snapshot={snapshot}
+          currentPlayerId="p1"
+          answer={makeAnswerMutation()}
+          skip={makeSkipMutation({ mutate })}
+          refetch={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('button-skip-turn'));
+
+      expect(mutate).toHaveBeenCalledWith(undefined, expect.any(Object));
+    });
+
+    it('disables the skip button while the skip mutation is in flight', () => {
+      const snapshot = makeSnapshot({
+        activePlayerId: 'p2',
+        players: [
+          makePlayer({ id: 'p1', nickname: 'Alice', isHost: true }),
+          makePlayer({
+            id: 'p2',
+            nickname: 'Bob',
+            isHost: false,
+            lastSeenAt: staleTimestamp(61_000),
+          }),
+        ],
+      });
+      render(
+        <QuestionView
+          snapshot={snapshot}
+          currentPlayerId="p1"
+          answer={makeAnswerMutation()}
+          skip={makeSkipMutation({ isPending: true })}
+          refetch={vi.fn()}
+        />
+      );
+
+      expect(screen.getByTestId('button-skip-turn')).toBeDisabled();
+    });
   });
 });

--- a/client/src/components/room/QuestionView.tsx
+++ b/client/src/components/room/QuestionView.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import type { UseMutationResult } from '@tanstack/react-query';
-import type { AnswerRoomRequest, AnswerRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+import type {
+  AnswerRoomRequest,
+  AnswerRoomResponse,
+  RoomSnapshot,
+  SkipRoomResponse,
+} from '@shared/models/rooms';
 
 import { isRoomConflict } from '@/hooks/use-room';
 import { Badge } from '@/components/ui/badge';
@@ -12,18 +17,34 @@ import { cn, getDifficultyBadgeClass } from '@/lib/utils';
 
 type QuestionSnapshot = Extract<RoomSnapshot, { phase: 'QUESTION' }>;
 
+// Mirrors the server's SKIP_THRESHOLD_MS (server/routes.rooms.ts) so the
+// button only appears once the skip mutation would actually succeed.
+const SKIP_THRESHOLD_MS = 60_000;
+
 export interface QuestionViewProps {
   snapshot: QuestionSnapshot;
   currentPlayerId: string;
   answer: UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest>;
+  skip: UseMutationResult<SkipRoomResponse, Error, void>;
   refetch: () => void;
 }
 
-export function QuestionView({ snapshot, currentPlayerId, answer, refetch }: QuestionViewProps) {
+export function QuestionView({
+  snapshot,
+  currentPlayerId,
+  answer,
+  skip,
+  refetch,
+}: QuestionViewProps) {
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const isMyTurn = snapshot.activePlayerId === currentPlayerId;
+  const isHost = snapshot.hostPlayerId === currentPlayerId;
   const activePlayer = snapshot.players.find((player) => player.id === snapshot.activePlayerId);
+  const activePlayerStale = activePlayer
+    ? Date.now() - new Date(activePlayer.lastSeenAt).getTime() > SKIP_THRESHOLD_MS
+    : false;
+  const canSkip = isHost && activePlayerStale;
 
   useEffect(() => {
     setValue('');
@@ -48,6 +69,11 @@ export function QuestionView({ snapshot, currentPlayerId, answer, refetch }: Que
     answer.mutate({ answer: null }, { onError: handleActionError });
   }
 
+  function handleSkip() {
+    if (skip.isPending) return;
+    skip.mutate(undefined, { onError: handleActionError });
+  }
+
   return (
     <div className="w-full max-w-lg space-y-4">
       {isMyTurn ? (
@@ -67,6 +93,18 @@ export function QuestionView({ snapshot, currentPlayerId, answer, refetch }: Que
         </p>
       )}
 
+      {canSkip && (
+        <Button
+          variant="outline"
+          onClick={handleSkip}
+          disabled={skip.isPending}
+          className="w-full border-yellow-500/40 text-yellow-300 hover:bg-yellow-500/10"
+          data-testid="button-skip-turn"
+        >
+          {skip.isPending ? 'Skipping…' : `Skip ${activePlayer?.nickname ?? 'their'} turn`}
+        </Button>
+      )}
+
       <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
         <CardContent className="p-6 md:p-8 space-y-4">
           <div className="flex flex-wrap gap-2 justify-center">
@@ -74,7 +112,10 @@ export function QuestionView({ snapshot, currentPlayerId, answer, refetch }: Que
               {snapshot.currentQuestion.category}
             </Badge>
             <Badge
-              className={cn('border-none', getDifficultyBadgeClass(snapshot.currentQuestion.difficulty))}
+              className={cn(
+                'border-none',
+                getDifficultyBadgeClass(snapshot.currentQuestion.difficulty)
+              )}
             >
               {snapshot.currentQuestion.difficulty}
             </Badge>
@@ -91,7 +132,9 @@ export function QuestionView({ snapshot, currentPlayerId, answer, refetch }: Que
             ref={inputRef}
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            onFocus={() => inputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
+            onFocus={() =>
+              inputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            }
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSubmit();
             }}

--- a/client/src/components/room/RoomAbandoned.test.tsx
+++ b/client/src/components/room/RoomAbandoned.test.tsx
@@ -1,0 +1,103 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { RoomAbandoned } from './RoomAbandoned';
+import type { RoomSnapshot } from '@shared/models/rooms';
+
+const mockSetLocation = vi.fn();
+vi.mock('wouter', () => ({
+  useLocation: () => ['/room/ABCDE', mockSetLocation],
+}));
+
+const mockClearRoomSession = vi.fn();
+vi.mock('@/lib/room-session', () => ({
+  clearRoomSession: (...args: unknown[]) => mockClearRoomSession(...args),
+}));
+
+function makePlayer(overrides: Partial<RoomSnapshot['players'][number]> = {}) {
+  return {
+    id: 'p1',
+    nickname: 'Alice',
+    joinOrder: 0,
+    score: 20,
+    questionCount: 8,
+    lastRoundDelta: 0,
+    isHost: true,
+    presence: 'online' as const,
+    lastSeenAt: new Date().toISOString(),
+    leftAt: null,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<RoomSnapshot> = {}): RoomSnapshot {
+  return {
+    id: 'room-1',
+    code: 'ABCDE',
+    status: 'abandoned',
+    phase: 'QUESTION',
+    version: 5,
+    hostPlayerId: 'p1',
+    category: 'All',
+    numRounds: 10,
+    currentQuestionIndex: 4,
+    activePlayerId: 'p1',
+    currentAttempt: null,
+    currentQuestion: {
+      id: 'q1',
+      category: 'Science',
+      difficulty: 'Medium',
+      question: 'What planet is closest to the sun?',
+      pillar: 'Astronomy',
+      tags: [],
+      sourceUrl: null,
+      sourceName: null,
+    },
+    players: [
+      makePlayer({ id: 'p1', nickname: 'Alice', score: 20 }),
+      makePlayer({ id: 'p2', nickname: 'Bob', isHost: false, score: 12 }),
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date().toISOString(),
+    ...overrides,
+  } as unknown as RoomSnapshot;
+}
+
+describe('RoomAbandoned', () => {
+  beforeEach(() => {
+    mockSetLocation.mockClear();
+    mockClearRoomSession.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the final scores when players have any', () => {
+    render(<RoomAbandoned snapshot={makeSnapshot()} />);
+
+    const rows = screen.getAllByTestId(/abandoned-result-row-/);
+    expect(rows[0]).toHaveTextContent('Alice');
+    expect(rows[1]).toHaveTextContent('Bob');
+  });
+
+  it('omits the score list when there are no players', () => {
+    render(<RoomAbandoned snapshot={makeSnapshot({ players: [] })} />);
+
+    expect(screen.queryByTestId(/abandoned-result-row-/)).toBeNull();
+  });
+
+  it('clears the room session and navigates home on Back to Home', () => {
+    render(<RoomAbandoned snapshot={makeSnapshot()} />);
+
+    fireEvent.click(screen.getByTestId('button-abandoned-home'));
+
+    expect(mockClearRoomSession).toHaveBeenCalledWith('ABCDE');
+    expect(mockSetLocation).toHaveBeenCalledWith('/');
+  });
+});

--- a/client/src/components/room/RoomAbandoned.test.tsx
+++ b/client/src/components/room/RoomAbandoned.test.tsx
@@ -100,4 +100,19 @@ describe('RoomAbandoned', () => {
     expect(mockClearRoomSession).toHaveBeenCalledWith('ABCDE');
     expect(mockSetLocation).toHaveBeenCalledWith('/');
   });
+
+  it('exposes dialog semantics labelled by the title', () => {
+    render(<RoomAbandoned snapshot={makeSnapshot()} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'room-abandoned-title');
+    expect(document.getElementById('room-abandoned-title')).toHaveTextContent('Room Closed');
+  });
+
+  it('auto-focuses the Back to Home button on mount', () => {
+    render(<RoomAbandoned snapshot={makeSnapshot()} />);
+
+    expect(screen.getByTestId('button-abandoned-home')).toHaveFocus();
+  });
 });

--- a/client/src/components/room/RoomAbandoned.tsx
+++ b/client/src/components/room/RoomAbandoned.tsx
@@ -1,0 +1,55 @@
+import { useLocation } from 'wouter';
+import type { RoomSnapshot } from '@shared/models/rooms';
+
+import { clearRoomSession } from '@/lib/room-session';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+export interface RoomAbandonedProps {
+  snapshot: RoomSnapshot;
+}
+
+export function RoomAbandoned({ snapshot }: RoomAbandonedProps) {
+  const [, setLocation] = useLocation();
+  const ranked = [...snapshot.players].sort((a, b) => b.score - a.score);
+
+  function handleBackToHome() {
+    clearRoomSession(snapshot.code);
+    setLocation('/');
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
+      data-testid="room-abandoned"
+    >
+      <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
+        <CardHeader>
+          <CardTitle>Room Closed</CardTitle>
+          <CardDescription>The host has ended this game.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {ranked.length > 0 && (
+            <div className="space-y-2">
+              {ranked.map((player, index) => (
+                <div
+                  key={player.id}
+                  className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-4 py-2"
+                  data-testid={`abandoned-result-row-${player.id}`}
+                >
+                  <span>
+                    #{index + 1} {player.nickname}
+                  </span>
+                  <span className="font-mono">{player.score}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          <Button className="w-full" onClick={handleBackToHome} data-testid="button-abandoned-home">
+            Back to Home
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/components/room/RoomAbandoned.tsx
+++ b/client/src/components/room/RoomAbandoned.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'wouter';
 import type { RoomSnapshot } from '@shared/models/rooms';
 
@@ -12,6 +13,11 @@ export interface RoomAbandonedProps {
 export function RoomAbandoned({ snapshot }: RoomAbandonedProps) {
   const [, setLocation] = useLocation();
   const ranked = [...snapshot.players].sort((a, b) => b.score - a.score);
+  const homeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    homeButtonRef.current?.focus();
+  }, []);
 
   function handleBackToHome() {
     clearRoomSession(snapshot.code);
@@ -22,10 +28,13 @@ export function RoomAbandoned({ snapshot }: RoomAbandonedProps) {
     <div
       className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
       data-testid="room-abandoned"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="room-abandoned-title"
     >
       <Card className="w-full max-w-md border-white/10 bg-white/5 backdrop-blur-md">
         <CardHeader>
-          <CardTitle>Room Closed</CardTitle>
+          <CardTitle id="room-abandoned-title">Room Closed</CardTitle>
           <CardDescription>The host has ended this game.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -45,7 +54,12 @@ export function RoomAbandoned({ snapshot }: RoomAbandonedProps) {
               ))}
             </div>
           )}
-          <Button className="w-full" onClick={handleBackToHome} data-testid="button-abandoned-home">
+          <Button
+            ref={homeButtonRef}
+            className="w-full"
+            onClick={handleBackToHome}
+            data-testid="button-abandoned-home"
+          >
             Back to Home
           </Button>
         </CardContent>

--- a/client/src/lib/room-session.test.ts
+++ b/client/src/lib/room-session.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { clearRoomSession, getRoomSession, saveRoomSession } from './room-session';
+import {
+  clearRoomSession,
+  getRoomSession,
+  listRoomSessions,
+  saveRoomSession,
+} from './room-session';
 
 // Stub localStorage for jsdom compatibility
 const storage: Record<string, string> = {};
@@ -14,6 +19,10 @@ vi.stubGlobal('localStorage', {
   },
   clear: () => {
     for (const key of Object.keys(storage)) delete storage[key];
+  },
+  key: (index: number) => Object.keys(storage)[index] ?? null,
+  get length() {
+    return Object.keys(storage).length;
   },
 });
 
@@ -58,5 +67,34 @@ describe('room-session', () => {
     saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'token-1' });
     clearRoomSession('ABCD2');
     expect(getRoomSession('ABCD2')).toBeNull();
+  });
+
+  describe('listRoomSessions', () => {
+    it('returns an empty array when no sessions are stored', () => {
+      expect(listRoomSessions()).toEqual([]);
+    });
+
+    it('returns every stored session', () => {
+      saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'token-1' });
+      saveRoomSession({ code: 'WXYZ2', playerId: 'player-2', token: 'token-2' });
+
+      const sessions = listRoomSessions();
+      expect(sessions).toHaveLength(2);
+      expect(sessions).toEqual(
+        expect.arrayContaining([
+          { code: 'ABCD2', playerId: 'player-1', token: 'token-1' },
+          { code: 'WXYZ2', playerId: 'player-2', token: 'token-2' },
+        ])
+      );
+    });
+
+    it('ignores unrelated localStorage entries', () => {
+      saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'token-1' });
+      localStorage.setItem('trivia:some-other-key', 'value');
+
+      expect(listRoomSessions()).toEqual([
+        { code: 'ABCD2', playerId: 'player-1', token: 'token-1' },
+      ]);
+    });
   });
 });

--- a/client/src/lib/room-session.ts
+++ b/client/src/lib/room-session.ts
@@ -39,3 +39,14 @@ export function getRoomSession(code: string): RoomSession | null {
 export function clearRoomSession(code: string): void {
   localStorage.removeItem(storageKey(code));
 }
+
+export function listRoomSessions(): RoomSession[] {
+  const sessions: RoomSession[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key || !key.startsWith(STORAGE_PREFIX)) continue;
+    const session = getRoomSession(key.slice(STORAGE_PREFIX.length));
+    if (session) sessions.push(session);
+  }
+  return sessions;
+}

--- a/client/src/pages/Home.multiplayer.test.tsx
+++ b/client/src/pages/Home.multiplayer.test.tsx
@@ -1,8 +1,10 @@
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Home from './Home';
 import { GameProvider } from '@/lib/store';
+import { getRoomSession, saveRoomSession } from '@/lib/room-session';
 
 // Stub localStorage for jsdom compatibility
 const storage: Record<string, string> = {};
@@ -17,6 +19,10 @@ vi.stubGlobal('localStorage', {
   clear: () => {
     for (const key of Object.keys(storage)) delete storage[key];
   },
+  key: (index: number) => Object.keys(storage)[index] ?? null,
+  get length() {
+    return Object.keys(storage).length;
+  },
 });
 
 function createFetchMock() {
@@ -28,6 +34,26 @@ function createFetchMock() {
   );
 }
 
+function createRoomAwareFetchMock(roomResponse: { status: number; body?: unknown }) {
+  return vi.fn((input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+    if (url.includes('/api/rooms/')) {
+      const ok = roomResponse.status >= 200 && roomResponse.status < 300;
+      return Promise.resolve({
+        ok,
+        status: roomResponse.status,
+        json: () => Promise.resolve(roomResponse.body ?? {}),
+      } as Response);
+    }
+
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ questions: [], categories: [] }),
+    } as Response);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Mocks — same as Home.test.tsx, but with MULTIPLAYER enabled
 // ---------------------------------------------------------------------------
@@ -36,6 +62,9 @@ const mockSetLocation = vi.fn();
 
 vi.mock('wouter', () => ({
   useLocation: () => ['/', mockSetLocation],
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
 }));
 
 vi.mock('@/lib/featureFlags', () => ({
@@ -126,5 +155,67 @@ describe('Home page with VITE_MULTIPLAYER enabled', () => {
     renderHome();
     fireEvent.click(screen.getByTestId('button-mode-solo'));
     expect(await screen.findByText('Team Setup')).toBeDefined();
+  });
+
+  describe('rejoin chip', () => {
+    it('does not show a rejoin chip when no session is stored', () => {
+      renderHome();
+      expect(screen.queryByTestId('button-rejoin-room')).toBeNull();
+    });
+
+    it('shows a rejoin chip for a stored session when the room is still active', async () => {
+      saveRoomSession({ code: 'ABCDE', playerId: 'player-1', token: 'token-1' });
+      vi.stubGlobal('fetch', createRoomAwareFetchMock({ status: 200, body: { status: 'active' } }));
+
+      renderHome();
+
+      expect(await screen.findByTestId('button-rejoin-room')).toHaveTextContent('ABCDE');
+    });
+
+    it('clears the session and hides the chip when the room no longer exists', async () => {
+      saveRoomSession({ code: 'ABCDE', playerId: 'player-1', token: 'token-1' });
+      vi.stubGlobal('fetch', createRoomAwareFetchMock({ status: 404 }));
+
+      renderHome();
+
+      await waitFor(() => expect(getRoomSession('ABCDE')).toBeNull());
+      expect(screen.queryByTestId('button-rejoin-room')).toBeNull();
+    });
+
+    it('clears the session and hides the chip when the room has been abandoned', async () => {
+      saveRoomSession({ code: 'ABCDE', playerId: 'player-1', token: 'token-1' });
+      vi.stubGlobal(
+        'fetch',
+        createRoomAwareFetchMock({ status: 200, body: { status: 'abandoned' } })
+      );
+
+      renderHome();
+
+      await waitFor(() => expect(getRoomSession('ABCDE')).toBeNull());
+      expect(screen.queryByTestId('button-rejoin-room')).toBeNull();
+    });
+
+    it('clears the session and hides the chip when the room has finished', async () => {
+      saveRoomSession({ code: 'ABCDE', playerId: 'player-1', token: 'token-1' });
+      vi.stubGlobal(
+        'fetch',
+        createRoomAwareFetchMock({ status: 200, body: { status: 'finished' } })
+      );
+
+      renderHome();
+
+      await waitFor(() => expect(getRoomSession('ABCDE')).toBeNull());
+      expect(screen.queryByTestId('button-rejoin-room')).toBeNull();
+    });
+
+    it('links the chip to the room route for the stored code', async () => {
+      saveRoomSession({ code: 'ABCDE', playerId: 'player-1', token: 'token-1' });
+      vi.stubGlobal('fetch', createRoomAwareFetchMock({ status: 200, body: { status: 'active' } }));
+
+      renderHome();
+
+      const chip = await screen.findByTestId('button-rejoin-room');
+      expect(chip.closest('a')).toHaveAttribute('href', '/room/ABCDE');
+    });
   });
 });

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
-import { useLocation } from 'wouter';
+import { useEffect, useState } from 'react';
+import { Link, useLocation } from 'wouter';
 import { useGame, QUESTIONS_PER_TEAM_ROTATION } from '@/lib/store';
 import { useAuth } from '@/hooks/use-auth';
 import { useAdmin } from '@/hooks/use-admin';
 import { useCategoryCounts } from '@/hooks/use-category-counts';
+import { clearRoomSession, listRoomSessions, type RoomSession } from '@/lib/room-session';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -23,13 +24,56 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { MULTIPLAYER } from '@/lib/featureFlags';
 
+// A stored room session may point at a room that has since been closed or
+// expired. Validate against the server before offering it as a rejoin target.
+function useRejoinableSession(enabled: boolean): RoomSession | null {
+  const [session, setSession] = useState<RoomSession | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const candidate = listRoomSessions()[0];
+    if (!candidate) return;
+
+    let cancelled = false;
+    fetch(`/api/rooms/${encodeURIComponent(candidate.code)}`, {
+      headers: { 'X-Player-Token': candidate.token },
+    })
+      .then(async (res) => {
+        if (cancelled) return;
+        if (res.status === 404 || res.status === 401) {
+          clearRoomSession(candidate.code);
+          return;
+        }
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.status === 'abandoned' || data.status === 'finished') {
+          clearRoomSession(candidate.code);
+          return;
+        }
+        setSession(candidate);
+      })
+      .catch(() => {
+        // Transient network error — leave the stored session alone and
+        // simply don't offer the rejoin chip this time.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return session;
+}
+
 export default function Home() {
   const [, setLocation] = useLocation();
   const [mode, setMode] = useState<'choose' | 'solo'>(MULTIPLAYER ? 'choose' : 'solo');
+  const rejoinSession = useRejoinableSession(MULTIPLAYER);
 
   if (MULTIPLAYER && mode === 'choose') {
     return (
       <ModeChooser
+        rejoinSession={rejoinSession}
         onPlaySolo={() => setMode('solo')}
         onHost={() => setLocation('/host')}
         onJoin={() => setLocation('/join')}
@@ -41,10 +85,12 @@ export default function Home() {
 }
 
 function ModeChooser({
+  rejoinSession,
   onPlaySolo,
   onHost,
   onJoin,
 }: {
+  rejoinSession: RoomSession | null;
   onPlaySolo: () => void;
   onHost: () => void;
   onJoin: () => void;
@@ -73,6 +119,17 @@ function ModeChooser({
         </div>
 
         <div className="flex flex-col w-full gap-4">
+          {rejoinSession && (
+            <Link href={`/room/${rejoinSession.code}`}>
+              <Button
+                variant="secondary"
+                className="w-full h-12 text-base font-semibold rounded-2xl border border-primary/30 bg-primary/10 hover:bg-primary/20"
+                data-testid="button-rejoin-room"
+              >
+                Rejoin game {rejoinSession.code}
+              </Button>
+            </Link>
+          )}
           <Button
             className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
             onClick={onPlaySolo}

--- a/client/src/pages/Room.test.tsx
+++ b/client/src/pages/Room.test.tsx
@@ -54,6 +54,12 @@ vi.mock('@/components/room/TurnHandoff', () => ({
   TurnHandoff: () => <div data-testid="turn-handoff-mock" />,
 }));
 
+vi.mock('@/components/room/RoomAbandoned', () => ({
+  RoomAbandoned: ({ snapshot }: { snapshot: RoomSnapshot }) => (
+    <div data-testid="room-abandoned-mock">Abandoned {snapshot.code}</div>
+  ),
+}));
+
 const SESSION = { code: 'ABCDE', playerId: 'host-1', token: 'test-token' };
 
 function makeSnapshot(overrides: Partial<RoomSnapshot> = {}): RoomSnapshot {
@@ -186,7 +192,9 @@ describe('Room', () => {
   it('renders RoundScore when phase is ROUND_SCORE', () => {
     mockGetRoomSession.mockReturnValue(SESSION);
     mockUseRoom.mockReturnValue(
-      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'ROUND_SCORE', activePlayerId: 'host-1' }) })
+      makeUseRoomResult({
+        snapshot: makeSnapshot({ phase: 'ROUND_SCORE', activePlayerId: 'host-1' }),
+      })
     );
 
     render(<Room />);
@@ -197,12 +205,56 @@ describe('Room', () => {
   it('renders FinalResults when phase is GAME_OVER', () => {
     mockGetRoomSession.mockReturnValue(SESSION);
     mockUseRoom.mockReturnValue(
-      makeUseRoomResult({ snapshot: makeSnapshot({ phase: 'GAME_OVER', activePlayerId: 'host-1' }) })
+      makeUseRoomResult({
+        snapshot: makeSnapshot({ phase: 'GAME_OVER', activePlayerId: 'host-1' }),
+      })
     );
 
     render(<Room />);
 
     expect(screen.getByTestId('final-results-mock')).toBeInTheDocument();
+  });
+
+  it('renders the RoomAbandoned overlay instead of phase content when status is abandoned', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(
+      makeUseRoomResult({
+        snapshot: makeSnapshot({
+          phase: 'QUESTION',
+          status: 'abandoned',
+          activePlayerId: 'host-1',
+        }),
+      })
+    );
+
+    render(<Room />);
+
+    expect(screen.getByTestId('room-abandoned-mock')).toBeInTheDocument();
+    expect(screen.queryByTestId('question-view-mock')).toBeNull();
+    expect(screen.queryByTestId('player-roster-mock')).toBeNull();
+  });
+
+  describe('silent rejoin from stored session', () => {
+    it.each([
+      ['LOBBY', 'lobby-mock'],
+      ['QUESTION', 'question-view-mock'],
+      ['REVEAL', 'reveal-view-mock'],
+      ['ROUND_SCORE', 'round-score-mock'],
+      ['GAME_OVER', 'final-results-mock'],
+    ] as const)(
+      'resumes directly into the %s phase on mount without redirecting',
+      (phase, testId) => {
+        mockGetRoomSession.mockReturnValue(SESSION);
+        mockUseRoom.mockReturnValue(
+          makeUseRoomResult({ snapshot: makeSnapshot({ phase, activePlayerId: 'host-1' }) })
+        );
+
+        render(<Room />);
+
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+        expect(mockSetLocation).not.toHaveBeenCalled();
+      }
+    );
   });
 
   describe('turn handoff interstitial', () => {
@@ -279,7 +331,12 @@ describe('Room', () => {
 
       mockUseRoom.mockReturnValue(
         makeUseRoomResult({
-          snapshot: makeSnapshot({ phase: 'ROUND_SCORE', activePlayerId: 'p2', players, version: 3 }),
+          snapshot: makeSnapshot({
+            phase: 'ROUND_SCORE',
+            activePlayerId: 'p2',
+            players,
+            version: 3,
+          }),
         })
       );
       rerender(<Room />);

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -8,6 +8,7 @@ import { Lobby } from '@/components/room/Lobby';
 import { PlayerRoster } from '@/components/room/PlayerRoster';
 import { QuestionView } from '@/components/room/QuestionView';
 import { RevealView } from '@/components/room/RevealView';
+import { RoomAbandoned } from '@/components/room/RoomAbandoned';
 import { RoundScore } from '@/components/room/RoundScore';
 import { TurnHandoff } from '@/components/room/TurnHandoff';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -20,8 +21,19 @@ export default function Room() {
   const { code } = useParams<{ code: string }>();
   const [, setLocation] = useLocation();
   const session = useMemo(() => getRoomSession(code), [code]);
-  const { snapshot, isLoading, isDisconnected, error, start, answer, advance, continueRound, end, refetch } =
-    useRoom(code, { enabled: !!session });
+  const {
+    snapshot,
+    isLoading,
+    isDisconnected,
+    error,
+    start,
+    answer,
+    advance,
+    continueRound,
+    skip,
+    end,
+    refetch,
+  } = useRoom(code, { enabled: !!session });
 
   const [handoffPlayer, setHandoffPlayer] = useState<RoomPlayerSnapshot | null>(null);
   const prevActivePlayerRef = useRef<string | null>(null);
@@ -77,6 +89,10 @@ export default function Room() {
     return null;
   }
 
+  if (snapshot.status === 'abandoned') {
+    return <RoomAbandoned snapshot={snapshot} />;
+  }
+
   const showProgress = snapshot.phase === 'QUESTION' || snapshot.phase === 'REVEAL';
   const activePlayerCount = snapshot.players.filter((player) => !player.leftAt).length;
   const totalQuestions = snapshot.numRounds * activePlayerCount * QUESTIONS_PER_TEAM_ROTATION;
@@ -109,9 +125,15 @@ export default function Room() {
         ))}
 
       {isDisconnected && (
-        <p className="text-sm text-yellow-400" data-testid="text-disconnected" aria-live="polite">
+        <div
+          className={`fixed left-0 w-full z-40 py-2 text-center text-sm font-medium bg-yellow-500/90 text-black ${
+            showProgress ? 'top-2' : 'top-0'
+          }`}
+          data-testid="text-disconnected"
+          aria-live="polite"
+        >
           Connection lost. Reconnecting…
-        </p>
+        </div>
       )}
 
       {snapshot.phase === 'LOBBY' && (
@@ -135,6 +157,7 @@ export default function Room() {
               snapshot={snapshot}
               currentPlayerId={session.playerId}
               answer={answer}
+              skip={skip}
               refetch={refetch}
             />
           )}


### PR DESCRIPTION
## Summary

Implements STE-213: client-side handling for disconnect, silent rejoin, and host-left scenarios in multiplayer rooms.

- **Reconnecting banner**: now a sticky top bar (instead of inline text) that appears after ≥2 consecutive poll failures and auto-clears on the next success.
- **Silent rejoin**: added test coverage confirming `Room.tsx` resumes directly into every phase on mount when a stored room-session token exists, without redirecting (the resume-by-design behavior already worked; this closes the gap in coverage).
- **Home rejoin chip**: `Home.tsx` now checks `localStorage` for an unfinished room session and, after validating the room is still active via `GET /api/rooms/:code`, shows a "Rejoin game {code}" chip in the multiplayer mode chooser. A 404/401 response or a `finished`/`abandoned` room status clears the stale session instead of showing the chip.
- **Host-left / room abandoned**: new `RoomAbandoned` overlay renders across *every* phase (not just the lobby, which already had its own closed-room card) when `snapshot.status === 'abandoned'`, showing final scores and clearing the room session on "Back to Home".
- **Stale player greying**: already fully implemented in `PlayerRoster` from STE-210 — no changes needed.
- **Skip stale turn**: `QuestionView` now shows a "Skip {nickname} turn" button once the active player has been stale beyond the 60s threshold the server enforces (`SKIP_THRESHOLD_MS` in `server/routes.rooms.ts`), visible only to the host.

Client-only change — no `shared/` or `server/` files were touched.

## Test plan

- [x] `npm test` — 411 tests passing (52 in the touched files, including ~23 new tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` / `npx prettier --check` on all changed files — clean
- [ ] Manual smoke test in a running dev server (not performed in this session — recommend before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)