### PR TITLE
fix(shared): tolerate single-typo answers in fuzzy matching [STE-237]

### DIFF
--- a/shared/lib/answers.test.ts
+++ b/shared/lib/answers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalize, verifyAttempt, pointsFor, QUESTIONS_PER_TEAM_ROTATION } from './answers';
+import { normalize, verifyAttempt, pointsFor, damerauLevenshtein, QUESTIONS_PER_TEAM_ROTATION } from './answers';
 import type { Question } from './answers';
 
 function makeQuestion(overrides: Partial<Question> = {}): Question {
@@ -106,6 +106,95 @@ describe('verifyAttempt', () => {
     const q = makeQuestion({ answer: 'Go', difficulty: 'Easy' });
     expect(verifyAttempt('Go', q).verdict).toBe('CORRECT');
     expect(verifyAttempt('Go', q).points).toBe(1);
+  });
+});
+
+describe('damerauLevenshtein', () => {
+  it('returns 0 for identical strings', () => {
+    expect(damerauLevenshtein('abc', 'abc')).toBe(0);
+  });
+
+  it('handles single substitution', () => {
+    expect(damerauLevenshtein('cat', 'bat')).toBe(1);
+  });
+
+  it('handles single insertion', () => {
+    expect(damerauLevenshtein('cat', 'cats')).toBe(1);
+  });
+
+  it('handles single deletion', () => {
+    expect(damerauLevenshtein('cats', 'cat')).toBe(1);
+  });
+
+  it('handles adjacent transposition', () => {
+    expect(damerauLevenshtein('ab', 'ba')).toBe(1);
+    expect(damerauLevenshtein('swift', 'swfit')).toBe(1);
+  });
+
+  it('returns string length when compared with empty string', () => {
+    expect(damerauLevenshtein('abc', '')).toBe(3);
+    expect(damerauLevenshtein('', 'xyz')).toBe(3);
+  });
+});
+
+describe('verifyAttempt — edit-distance typo tolerance (STE-237)', () => {
+  it('accepts "ottowa" for "ottawa" (single substitution, len 6)', () => {
+    const q = makeQuestion({ answer: 'Ottawa', difficulty: 'Medium' });
+    expect(verifyAttempt('ottowa', q).verdict).toBe('CORRECT');
+  });
+
+  it('accepts "emenem" for "eminem" (transposition, len 6)', () => {
+    const q = makeQuestion({ answer: 'Eminem', difficulty: 'Medium' });
+    expect(verifyAttempt('emenem', q).verdict).toBe('CORRECT');
+  });
+
+  it('accepts "taylor swfit" for "taylor swift" (transposition, len 12)', () => {
+    const q = makeQuestion({ answer: 'Taylor Swift', difficulty: 'Medium' });
+    expect(verifyAttempt('taylor swfit', q).verdict).toBe('CORRECT');
+  });
+
+  it('accepts "zendya" for "zendaya" (deletion, len 7)', () => {
+    const q = makeQuestion({ answer: 'Zendaya', difficulty: 'Medium' });
+    expect(verifyAttempt('zendya', q).verdict).toBe('CORRECT');
+  });
+
+  it('still accepts "obamma" for "obama" (Dice ≥0.8)', () => {
+    const q = makeQuestion({ answer: 'Obama', difficulty: 'Medium' });
+    expect(verifyAttempt('obamma', q).verdict).toBe('CORRECT');
+  });
+
+  it('still accepts "the weekend" for "the weeknd" (Dice ≥0.8)', () => {
+    const q = makeQuestion({ answer: 'The Weeknd', difficulty: 'Medium' });
+    expect(verifyAttempt('the weekend', q).verdict).toBe('CORRECT');
+  });
+});
+
+describe('verifyAttempt — numeric guardrail (STE-237)', () => {
+  it('rejects "1998" when answer is "1997" (numeric exact-match only)', () => {
+    const q = makeQuestion({ answer: '1997', difficulty: 'Medium' });
+    expect(verifyAttempt('1998', q).verdict).toBe('INCORRECT');
+  });
+
+  it('accepts exact numeric match', () => {
+    const q = makeQuestion({ answer: '1997', difficulty: 'Medium' });
+    expect(verifyAttempt('1997', q).verdict).toBe('CORRECT');
+  });
+
+  it('rejects "42" when answer is "43" (short numeric)', () => {
+    const q = makeQuestion({ answer: '43', difficulty: 'Easy' });
+    expect(verifyAttempt('42', q).verdict).toBe('INCORRECT');
+  });
+});
+
+describe('verifyAttempt — wrong answers stay rejected (STE-237)', () => {
+  it('rejects "fire" when answer is "water"', () => {
+    const q = makeQuestion({ answer: 'Water', difficulty: 'Medium' });
+    expect(verifyAttempt('fire', q).verdict).toBe('INCORRECT');
+  });
+
+  it('rejects totally different multi-word answers', () => {
+    const q = makeQuestion({ answer: 'Niagara Falls', difficulty: 'Easy' });
+    expect(verifyAttempt('Rocky Mountains', q).verdict).toBe('INCORRECT');
   });
 });
 

--- a/shared/lib/answers.test.ts
+++ b/shared/lib/answers.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { normalize, verifyAttempt, pointsFor, damerauLevenshtein, QUESTIONS_PER_TEAM_ROTATION } from './answers';
+import {
+  normalize,
+  verifyAttempt,
+  pointsFor,
+  damerauLevenshtein,
+  QUESTIONS_PER_TEAM_ROTATION,
+} from './answers';
 import type { Question } from './answers';
 
 function makeQuestion(overrides: Partial<Question> = {}): Question {
@@ -166,6 +172,14 @@ describe('verifyAttempt — edit-distance typo tolerance (STE-237)', () => {
   it('still accepts "the weekend" for "the weeknd" (Dice ≥0.8)', () => {
     const q = makeQuestion({ answer: 'The Weeknd', difficulty: 'Medium' });
     expect(verifyAttempt('the weekend', q).verdict).toBe('CORRECT');
+  });
+
+  it('rejects a wildly oversized input without hanging (length-diff guard)', () => {
+    const q = makeQuestion({ answer: 'Ottawa', difficulty: 'Medium' });
+    const hugeInput = 'a'.repeat(50_000);
+    const start = Date.now();
+    expect(verifyAttempt(hugeInput, q).verdict).toBe('INCORRECT');
+    expect(Date.now() - start).toBeLessThan(1000);
   });
 });
 

--- a/shared/lib/answers.ts
+++ b/shared/lib/answers.ts
@@ -11,9 +11,7 @@ export const damerauLevenshtein = (a: string, b: string): number => {
   if (la === 0) return lb;
   if (lb === 0) return la;
 
-  const d: number[][] = Array.from({ length: la + 1 }, () =>
-    new Array<number>(lb + 1).fill(0)
-  );
+  const d: number[][] = Array.from({ length: la + 1 }, () => new Array<number>(lb + 1).fill(0));
 
   for (let i = 0; i <= la; i++) d[i][0] = i;
   for (let j = 0; j <= lb; j++) d[0][j] = j;
@@ -22,17 +20,12 @@ export const damerauLevenshtein = (a: string, b: string): number => {
     for (let j = 1; j <= lb; j++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1;
       d[i][j] = Math.min(
-        d[i - 1][j] + 1,       // deletion
-        d[i][j - 1] + 1,       // insertion
+        d[i - 1][j] + 1, // deletion
+        d[i][j - 1] + 1, // insertion
         d[i - 1][j - 1] + cost // substitution
       );
       // transposition
-      if (
-        i > 1 &&
-        j > 1 &&
-        a[i - 1] === b[j - 2] &&
-        a[i - 2] === b[j - 1]
-      ) {
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
         d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
       }
     }
@@ -126,6 +119,10 @@ export const verifyAttempt = (
         const refLen = target.length;
         const threshold = maxDist(refLen);
         if (threshold === null) continue;
+        // Edit distance is always >= the length difference, so a mismatch
+        // beyond the threshold can't pass — skip before allocating the
+        // O(len(normInput) * len(target)) matrix.
+        if (Math.abs(normInput.length - refLen) > threshold) continue;
         if (damerauLevenshtein(normInput, target) <= threshold) {
           isCorrect = true;
           break;

--- a/shared/lib/answers.ts
+++ b/shared/lib/answers.ts
@@ -1,5 +1,45 @@
 import stringSimilarity from 'string-similarity';
 
+/**
+ * Damerau–Levenshtein distance (optimal string alignment variant).
+ * Handles insertions, deletions, substitutions, and adjacent transpositions.
+ * Inline to avoid adding an npm dependency.
+ */
+export const damerauLevenshtein = (a: string, b: string): number => {
+  const la = a.length;
+  const lb = b.length;
+  if (la === 0) return lb;
+  if (lb === 0) return la;
+
+  const d: number[][] = Array.from({ length: la + 1 }, () =>
+    new Array<number>(lb + 1).fill(0)
+  );
+
+  for (let i = 0; i <= la; i++) d[i][0] = i;
+  for (let j = 0; j <= lb; j++) d[0][j] = j;
+
+  for (let i = 1; i <= la; i++) {
+    for (let j = 1; j <= lb; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      d[i][j] = Math.min(
+        d[i - 1][j] + 1,       // deletion
+        d[i][j - 1] + 1,       // insertion
+        d[i - 1][j - 1] + cost // substitution
+      );
+      // transposition
+      if (
+        i > 1 &&
+        j > 1 &&
+        a[i - 1] === b[j - 2] &&
+        a[i - 2] === b[j - 1]
+      ) {
+        d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
+      }
+    }
+  }
+  return d[la][lb];
+};
+
 export type Difficulty = 'Easy' | 'Medium' | 'Hard';
 
 export interface Question {
@@ -49,16 +89,44 @@ export const verifyAttempt = (
   // Exact match first
   let isCorrect = normInput === normCorrect || acceptable.includes(normInput);
 
-  // Fuzzy match if not exact
-  if (!isCorrect && normInput.length > 2) {
+  // Numeric guardrail: if the correct answer is purely digits, require exact match only.
+  // Years (1997), counts, etc. must not fuzzy-match neighbouring numbers.
+  const isNumericAnswer = /^\d+$/.test(normCorrect);
+
+  // Fuzzy match if not exact and not a numeric answer
+  if (!isCorrect && normInput.length > 2 && !isNumericAnswer) {
+    // --- Dice coefficient check (existing) ---
     const similarity = stringSimilarity.compareTwoStrings(normInput, normCorrect);
     // 0.8 is a good threshold for typos but enough to prevent wild guesses
     if (similarity > 0.8) isCorrect = true;
 
-    // Check acceptable variants with fuzzy logic too
+    // Check acceptable variants with Dice too
     if (!isCorrect) {
       for (const variant of acceptable) {
         if (stringSimilarity.compareTwoStrings(normInput, variant) > 0.8) {
+          isCorrect = true;
+          break;
+        }
+      }
+    }
+
+    // --- Damerau–Levenshtein edit-distance check (new) ---
+    // Covers single-typo / transposition cases that Dice misses on short strings.
+    // Length 3–4: skip (edit distance 1 on very short words is too permissive).
+    // Length 5–8: accept distance ≤ 1.  Length ≥ 9: accept distance ≤ 2.
+    if (!isCorrect) {
+      const allTargets = [normCorrect, ...acceptable];
+      const maxDist = (len: number): number | null => {
+        if (len <= 4) return null; // skip — Dice handles 3–4
+        if (len <= 8) return 1;
+        return 2;
+      };
+
+      for (const target of allTargets) {
+        const refLen = target.length;
+        const threshold = maxDist(refLen);
+        if (threshold === null) continue;
+        if (damerauLevenshtein(normInput, target) <= threshold) {
           isCorrect = true;
           break;
         }


### PR DESCRIPTION
## Summary
- Add an inline Damerau–Levenshtein edit-distance check alongside the existing Dice coefficient check in `verifyAttempt` — accept if either method passes
- Length ≤ 2: exact match only (unchanged); length 3–4: Dice only (unchanged); length 5–8: accept distance ≤ 1; length ≥ 9: accept distance ≤ 2
- Numeric guardrail: purely-digit correct answers (years, counts) skip all fuzzy matching and require an exact match, so "1998" never matches "1997"

Fixes single-typo answers like "ottowa" → "ottawa" (Dice 0.600) and "taylor swfit" → "taylor swift" (Dice 0.700) that were previously scored INCORRECT.

## Test plan
- [x] `npm test` — 430/430 passing, including new edit-distance and numeric-guardrail cases in `shared/lib/answers.test.ts`
- [x] Verified existing Dice-only cases ("obamma"→"obama", "the weekend"→"the weeknd") still pass
- [x] Verified negative cases stay INCORRECT ("1998" vs "1997", "fire" vs "water", "rocky mountains" vs "niagara falls")

Fixes STE-237.