### PR TITLE
fix(room): add dispute button and point-awarding to multiplayer reveal [STE-236]

### DIFF
--- a/client/src/components/DisputeModal.tsx
+++ b/client/src/components/DisputeModal.tsx
@@ -11,7 +11,6 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { saveDispute } from '@/lib/disputes';
-import { useGame } from '@/lib/store';
 import { useToast } from '@/hooks/use-toast';
 
 interface DisputeModalProps {
@@ -22,6 +21,8 @@ interface DisputeModalProps {
   correctAnswer: string;
   teamName: string;
   submittedAnswer: string | null;
+  /** Callback invoked after a dispute is successfully submitted. In solo mode, this should call markDisputeSubmitted from the game store. In multiplayer, it sets local state. */
+  onDisputeSubmitted: () => void;
 }
 
 export function DisputeModal({
@@ -32,10 +33,10 @@ export function DisputeModal({
   correctAnswer,
   teamName,
   submittedAnswer,
+  onDisputeSubmitted,
 }: DisputeModalProps) {
   const [explanation, setExplanation] = useState('');
   const { toast } = useToast();
-  const { markDisputeSubmitted } = useGame();
 
   const handleSubmit = async () => {
     if (!explanation.trim()) {
@@ -65,7 +66,7 @@ export function DisputeModal({
       return;
     }
 
-    markDisputeSubmitted();
+    onDisputeSubmitted();
 
     toast({
       title: 'Dispute Submitted',

--- a/client/src/components/room/RevealView.tsx
+++ b/client/src/components/room/RevealView.tsx
@@ -1,12 +1,14 @@
+import { useState } from 'react';
 import { toast } from 'sonner';
-import { ArrowRight, ExternalLink } from 'lucide-react';
+import { ArrowRight, ExternalLink, Flag } from 'lucide-react';
 import type { UseMutationResult } from '@tanstack/react-query';
-import type { AdvanceRoomResponse, RoomSnapshot } from '@shared/models/rooms';
+import type { AdvanceRoomResponse, RoomActionResponse, RoomSnapshot } from '@shared/models/rooms';
 
 import { isRoomConflict } from '@/hooks/use-room';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { DisputeModal } from '@/components/DisputeModal';
 import { cn, getDifficultyBadgeClass } from '@/lib/utils';
 
 type RevealSnapshot = Extract<RoomSnapshot, { phase: 'REVEAL' }>;
@@ -15,10 +17,17 @@ export interface RevealViewProps {
   snapshot: RevealSnapshot;
   currentPlayerId: string;
   advance: UseMutationResult<AdvanceRoomResponse, Error, void>;
+  awardDispute: UseMutationResult<RoomActionResponse, Error, void>;
   refetch: () => void;
 }
 
-export function RevealView({ snapshot, currentPlayerId, advance, refetch }: RevealViewProps) {
+export function RevealView({
+  snapshot,
+  currentPlayerId,
+  advance,
+  awardDispute,
+  refetch,
+}: RevealViewProps) {
   const attempt = snapshot.currentAttempt;
   const isActive = snapshot.activePlayerId === currentPlayerId;
   const isHost = snapshot.hostPlayerId === currentPlayerId;
@@ -26,6 +35,14 @@ export function RevealView({ snapshot, currentPlayerId, advance, refetch }: Reve
   const answeringPlayer = attempt
     ? snapshot.players.find((player) => player.id === attempt.playerId)
     : undefined;
+
+  const [disputeOpen, setDisputeOpen] = useState(false);
+  const [disputeSubmitted, setDisputeSubmitted] = useState(false);
+
+  // Show dispute button when the attempt is INCORRECT and hasn't been disputed yet
+  const canDispute = attempt?.verdict === 'INCORRECT' && !disputeSubmitted;
+  // Show award-points button after a dispute has been submitted (and points not yet awarded)
+  const canAwardPoints = disputeSubmitted && attempt?.verdict === 'INCORRECT';
 
   function handleNext() {
     if (advance.isPending) return;
@@ -40,6 +57,23 @@ export function RevealView({ snapshot, currentPlayerId, advance, refetch }: Reve
     });
   }
 
+  function handleAwardDisputedPoints() {
+    if (awardDispute.isPending) return;
+    awardDispute.mutate(undefined, {
+      onSuccess: () => {
+        toast.success(`Points awarded to ${answeringPlayer?.nickname || 'player'}.`);
+        setDisputeSubmitted(false);
+      },
+      onError: (error) => {
+        if (isRoomConflict(error)) {
+          refetch();
+          return;
+        }
+        toast.error(error.message || 'Failed to award points.');
+      },
+    });
+  }
+
   return (
     <div className="w-full max-w-lg space-y-4">
       <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
@@ -49,7 +83,10 @@ export function RevealView({ snapshot, currentPlayerId, advance, refetch }: Reve
               {snapshot.currentQuestion.category}
             </Badge>
             <Badge
-              className={cn('border-none', getDifficultyBadgeClass(snapshot.currentQuestion.difficulty))}
+              className={cn(
+                'border-none',
+                getDifficultyBadgeClass(snapshot.currentQuestion.difficulty)
+              )}
             >
               {snapshot.currentQuestion.difficulty}
             </Badge>
@@ -87,8 +124,12 @@ export function RevealView({ snapshot, currentPlayerId, advance, refetch }: Reve
 
           <Card className="bg-primary/10 border-primary/20">
             <CardContent className="p-4 text-center">
-              <div className="text-sm uppercase tracking-widest opacity-70 mb-1">Correct Answer</div>
-              <div className="text-xl font-bold text-primary">{snapshot.currentQuestion.answer}</div>
+              <div className="text-sm uppercase tracking-widest opacity-70 mb-1">
+                Correct Answer
+              </div>
+              <div className="text-xl font-bold text-primary">
+                {snapshot.currentQuestion.answer}
+              </div>
             </CardContent>
           </Card>
         </div>
@@ -112,19 +153,59 @@ export function RevealView({ snapshot, currentPlayerId, advance, refetch }: Reve
         </div>
       )}
 
-      {canAdvance ? (
-        <Button
-          onClick={handleNext}
-          disabled={advance.isPending}
-          className="w-full h-14 text-lg font-bold"
-          data-testid="button-next"
-        >
-          {advance.isPending ? 'Continuing…' : 'Next'} <ArrowRight className="ml-2 w-5 h-5" />
-        </Button>
-      ) : (
-        <p className="text-center text-muted-foreground" data-testid="text-waiting-continue">
-          Waiting to continue…
-        </p>
+      <div className="flex gap-4">
+        {canAdvance ? (
+          <Button
+            onClick={handleNext}
+            disabled={advance.isPending}
+            className="flex-1 h-14 text-lg font-bold"
+            data-testid="button-next"
+          >
+            {advance.isPending ? 'Continuing…' : 'Next'} <ArrowRight className="ml-2 w-5 h-5" />
+          </Button>
+        ) : (
+          <p
+            className="flex-1 text-center text-muted-foreground self-center"
+            data-testid="text-waiting-continue"
+          >
+            Waiting to continue…
+          </p>
+        )}
+
+        {canAwardPoints && (
+          <Button
+            onClick={handleAwardDisputedPoints}
+            disabled={awardDispute.isPending}
+            variant="secondary"
+            className="h-14 px-6 font-bold"
+          >
+            {awardDispute.isPending ? 'Awarding…' : 'Group agreed — award points'}
+          </Button>
+        )}
+
+        {canDispute && (
+          <Button
+            onClick={() => setDisputeOpen(true)}
+            variant="outline"
+            className="h-14 px-6 border-white/20 hover:bg-red-500/10 hover:text-red-500 transition-colors"
+          >
+            <Flag className="w-5 h-5" />
+            <span className="hidden sm:inline ml-2">Dispute</span>
+          </Button>
+        )}
+      </div>
+
+      {attempt && (
+        <DisputeModal
+          open={disputeOpen}
+          onOpenChange={setDisputeOpen}
+          questionId={snapshot.currentQuestion.id}
+          questionText={snapshot.currentQuestion.question}
+          correctAnswer={snapshot.currentQuestion.answer}
+          teamName={answeringPlayer?.nickname || 'Unknown'}
+          submittedAnswer={attempt.submittedAnswer}
+          onDisputeSubmitted={() => setDisputeSubmitted(true)}
+        />
       )}
     </div>
   );

--- a/client/src/hooks/use-room.ts
+++ b/client/src/hooks/use-room.ts
@@ -75,7 +75,10 @@ async function parseResponse<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-async function fetchSnapshot(code: string, sinceVersion: number | undefined): Promise<RoomPollResponse> {
+async function fetchSnapshot(
+  code: string,
+  sinceVersion: number | undefined
+): Promise<RoomPollResponse> {
   const res = await fetch(buildPollUrl(code, sinceVersion), {
     credentials: 'include',
     headers: authHeaders(code),
@@ -103,7 +106,10 @@ function roomQueryKey(code: string) {
 // Never let a write (poll or mutation response) regress the cache to an
 // older version — the two can race, since polls and mutations both hit the
 // network concurrently and settle in whatever order the server responds.
-export function newerSnapshot(candidate: RoomSnapshot, current: RoomSnapshot | undefined): RoomSnapshot {
+export function newerSnapshot(
+  candidate: RoomSnapshot,
+  current: RoomSnapshot | undefined
+): RoomSnapshot {
   return current && current.version >= candidate.version ? current : candidate;
 }
 
@@ -120,6 +126,7 @@ export interface UseRoomResult {
   continueRound: UseMutationResult<ContinueRoomResponse, Error, void>;
   skip: UseMutationResult<SkipRoomResponse, Error, void>;
   end: UseMutationResult<EndRoomResponse, Error, void>;
+  awardDispute: UseMutationResult<RoomActionResponse, Error, void>;
 }
 
 export interface UseRoomOptions {
@@ -175,7 +182,9 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
 
   const onActionSuccess = useCallback(
     (response: RoomActionResponse) => {
-      queryClient.setQueryData<RoomSnapshot>(queryKey, (current) => newerSnapshot(response.snapshot, current));
+      queryClient.setQueryData<RoomSnapshot>(queryKey, (current) =>
+        newerSnapshot(response.snapshot, current)
+      );
     },
     [queryClient, queryKey]
   );
@@ -185,7 +194,9 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
       postRoomAction<JoinRoomRequest, JoinRoomResponse>(code, 'join', body),
     onSuccess: (response) => {
       saveRoomSession({ code, playerId: response.playerId, token: response.token });
-      queryClient.setQueryData<RoomSnapshot>(queryKey, (current) => newerSnapshot(response.snapshot, current));
+      queryClient.setQueryData<RoomSnapshot>(queryKey, (current) =>
+        newerSnapshot(response.snapshot, current)
+      );
     },
   });
 
@@ -201,12 +212,14 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
   });
 
   const advance = useMutation({
-    mutationFn: () => postRoomAction<Record<string, never>, AdvanceRoomResponse>(code, 'advance', {}),
+    mutationFn: () =>
+      postRoomAction<Record<string, never>, AdvanceRoomResponse>(code, 'advance', {}),
     onSuccess: onActionSuccess,
   });
 
   const continueRound = useMutation({
-    mutationFn: () => postRoomAction<Record<string, never>, ContinueRoomResponse>(code, 'continue', {}),
+    mutationFn: () =>
+      postRoomAction<Record<string, never>, ContinueRoomResponse>(code, 'continue', {}),
     onSuccess: onActionSuccess,
   });
 
@@ -217,6 +230,12 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
 
   const end = useMutation({
     mutationFn: () => postRoomAction<Record<string, never>, EndRoomResponse>(code, 'end', {}),
+    onSuccess: onActionSuccess,
+  });
+
+  const awardDispute = useMutation({
+    mutationFn: () =>
+      postRoomAction<Record<string, never>, RoomActionResponse>(code, 'award-dispute', {}),
     onSuccess: onActionSuccess,
   });
 
@@ -233,5 +252,6 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
     continueRound,
     skip,
     end,
+    awardDispute,
   };
 }

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -24,6 +24,7 @@ export default function Game() {
     submitAnswer,
     passQuestion,
     awardDisputedPoints,
+    markDisputeSubmitted,
     advanceToScoreUpdate,
     continueToNextRound,
     endGame,
@@ -42,7 +43,9 @@ export default function Game() {
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="text-center space-y-4">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
-          <p className="text-muted-foreground" data-testid="text-loading-game">Loading game...</p>
+          <p className="text-muted-foreground" data-testid="text-loading-game">
+            Loading game...
+          </p>
         </div>
       </div>
     );
@@ -100,7 +103,9 @@ export default function Game() {
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="text-center space-y-4">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
-          <p className="text-muted-foreground" data-testid="text-loading-questions">Loading questions...</p>
+          <p className="text-muted-foreground" data-testid="text-loading-questions">
+            Loading questions...
+          </p>
         </div>
       </div>
     );
@@ -389,6 +394,7 @@ export default function Game() {
                     correctAnswer={currentQ?.answer || ''}
                     teamName={activeTeam?.name || 'Unknown'}
                     submittedAnswer={state.currentAttempt?.submittedAnswer || null}
+                    onDisputeSubmitted={markDisputeSubmitted}
                   />
                 </motion.div>
               )}

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -32,6 +32,7 @@ export default function Room() {
     continueRound,
     skip,
     end,
+    awardDispute,
     refetch,
   } = useRoom(code, { enabled: !!session });
 
@@ -167,6 +168,7 @@ export default function Room() {
               snapshot={snapshot}
               currentPlayerId={session.playerId}
               advance={advance}
+              awardDispute={awardDispute}
               refetch={refetch}
             />
           )}

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -6,7 +6,11 @@ import { z } from 'zod';
 import { db } from './db';
 import { advanceRoomEngine, createRoomAttempt } from './lib/room-engine';
 import type { AuthenticatedRequest } from './types';
-import { QUESTIONS_PER_TEAM_ROTATION, type Question as AnswerQuestion } from '@shared/lib/answers';
+import {
+  QUESTIONS_PER_TEAM_ROTATION,
+  pointsFor,
+  type Question as AnswerQuestion,
+} from '@shared/lib/answers';
 import {
   advanceRoomRequestSchema,
   advanceRoomResponseSchema,
@@ -31,6 +35,7 @@ import {
   startRoomResponseSchema,
   skipRoomRequestSchema,
   skipRoomResponseSchema,
+  roomActionResponseSchema,
   unchangedRoomPollResponseSchema,
   type Question,
   type Room,
@@ -858,6 +863,82 @@ export function registerRoomRoutes(app: Express): void {
       );
     } catch (error) {
       return sendRoomError(res, error, 'Error skipping room turn:');
+    }
+  });
+
+  // Award disputed points — flips an INCORRECT attempt to CORRECT and credits the player
+  app.post('/api/rooms/:code/award-dispute', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+        if (!room) {
+          throw new RoomRouteError(404, 'Room not found');
+        }
+        if (isExpired(room)) {
+          throw new RoomRouteError(404, 'Room expired');
+        }
+        if (room.phase !== 'REVEAL' || room.status !== 'active') {
+          throw new RoomRouteError(409, 'Room is not in the reveal phase');
+        }
+        if (!room.currentAttempt || room.currentAttempt.verdict !== 'INCORRECT') {
+          throw new RoomRouteError(409, 'No incorrect attempt to award points for');
+        }
+
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        if (actor.id !== room.hostPlayerId && actor.id !== room.activePlayerId) {
+          throw new RoomRouteError(403, 'Only the host or active player can award disputed points');
+        }
+
+        // Look up the question to calculate the correct point value
+        const questionId = room.currentAttempt.questionId;
+        const [question] = await tx
+          .select()
+          .from(questions)
+          .where(eq(questions.id, questionId))
+          .limit(1);
+        if (!question) {
+          throw new Error(`Question ${questionId} not found`);
+        }
+
+        // Calculate the correct point value for the disputed question
+        const correctPoints = pointsFor(
+          question.difficulty as import('@shared/lib/answers').Difficulty
+        );
+
+        const updatedAttempt = {
+          ...room.currentAttempt,
+          verdict: 'CORRECT' as const,
+          pointsDelta: correctPoints,
+        };
+
+        const [awardedRoom] = await tx
+          .update(rooms)
+          .set({
+            currentAttempt: updatedAttempt,
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(rooms.id, room.id), eq(rooms.status, 'active'), eq(rooms.phase, 'REVEAL')))
+          .returning();
+        if (!awardedRoom) {
+          throw new RoomRouteError(409, 'Room state changed before points could be awarded');
+        }
+
+        return awardedRoom;
+      });
+
+      return res.json(
+        roomActionResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error awarding disputed points:');
     }
   });
 


### PR DESCRIPTION
The dispute button and point-awarding mechanism existed in solo mode (Game.tsx) but were never added to the multiplayer RevealView. This PR adds the same UX flow to multiplayer: a flag button on INCORRECT verdicts, the DisputeModal for submitting disputes to the admin review queue, and a 'Group agreed — award points' button that updates scores server-side via a new POST /api/rooms/:code/award-dispute endpoint. The DisputeModal was refactored to accept a required onDisputeSubmitted callback, removing its dependency on the solo game store (useGame) so it works in any context.