### PR TITLE
fix(client): prevent guest cross-game question repeats [STE-235]

### DIFF
--- a/client/src/components/room/Lobby.test.tsx
+++ b/client/src/components/room/Lobby.test.tsx
@@ -5,13 +5,34 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { UseMutationResult } from '@tanstack/react-query';
 
 import { Lobby } from './Lobby';
-import type { EndRoomResponse, RoomSnapshot, StartRoomResponse } from '@shared/models/rooms';
+import { addGuestSeenIds } from '@/lib/guest-seen';
+import type {
+  EndRoomResponse,
+  RoomSnapshot,
+  StartRoomRequest,
+  StartRoomResponse,
+} from '@shared/models/rooms';
 
 vi.mock('wouter', () => ({
   Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
     <a href={href}>{children}</a>
   ),
 }));
+
+// Stub localStorage for jsdom compatibility
+const storage: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage[key] ?? null,
+  setItem: (key: string, value: string) => {
+    storage[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete storage[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(storage)) delete storage[key];
+  },
+});
 
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
@@ -78,6 +99,7 @@ describe('Lobby', () => {
   beforeEach(() => {
     toastSuccess.mockClear();
     toastError.mockClear();
+    localStorage.clear();
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
@@ -95,7 +117,7 @@ describe('Lobby', () => {
       <Lobby
         snapshot={snapshot}
         currentPlayerId="host-1"
-        start={makeMutation<StartRoomResponse, void>()}
+        start={makeMutation<StartRoomResponse, StartRoomRequest>()}
         end={makeMutation<EndRoomResponse, void>()}
       />
     );
@@ -115,7 +137,7 @@ describe('Lobby', () => {
       <Lobby
         snapshot={snapshot}
         currentPlayerId="host-1"
-        start={makeMutation<StartRoomResponse, void>()}
+        start={makeMutation<StartRoomResponse, StartRoomRequest>()}
         end={makeMutation<EndRoomResponse, void>()}
       />
     );
@@ -134,7 +156,7 @@ describe('Lobby', () => {
       <Lobby
         snapshot={snapshot}
         currentPlayerId="host-1"
-        start={makeMutation<StartRoomResponse, void>()}
+        start={makeMutation<StartRoomResponse, StartRoomRequest>()}
         end={makeMutation<EndRoomResponse, void>()}
       />
     );
@@ -148,7 +170,7 @@ describe('Lobby', () => {
       <Lobby
         snapshot={snapshot}
         currentPlayerId="host-1"
-        start={makeMutation<StartRoomResponse, void>()}
+        start={makeMutation<StartRoomResponse, StartRoomRequest>()}
         end={makeMutation<EndRoomResponse, void>()}
       />
     );
@@ -164,7 +186,7 @@ describe('Lobby', () => {
       <Lobby
         snapshot={snapshot}
         currentPlayerId="guest-1"
-        start={makeMutation<StartRoomResponse, void>()}
+        start={makeMutation<StartRoomResponse, StartRoomRequest>()}
         end={makeMutation<EndRoomResponse, void>()}
       />
     );
@@ -180,7 +202,7 @@ describe('Lobby', () => {
       <Lobby
         snapshot={snapshot}
         currentPlayerId="host-1"
-        start={makeMutation<StartRoomResponse, void>()}
+        start={makeMutation<StartRoomResponse, StartRoomRequest>()}
         end={makeMutation<EndRoomResponse, void>()}
       />
     );
@@ -195,13 +217,39 @@ describe('Lobby', () => {
     await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
   });
 
+  it('sends the locally-seen guest question ids when starting the game', async () => {
+    addGuestSeenIds(['q1', 'q2']);
+    const snapshot = makeSnapshot({
+      players: [
+        makePlayer({ id: 'host-1' }),
+        makePlayer({ id: 'p2', isHost: false, joinOrder: 1 }),
+      ],
+    });
+    const start = makeMutation<StartRoomResponse, StartRoomRequest>();
+    render(
+      <Lobby
+        snapshot={snapshot}
+        currentPlayerId="host-1"
+        start={start}
+        end={makeMutation<EndRoomResponse, void>()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('button-start-game'));
+
+    expect(start.mutate).toHaveBeenCalledWith(
+      { excludeQuestionIds: ['q1', 'q2'] },
+      expect.anything()
+    );
+  });
+
   it('shows a closed message with a link home when the room is no longer in the lobby status', () => {
     const snapshot = makeSnapshot({ status: 'abandoned' });
     render(
       <Lobby
         snapshot={snapshot}
         currentPlayerId="guest-1"
-        start={makeMutation<StartRoomResponse, void>()}
+        start={makeMutation<StartRoomResponse, StartRoomRequest>()}
         end={makeMutation<EndRoomResponse, void>()}
       />
     );

--- a/client/src/components/room/Lobby.tsx
+++ b/client/src/components/room/Lobby.tsx
@@ -2,18 +2,25 @@ import { Link } from 'wouter';
 import { toast } from 'sonner';
 import { Copy, DoorOpen, Play } from 'lucide-react';
 import type { UseMutationResult } from '@tanstack/react-query';
-import { MAX_PLAYERS, type EndRoomResponse, type RoomSnapshot, type StartRoomResponse } from '@shared/models/rooms';
+import {
+  MAX_PLAYERS,
+  type EndRoomResponse,
+  type RoomSnapshot,
+  type StartRoomRequest,
+  type StartRoomResponse,
+} from '@shared/models/rooms';
 
 import { PlayerRoster } from './PlayerRoster';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { getGuestSeenIds } from '@/lib/guest-seen';
 
 type LobbySnapshot = Extract<RoomSnapshot, { phase: 'LOBBY' }>;
 
 export interface LobbyProps {
   snapshot: LobbySnapshot;
   currentPlayerId: string;
-  start: UseMutationResult<StartRoomResponse, Error, void>;
+  start: UseMutationResult<StartRoomResponse, Error, StartRoomRequest>;
   end: UseMutationResult<EndRoomResponse, Error, void>;
 }
 
@@ -34,9 +41,12 @@ export function Lobby({ snapshot, currentPlayerId, start, end }: LobbyProps) {
 
   const handleStart = () => {
     if (!canStart || start.isPending) return;
-    start.mutate(undefined, {
-      onError: (error) => toast.error(error.message || 'Failed to start game. Please try again.'),
-    });
+    start.mutate(
+      { excludeQuestionIds: getGuestSeenIds() },
+      {
+        onError: (error) => toast.error(error.message || 'Failed to start game. Please try again.'),
+      }
+    );
   };
 
   const handleClose = () => {

--- a/client/src/hooks/use-record-guest-room-question.test.ts
+++ b/client/src/hooks/use-record-guest-room-question.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRecordGuestRoomQuestion } from './use-record-guest-room-question';
+import { getGuestSeenIds } from '@/lib/guest-seen';
+
+// Stub localStorage for jsdom compatibility
+const storage: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage[key] ?? null,
+  setItem: (key: string, value: string) => {
+    storage[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete storage[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(storage)) delete storage[key];
+  },
+});
+
+describe('useRecordGuestRoomQuestion', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('records the displayed question for a guest', () => {
+    renderHook(() => useRecordGuestRoomQuestion('q1', false, false));
+    expect(getGuestSeenIds()).toEqual(['q1']);
+  });
+
+  it('does not record while auth status is still loading', () => {
+    renderHook(() => useRecordGuestRoomQuestion('q1', false, true));
+    expect(getGuestSeenIds()).toEqual([]);
+  });
+
+  it('does not record for a signed-in player', () => {
+    renderHook(() => useRecordGuestRoomQuestion('q1', true, false));
+    expect(getGuestSeenIds()).toEqual([]);
+  });
+
+  it('does not record when there is no question id yet', () => {
+    renderHook(() => useRecordGuestRoomQuestion(undefined, false, false));
+    expect(getGuestSeenIds()).toEqual([]);
+  });
+
+  it('records a new question id when it changes, without re-recording the same one', () => {
+    const { rerender } = renderHook(
+      ({ questionId }) => useRecordGuestRoomQuestion(questionId, false, false),
+      { initialProps: { questionId: 'q1' } }
+    );
+    expect(getGuestSeenIds()).toEqual(['q1']);
+
+    rerender({ questionId: 'q1' });
+    expect(getGuestSeenIds()).toEqual(['q1']);
+
+    rerender({ questionId: 'q2' });
+    expect(getGuestSeenIds()).toEqual(['q1', 'q2']);
+  });
+
+  it('starts recording once auth resolves to guest after a loading state', () => {
+    const { rerender } = renderHook(
+      ({ authLoading }) => useRecordGuestRoomQuestion('q1', false, authLoading),
+      { initialProps: { authLoading: true } }
+    );
+    expect(getGuestSeenIds()).toEqual([]);
+
+    rerender({ authLoading: false });
+    expect(getGuestSeenIds()).toEqual(['q1']);
+  });
+});

--- a/client/src/hooks/use-record-guest-room-question.ts
+++ b/client/src/hooks/use-record-guest-room-question.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+import { addGuestSeenIds } from '@/lib/guest-seen';
+
+// Records each room question a guest client actually sees, so consecutive
+// guest games in this browser (hosted or joined) avoid repeats. Skips
+// while auth status is still resolving so a guest is never misclassified,
+// and skips entirely for signed-in players (server history covers them).
+export function useRecordGuestRoomQuestion(
+  questionId: string | null | undefined,
+  isAuthenticated: boolean,
+  authLoading: boolean
+): void {
+  const lastRecordedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (authLoading || isAuthenticated) return;
+    if (!questionId) return;
+    if (lastRecordedId.current === questionId) return;
+    lastRecordedId.current = questionId;
+    addGuestSeenIds([questionId]);
+  }, [questionId, isAuthenticated, authLoading]);
+}

--- a/client/src/hooks/use-room.ts
+++ b/client/src/hooks/use-room.ts
@@ -19,6 +19,7 @@ import type {
   RoomPollResponse,
   RoomSnapshot,
   SkipRoomResponse,
+  StartRoomRequest,
   StartRoomResponse,
 } from '@shared/models/rooms';
 
@@ -120,7 +121,7 @@ export interface UseRoomResult {
   error: Error | null;
   refetch: UseQueryResult<RoomSnapshot, Error>['refetch'];
   join: UseMutationResult<JoinRoomResponse, Error, JoinRoomRequest>;
-  start: UseMutationResult<StartRoomResponse, Error, void>;
+  start: UseMutationResult<StartRoomResponse, Error, StartRoomRequest>;
   answer: UseMutationResult<AnswerRoomResponse, Error, AnswerRoomRequest>;
   advance: UseMutationResult<AdvanceRoomResponse, Error, void>;
   continueRound: UseMutationResult<ContinueRoomResponse, Error, void>;
@@ -201,7 +202,8 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
   });
 
   const start = useMutation({
-    mutationFn: () => postRoomAction<Record<string, never>, StartRoomResponse>(code, 'start', {}),
+    mutationFn: (body: StartRoomRequest = {}) =>
+      postRoomAction<StartRoomRequest, StartRoomResponse>(code, 'start', body),
     onSuccess: onActionSuccess,
   });
 

--- a/client/src/lib/guest-seen.test.ts
+++ b/client/src/lib/guest-seen.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getGuestSeenIds, addGuestSeenIds } from './guest-seen';
+
+const storage: Record<string, string> = {};
+
+function stubWorkingLocalStorage() {
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+    clear: () => {
+      for (const key of Object.keys(storage)) delete storage[key];
+    },
+  });
+}
+
+describe('guest-seen', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(storage)) delete storage[key];
+    stubWorkingLocalStorage();
+  });
+
+  it('returns an empty array when nothing has been seen', () => {
+    expect(getGuestSeenIds()).toEqual([]);
+  });
+
+  it('adds and retrieves seen ids', () => {
+    addGuestSeenIds(['q1', 'q2']);
+    expect(getGuestSeenIds()).toEqual(['q1', 'q2']);
+  });
+
+  it('appends new ids after existing ones', () => {
+    addGuestSeenIds(['q1', 'q2']);
+    addGuestSeenIds(['q3']);
+    expect(getGuestSeenIds()).toEqual(['q1', 'q2', 'q3']);
+  });
+
+  it('moves a re-seen id to the newest position instead of duplicating it', () => {
+    addGuestSeenIds(['q1', 'q2', 'q3']);
+    addGuestSeenIds(['q1']);
+    expect(getGuestSeenIds()).toEqual(['q2', 'q3', 'q1']);
+  });
+
+  it('does nothing when given an empty array', () => {
+    addGuestSeenIds(['q1']);
+    addGuestSeenIds([]);
+    expect(getGuestSeenIds()).toEqual(['q1']);
+  });
+
+  it('evicts the oldest ids once the cap of 500 is exceeded (FIFO)', () => {
+    const first500 = Array.from({ length: 500 }, (_, i) => `q${i}`);
+    addGuestSeenIds(first500);
+    expect(getGuestSeenIds()).toHaveLength(500);
+
+    addGuestSeenIds(['q500', 'q501']);
+    const result = getGuestSeenIds();
+
+    expect(result).toHaveLength(500);
+    // Oldest two (q0, q1) should have been evicted to make room.
+    expect(result).not.toContain('q0');
+    expect(result).not.toContain('q1');
+    // Newest entries should be present.
+    expect(result).toContain('q500');
+    expect(result).toContain('q501');
+    expect(result[result.length - 1]).toBe('q501');
+  });
+
+  it('degrades gracefully to a no-op when localStorage is unavailable', () => {
+    vi.stubGlobal('localStorage', undefined);
+
+    expect(() => getGuestSeenIds()).not.toThrow();
+    expect(getGuestSeenIds()).toEqual([]);
+
+    expect(() => addGuestSeenIds(['q1'])).not.toThrow();
+    expect(getGuestSeenIds()).toEqual([]);
+  });
+
+  it('resets to empty when stored JSON is malformed', () => {
+    storage['modern-trivia:guest-seen:v1'] = '{not valid json';
+    expect(getGuestSeenIds()).toEqual([]);
+
+    // Should still be able to write fresh history afterward.
+    addGuestSeenIds(['q1']);
+    expect(getGuestSeenIds()).toEqual(['q1']);
+  });
+
+  it('trims whitespace and drops empty/duplicate ids within a single call', () => {
+    addGuestSeenIds([' q1 ', 'q2', 'q2', '  ', 'q1']);
+    expect(getGuestSeenIds()).toEqual(['q1', 'q2']);
+  });
+
+  it('degrades gracefully when localStorage throws (e.g. private browsing quota)', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('SecurityError');
+      },
+      setItem: () => {
+        throw new Error('QuotaExceededError');
+      },
+      removeItem: () => {},
+      clear: () => {},
+    });
+
+    expect(() => getGuestSeenIds()).not.toThrow();
+    expect(getGuestSeenIds()).toEqual([]);
+    expect(() => addGuestSeenIds(['q1'])).not.toThrow();
+  });
+});

--- a/client/src/lib/guest-seen.ts
+++ b/client/src/lib/guest-seen.ts
@@ -1,0 +1,63 @@
+// Client-only "seen questions" tracking for non-signed-in players. Signed-in
+// users get server-side exclusion via the seen_questions table; guests get
+// this localStorage-backed equivalent so they don't see repeat questions
+// across separate games on the same browser.
+
+const STORAGE_KEY = 'modern-trivia:guest-seen:v1';
+const MAX_SEEN_IDS = 500;
+
+function normalizeIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of ids) {
+    const id = typeof raw === 'string' ? raw.trim() : '';
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
+function getStorage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getGuestSeenIds(): string[] {
+  const storage = getStorage();
+  if (!storage) return [];
+
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return normalizeIds(parsed.filter((id): id is string => typeof id === 'string'));
+  } catch {
+    // Malformed JSON or any other parse failure — degrade to empty history.
+    return [];
+  }
+}
+
+export function addGuestSeenIds(ids: string[]): void {
+  const incomingIds = normalizeIds(ids);
+  if (incomingIds.length === 0) return;
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    const existing = getGuestSeenIds();
+    const incoming = new Set(incomingIds);
+    // Move re-seen ids to the newest position instead of duplicating them.
+    const merged = [...existing.filter((id) => !incoming.has(id)), ...incomingIds];
+    const capped =
+      merged.length > MAX_SEEN_IDS ? merged.slice(merged.length - MAX_SEEN_IDS) : merged;
+    storage.setItem(STORAGE_KEY, JSON.stringify(capped));
+  } catch {
+    // localStorage unavailable (private browsing) or quota exceeded — degrade silently.
+  }
+}

--- a/client/src/lib/store.test.tsx
+++ b/client/src/lib/store.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GameProvider, useGame, normalize, verifyAttempt } from './store';
 import type { Question } from './store';
+import { getGuestSeenIds, addGuestSeenIds } from './guest-seen';
 
 // Stub localStorage for jsdom compatibility
 const storage: Record<string, string> = {};
@@ -123,6 +124,7 @@ async function setupAndStart(opts?: {
   category?: string;
   numRounds?: number;
   teamNames?: string[];
+  isAuthenticated?: boolean;
 }) {
   const hook = await renderGame();
   const { result } = hook;
@@ -141,10 +143,15 @@ async function setupAndStart(opts?: {
 
   // startGame is async (fetches from API)
   await act(async () => {
-    await result.current.startGame();
+    await result.current.startGame(opts?.isAuthenticated ?? false);
   });
 
   return hook;
+}
+
+function fetchUrlOf(call: unknown[]): string {
+  const input = call[0] as string | URL | Request;
+  return typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 }
 
 /** Submit a typed answer and advance through REVEAL → SCORE_UPDATE for one question. */
@@ -409,8 +416,9 @@ describe('GameProvider state machine', () => {
   it('awards disputed points immediately and flips the attempt to correct', async () => {
     const { result } = await setupAndStart();
     const activeTeamId = result.current.state.activeTeamId!;
-    const startingScore = result.current.state.teams.find((team) => team.id === activeTeamId)!
-      .score;
+    const startingScore = result.current.state.teams.find(
+      (team) => team.id === activeTeamId
+    )!.score;
     const question = submitIncorrectAnswer(result);
     const correctPoints = getCorrectPoints(question.difficulty);
 
@@ -437,8 +445,9 @@ describe('GameProvider state machine', () => {
     act(() => result.current.markDisputeSubmitted());
     act(() => result.current.awardDisputedPoints());
 
-    const scoreAfterAward = result.current.state.teams.find((team) => team.id === activeTeamId)!
-      .score;
+    const scoreAfterAward = result.current.state.teams.find(
+      (team) => team.id === activeTeamId
+    )!.score;
 
     act(() => result.current.advanceToScoreUpdate());
 
@@ -457,8 +466,9 @@ describe('GameProvider state machine', () => {
     act(() => result.current.markDisputeSubmitted());
     act(() => result.current.awardDisputedPoints());
 
-    const scoreAfterAward = result.current.state.teams.find((team) => team.id === activeTeamId)!
-      .score;
+    const scoreAfterAward = result.current.state.teams.find(
+      (team) => team.id === activeTeamId
+    )!.score;
 
     act(() => result.current.awardDisputedPoints());
 
@@ -660,5 +670,140 @@ describe('Full game happy path', () => {
     // At least one team should have a non-zero score (some were correct)
     const totalScore = result.current.state.teams.reduce((sum, t) => sum + Math.abs(t.score), 0);
     expect(totalScore).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STE-235: guest (non-signed-in) cross-game question repeats
+// ---------------------------------------------------------------------------
+
+describe('Guest question exclusion (STE-235)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', createFetchMock());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('excludes locally-seen question ids for a guest game', async () => {
+    // Mark the first 4 Science questions as already seen; 8 remain unseen.
+    const seenIds = SCIENCE_QUESTIONS.slice(0, 4).map((q) => q.id);
+    addGuestSeenIds(seenIds);
+
+    // numRounds=1, 2 teams -> totalNeeded = 1*2*4 = 8, exactly the unseen supply.
+    const { result } = await setupAndStart({ category: 'Science', numRounds: 1 });
+
+    const ids = result.current.state.questions.map((q) => q.id);
+    expect(ids).toHaveLength(8);
+    seenIds.forEach((id) => expect(ids).not.toContain(id));
+  });
+
+  it('backfills with the oldest-seen questions when the unseen pool runs short', async () => {
+    // Mark 10 of the 12 Science questions as seen (oldest-first: sci-0 .. sci-9);
+    // only sci-10 and sci-11 remain unseen, but 8 are needed.
+    const seenIds = SCIENCE_QUESTIONS.slice(0, 10).map((q) => q.id);
+    addGuestSeenIds(seenIds);
+
+    const { result } = await setupAndStart({ category: 'Science', numRounds: 1 });
+
+    // Starting the game must never fail due to the exclusion list.
+    expect(result.current.state.phase).toBe('QUESTION');
+    const ids = result.current.state.questions.map((q) => q.id);
+    expect(ids).toHaveLength(8);
+    expect(ids).toContain('sci-10');
+    expect(ids).toContain('sci-11');
+    // Deficit of 6 is backfilled with the 6 oldest-seen ids (sci-0 .. sci-5).
+    ['sci-0', 'sci-1', 'sci-2', 'sci-3', 'sci-4', 'sci-5'].forEach((id) =>
+      expect(ids).toContain(id)
+    );
+  });
+
+  it('does not perform an extra network fetch when the question catalog is already loaded', async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = await renderGame(); // triggers exactly one catalog fetch on mount
+    const callsBeforeStart = fetchMock.mock.calls.length;
+
+    act(() => {
+      hook.result.current.addTeam('Alpha');
+      hook.result.current.addTeam('Bravo');
+    });
+    await act(async () => {
+      await hook.result.current.startGame(false);
+    });
+
+    const questionFetchesDuringStart = fetchMock.mock.calls
+      .slice(callsBeforeStart)
+      .filter((call) => fetchUrlOf(call).includes('/api/questions'));
+
+    // The catalog was already loaded, so guest selection must not fetch
+    // totalNeeded+N rows from the server merely to filter them client-side.
+    expect(questionFetchesDuringStart).toHaveLength(0);
+  });
+
+  it('records only questions actually shown when a guest game is abandoned before GAME_OVER', async () => {
+    // numRounds=1, 2 teams -> 8 questions selected, but the game is abandoned after 3 are shown.
+    const { result, unmount } = await setupAndStart({ numRounds: 1 });
+    const allIds = result.current.state.questions.map((q) => q.id);
+
+    passAndAdvance(result); // question 0 answered, question 1 now shown
+    passAndAdvance(result); // question 1 answered, question 2 now shown
+
+    const shownIds = allIds.slice(0, 3);
+    const unshownIds = allIds.slice(3);
+
+    await waitFor(() => {
+      expect(getGuestSeenIds()).toEqual(expect.arrayContaining(shownIds));
+    });
+    unshownIds.forEach((id) => expect(getGuestSeenIds()).not.toContain(id));
+
+    unmount();
+  });
+
+  it('writes played question ids to local storage and skips the seen-questions POST for guests', async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = await setupAndStart({ numRounds: 1 });
+    const playedIds = result.current.state.questions.map((q) => q.id);
+
+    finishGame(result);
+    expect(result.current.state.phase).toBe('GAME_OVER');
+
+    await waitFor(() => {
+      expect(getGuestSeenIds()).toEqual(expect.arrayContaining(playedIds));
+    });
+
+    const calledSeenPost = fetchMock.mock.calls.some((call) =>
+      fetchUrlOf(call).includes('/api/questions/seen')
+    );
+    expect(calledSeenPost).toBe(false);
+  });
+
+  it('leaves the authenticated path unchanged: server-side exclusion and seen-questions POST', async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = await setupAndStart({ numRounds: 1, isAuthenticated: true });
+
+    const startCall = fetchMock.mock.calls.find((call) => {
+      const url = fetchUrlOf(call);
+      return url.includes('/api/questions?') && !url.includes('/api/questions/seen');
+    });
+    expect(startCall).toBeDefined();
+    expect(fetchUrlOf(startCall!)).toContain('excludeSeen=true');
+
+    finishGame(result);
+    expect(result.current.state.phase).toBe('GAME_OVER');
+
+    await waitFor(() => {
+      const calledSeenPost = fetchMock.mock.calls.some((call) =>
+        fetchUrlOf(call).includes('/api/questions/seen')
+      );
+      expect(calledSeenPost).toBe(true);
+    });
   });
 });

--- a/client/src/lib/store.tsx
+++ b/client/src/lib/store.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { verifyAttempt, pointsFor, QUESTIONS_PER_TEAM_ROTATION } from '@shared/lib/answers';
 import type { Question } from '@shared/lib/answers';
+import { getGuestSeenIds, addGuestSeenIds } from './guest-seen';
 export type { Difficulty, Question } from '@shared/lib/answers';
 export {
   normalize,
@@ -49,6 +50,7 @@ export interface GameState {
   typedAnswer: string;
   currentAttempt: Attempt | null;
   numRounds: number;
+  isAuthenticated: boolean;
 }
 
 interface GameContextType {
@@ -57,7 +59,7 @@ interface GameContextType {
   removeTeam: (id: string) => void;
   setCategory: (category: string) => void;
   setNumRounds: (rounds: number) => void;
-  startGame: () => Promise<void>;
+  startGame: (isAuthenticated?: boolean) => Promise<void>;
   setTypedAnswer: (text: string) => void;
   submitAnswer: () => void;
   passQuestion: () => void;
@@ -86,6 +88,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     typedAnswer: '',
     currentAttempt: null,
     numRounds: 10,
+    isAuthenticated: false,
   });
 
   // Load questions from the database API whenever we enter SETUP phase
@@ -112,14 +115,27 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     loadQuestions();
   }, [state.phase]);
 
-  // Record only actually-presented questions as seen when game ends
+  // Record each guest-seen question the moment it's actually displayed, so an
+  // abandoned game (one that never reaches GAME_OVER) still preserves
+  // history. Only presented questions are recorded — never the unused
+  // remainder of a preselected pool.
   useEffect(() => {
-    if (state.phase === 'GAME_OVER' && state.questions.length > 0) {
+    if (state.isAuthenticated || state.phase !== 'QUESTION') return;
+    const currentQuestion = state.questions[state.currentQuestionIndex];
+    if (!currentQuestion) return;
+    addGuestSeenIds([currentQuestion.id]);
+  }, [state.phase, state.currentQuestionIndex, state.isAuthenticated]);
+
+  // Record presented questions in server history when an authenticated game
+  // ends. Guests already had their history written incrementally above.
+  useEffect(() => {
+    if (state.phase === 'GAME_OVER' && state.questions.length > 0 && state.isAuthenticated) {
       // currentQuestionIndex points past the last asked question, so slice(0, index)
       // captures exactly the questions that were presented to players
       const askedQuestions = state.questions.slice(0, state.currentQuestionIndex);
       if (askedQuestions.length === 0) return;
       const seenIds = askedQuestions.map((q) => q.id);
+
       fetch('/api/questions/seen', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -149,7 +165,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
   const setCategory = (category: string) => setState((s) => ({ ...s, selectedCategory: category }));
   const setNumRounds = (rounds: number) => setState((s) => ({ ...s, numRounds: rounds }));
 
-  const startGame = async () => {
+  const startGame = async (isAuthenticated = false) => {
     const totalNeeded = state.numRounds * state.teams.length * QUESTIONS_PER_TEAM_ROTATION;
     const categoryParam =
       state.selectedCategory !== 'All'
@@ -157,19 +173,60 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         : '';
 
     try {
-      const res = await fetch(
-        `/api/questions?shuffle=true&limit=${totalNeeded}&excludeSeen=true${categoryParam}`,
-        { credentials: 'include' }
-      );
-      if (!res.ok) throw new Error('Failed to fetch game questions');
-      const data = await res.json();
+      let gameQuestions: Question[];
+
+      if (isAuthenticated) {
+        // Signed-in users get server-side exclusion of previously-seen questions.
+        const res = await fetch(
+          `/api/questions?shuffle=true&limit=${totalNeeded}&excludeSeen=true${categoryParam}`,
+          { credentials: 'include' }
+        );
+        if (!res.ok) throw new Error('Failed to fetch game questions');
+        const data = await res.json();
+        gameQuestions = data.questions;
+      } else {
+        // Guests have no server-side history. Select from the already-loaded
+        // approved-question catalog (fetching it once if it isn't loaded yet)
+        // and filter out locally-seen ids client-side. Never let the
+        // exclusion list itself prevent a game from starting: backfill with
+        // the oldest-seen questions if the unseen pool comes up short.
+        let catalog = state.questions;
+        if (catalog.length === 0) {
+          const res = await fetch('/api/questions', { credentials: 'include' });
+          if (!res.ok) throw new Error('Failed to fetch game questions');
+          const data = await res.json();
+          catalog = data.questions;
+        }
+
+        const categoryFiltered =
+          state.selectedCategory === 'All'
+            ? catalog
+            : catalog.filter((q) => q.category === state.selectedCategory);
+
+        const guestSeenIds = getGuestSeenIds();
+        const seenSet = new Set(guestSeenIds);
+        const unseen = categoryFiltered
+          .filter((q) => !seenSet.has(q.id))
+          .sort(() => Math.random() - 0.5);
+        gameQuestions = unseen.slice(0, totalNeeded);
+
+        if (gameQuestions.length < totalNeeded) {
+          const deficit = totalNeeded - gameQuestions.length;
+          const seenOrder = new Map(guestSeenIds.map((id, index) => [id, index]));
+          const seenInPool = categoryFiltered
+            .filter((q) => seenSet.has(q.id))
+            .sort((a, b) => (seenOrder.get(a.id) ?? 0) - (seenOrder.get(b.id) ?? 0));
+          gameQuestions = [...gameQuestions, ...seenInPool.slice(0, deficit)];
+        }
+      }
 
       setState((prev) => ({
         ...prev,
-        questions: data.questions,
+        questions: gameQuestions,
         phase: 'QUESTION',
         activeTeamId: prev.teams[0].id,
         currentQuestionIndex: 0,
+        isAuthenticated,
       }));
     } catch (error) {
       console.error('Failed to fetch questions from API, falling back to client-side:', error);
@@ -187,6 +244,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
           phase: 'QUESTION',
           activeTeamId: prev.teams[0].id,
           currentQuestionIndex: 0,
+          isAuthenticated,
         };
       });
     }
@@ -375,6 +433,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       typedAnswer: '',
       currentAttempt: null,
       numRounds: 10,
+      isAuthenticated: false,
     }));
   };
 

--- a/client/src/pages/Game.test.tsx
+++ b/client/src/pages/Game.test.tsx
@@ -148,6 +148,10 @@ describe('Game page', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.stubGlobal('fetch', createFetchMock());
+    // Guest selection genuinely shuffles the unseen pool; pin Math.random so
+    // the (stable) sort is a no-op and question order stays deterministic
+    // for these order-sensitive assertions.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
   });
 
   afterEach(() => {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -165,7 +165,7 @@ function ModeChooser({
 function SoloSetup() {
   const [_, setLocation] = useLocation();
   const { state, addTeam, removeTeam, setCategory, setNumRounds, startGame } = useGame();
-  const { user, isAuthenticated, logout } = useAuth();
+  const { user, isAuthenticated, isLoading: authLoading, logout } = useAuth();
   const { isAdmin } = useAdmin();
   const [newTeamName, setNewTeamName] = useState('');
 
@@ -185,7 +185,7 @@ function SoloSetup() {
   };
 
   const handleStart = async () => {
-    await startGame();
+    await startGame(isAuthenticated);
     setLocation('/game');
   };
 
@@ -370,7 +370,7 @@ function SoloSetup() {
           )}
           <Button
             className="w-full h-16 text-xl font-bold tracking-wide rounded-2xl shadow-[0_0_40px_-10px_var(--color-primary)] hover:shadow-[0_0_60px_-10px_var(--color-primary)] transition-all"
-            disabled={state.teams.length < 2}
+            disabled={state.teams.length < 2 || authLoading}
             onClick={handleStart}
             data-testid="button-start-game"
           >

--- a/client/src/pages/Room.test.tsx
+++ b/client/src/pages/Room.test.tsx
@@ -6,6 +6,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Room from './Room';
 import type { RoomSnapshot } from '@shared/models/rooms';
 
+// Stub localStorage for jsdom compatibility. Re-stubbed in beforeEach since
+// afterEach calls vi.unstubAllGlobals(), which would otherwise strip it after
+// the first test.
+const guestSeenStorage: Record<string, string> = {};
+function stubLocalStorage() {
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => guestSeenStorage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      guestSeenStorage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete guestSeenStorage[key];
+    },
+    clear: () => {
+      for (const key of Object.keys(guestSeenStorage)) delete guestSeenStorage[key];
+    },
+  });
+}
+
 const mockSetLocation = vi.fn();
 let mockParams: { code: string } = { code: 'ABCDE' };
 
@@ -22,6 +41,17 @@ vi.mock('@/lib/room-session', () => ({
 const mockUseRoom = vi.fn();
 vi.mock('@/hooks/use-room', () => ({
   useRoom: (...args: unknown[]) => mockUseRoom(...args),
+}));
+
+const mockUseAuth = vi.fn(() => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  logout: vi.fn(),
+  isLoggingOut: false,
+}));
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => mockUseAuth(),
 }));
 
 vi.mock('@/components/room/Lobby', () => ({
@@ -107,7 +137,16 @@ describe('Room', () => {
     mockSetLocation.mockClear();
     mockGetRoomSession.mockReset();
     mockUseRoom.mockReset();
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      logout: vi.fn(),
+      isLoggingOut: false,
+    });
     mockParams = { code: 'ABCDE' };
+    stubLocalStorage();
+    localStorage.clear();
   });
 
   afterEach(() => {

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -14,6 +14,8 @@ import { TurnHandoff } from '@/components/room/TurnHandoff';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
 import { useRoom } from '@/hooks/use-room';
+import { useAuth } from '@/hooks/use-auth';
+import { useRecordGuestRoomQuestion } from '@/hooks/use-record-guest-room-question';
 import { getRoomSession } from '@/lib/room-session';
 import type { RoomPlayerSnapshot } from '@shared/models/rooms';
 
@@ -35,9 +37,12 @@ export default function Room() {
     awardDispute,
     refetch,
   } = useRoom(code, { enabled: !!session });
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
 
   const [handoffPlayer, setHandoffPlayer] = useState<RoomPlayerSnapshot | null>(null);
   const prevActivePlayerRef = useRef<string | null>(null);
+
+  useRecordGuestRoomQuestion(snapshot?.currentQuestion?.id, isAuthenticated, authLoading);
 
   useEffect(() => {
     if (!session) {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -12,6 +12,12 @@ const EXPECTED_POINTS_DELTA = -1; // Easy wrong answer
 
 test.describe('SETUP → QUESTION → REVEAL loop', () => {
   test.beforeEach(async ({ page }) => {
+    // Guest question selection shuffles locally-unseen questions; keep this
+    // order-sensitive smoke path deterministic so smoke-q1 is selected first.
+    await page.addInitScript(() => {
+      Math.random = () => 0.5;
+    });
+
     // Intercept both the initial catalog load and startGame shuffle request
     await page.route('**/api/questions**', async (route) => {
       if (route.request().method() === 'GET') {

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -510,6 +510,176 @@ describe('room lifecycle routes', () => {
     );
   });
 
+  it('honors excludeQuestionIds for a guest host when the unseen pool is sufficient', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const selectedQuestions = Array.from({ length: 40 }, (_, index) => ({
+      id: `question-${index + 1}`,
+    }));
+    const startedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: selectedQuestions.map(({ id }) => id),
+      activePlayerId: hostId,
+    });
+    queueSelect(
+      [room()],
+      [player()],
+      [player(), guest],
+      selectedQuestions,
+      [player(), guest],
+      [question()]
+    );
+    dbMocks.updateResults.push([startedRoom]);
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/start')
+      .set('X-Player-Token', 'host-secret')
+      .send({ excludeQuestionIds: ['seen-1', 'seen-2'] })
+      .expect(200);
+
+    // Sufficient supply after exclusion — no backfill query needed.
+    expect(dbMocks.select).toHaveBeenCalledTimes(6);
+
+    const exclusionCondition = dbMocks.whereArgs.find((condition) => {
+      const query = new PgDialect().sqlToQuery(condition as Parameters<PgDialect['sqlToQuery']>[0]);
+      return query.sql.includes('not in') && query.params.includes('seen-1');
+    });
+    expect(exclusionCondition).toBeDefined();
+  });
+
+  it('backfills without exclusion for a guest host when the unseen pool is too small', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const shortSupply = Array.from({ length: 10 }, (_, index) => ({
+      id: `question-${index + 1}`,
+    }));
+    const backfilledQuestions = Array.from({ length: 40 }, (_, index) => ({
+      id: `question-${index + 1}`,
+    }));
+    const startedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: backfilledQuestions.map(({ id }) => id),
+      activePlayerId: hostId,
+    });
+    queueSelect(
+      [room()],
+      [player()],
+      [player(), guest],
+      shortSupply,
+      backfilledQuestions,
+      [player(), guest],
+      [question()]
+    );
+    dbMocks.updateResults.push([startedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/start')
+      .set('X-Player-Token', 'host-secret')
+      .send({ excludeQuestionIds: ['seen-1'] })
+      .expect(200);
+
+    // Two question-selection queries: the excluded attempt, then the backfill.
+    expect(dbMocks.select).toHaveBeenCalledTimes(7);
+    expect(response.body.snapshot.status).toBe('active');
+  });
+
+  it('rejects more than 500 excludeQuestionIds with a 422', async () => {
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/start')
+      .set('X-Player-Token', 'host-secret')
+      .send({ excludeQuestionIds: Array.from({ length: 501 }, (_, i) => `q${i}`) })
+      .expect(422);
+
+    expect(dbMocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it('ignores client-supplied excludeQuestionIds for an authenticated host', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const selectedQuestions = Array.from({ length: 40 }, (_, index) => ({
+      id: `question-${index + 1}`,
+    }));
+    const startedRoom = room({
+      status: 'active',
+      phase: 'QUESTION',
+      version: 2,
+      questionIds: selectedQuestions.map(({ id }) => id),
+      activePlayerId: hostId,
+    });
+    queueSelect(
+      [room()],
+      [player()],
+      [player(), guest],
+      selectedQuestions,
+      [player(), guest],
+      [question()]
+    );
+    dbMocks.updateResults.push([startedRoom]);
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/start')
+      .set('X-Player-Token', 'host-secret')
+      .set('x-test-user-id', 'host-user')
+      .send({ excludeQuestionIds: ['some-guest-only-id'] })
+      .expect(200);
+
+    // Same single question-selection query as the plain authenticated flow —
+    // the client's exclusion list never reaches the authenticated branch.
+    expect(dbMocks.select).toHaveBeenCalledTimes(6);
+    const exclusionCondition = dbMocks.whereArgs.find((condition) => {
+      const query = new PgDialect().sqlToQuery(condition as Parameters<PgDialect['sqlToQuery']>[0]);
+      return query.params.includes('some-guest-only-id');
+    });
+    expect(exclusionCondition).toBeUndefined();
+  });
+
+  it('returns 409 when the pool is genuinely too small even after backfill', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const stillShort = Array.from({ length: 10 }, (_, index) => ({
+      id: `question-${index + 1}`,
+    }));
+    queueSelect([room()], [player()], [player(), guest], stillShort.slice(0, 5), stillShort);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/start')
+      .set('X-Player-Token', 'host-secret')
+      .send({ excludeQuestionIds: ['seen-1'] })
+      .expect(409);
+
+    expect(response.body.message).toBe('Not enough approved questions to start this game');
+  });
+
   it('requires a host and at least two players to start', async () => {
     const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
     queueSelect([room()], [guest]);

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -555,7 +555,7 @@ describe('room lifecycle routes', () => {
     expect(exclusionCondition).toBeDefined();
   });
 
-  it('backfills without exclusion for a guest host when the unseen pool is too small', async () => {
+  it('backfills only the deficit, oldest-seen first, for a guest host when the unseen pool is too small', async () => {
     const guest = player({
       id: guestId,
       nickname: 'Guest',
@@ -563,25 +563,28 @@ describe('room lifecycle routes', () => {
       joinOrder: 1,
       isHost: false,
     });
-    const shortSupply = Array.from({ length: 10 }, (_, index) => ({
-      id: `question-${index + 1}`,
+    // 10 unseen questions available; questionLimit is 40 (5 rounds * 2 players * 4),
+    // so 30 more are needed. 35 eligible previously-seen ids are supplied,
+    // oldest-first, and only the 30 oldest should be used to fill the deficit.
+    const unseenQuestions = Array.from({ length: 10 }, (_, index) => ({
+      id: `unseen-${index + 1}`,
     }));
-    const backfilledQuestions = Array.from({ length: 40 }, (_, index) => ({
-      id: `question-${index + 1}`,
-    }));
+    const excludeIds = Array.from({ length: 35 }, (_, index) => `seen-${index + 1}`);
+    const eligibleSeenQuestions = excludeIds.map((id) => ({ id }));
+    const expectedSelection = [...unseenQuestions.map(({ id }) => id), ...excludeIds.slice(0, 30)];
     const startedRoom = room({
       status: 'active',
       phase: 'QUESTION',
       version: 2,
-      questionIds: backfilledQuestions.map(({ id }) => id),
+      questionIds: expectedSelection,
       activePlayerId: hostId,
     });
     queueSelect(
       [room()],
       [player()],
       [player(), guest],
-      shortSupply,
-      backfilledQuestions,
+      unseenQuestions,
+      eligibleSeenQuestions,
       [player(), guest],
       [question()]
     );
@@ -591,12 +594,17 @@ describe('room lifecycle routes', () => {
     const response = await request(app)
       .post('/api/rooms/ABCD2/start')
       .set('X-Player-Token', 'host-secret')
-      .send({ excludeQuestionIds: ['seen-1'] })
+      .send({ excludeQuestionIds: excludeIds })
       .expect(200);
 
-    // Two question-selection queries: the excluded attempt, then the backfill.
+    // Two question-selection queries: the unseen attempt, then the eligible-seen backfill.
     expect(dbMocks.select).toHaveBeenCalledTimes(7);
     expect(response.body.snapshot.status).toBe('active');
+    // The already-found unseen questions are kept; only the deficit (30) is
+    // backfilled, from the oldest-seen ids first — never a fresh unconstrained draw.
+    expect(dbMocks.valueArgs).toContainEqual(
+      expect.objectContaining({ questionIds: expectedSelection })
+    );
   });
 
   it('rejects more than 500 excludeQuestionIds with a 422', async () => {

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -1,6 +1,6 @@
 import { randomBytes, randomInt } from 'crypto';
 import type { Express, Request, Response } from 'express';
-import { and, asc, eq, isNull, lte, notInArray, or, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, lte, notInArray, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from './db';
@@ -473,31 +473,41 @@ export function registerRoomRoutes(app: Express): void {
               sql`random()`
             )
             .limit(questionLimit);
-        } else {
-          const selectUnexcluded = () =>
-            tx
-              .select({ id: questions.id })
-              .from(questions)
-              .where(and(...questionConditions))
-              .orderBy(sql`random()`)
-              .limit(questionLimit);
+        } else if (excludeQuestionIds.length > 0) {
+          const unseen = await tx
+            .select({ id: questions.id })
+            .from(questions)
+            .where(and(...questionConditions, notInArray(questions.id, excludeQuestionIds)))
+            .orderBy(sql`random()`)
+            .limit(questionLimit);
 
-          if (excludeQuestionIds.length > 0) {
-            selectedQuestions = await tx
-              .select({ id: questions.id })
-              .from(questions)
-              .where(and(...questionConditions, notInArray(questions.id, excludeQuestionIds)))
-              .orderBy(sql`random()`)
-              .limit(questionLimit);
-
+          if (unseen.length < questionLimit) {
             // The exclusion list (guest's locally-seen questions) must never
-            // block a game from starting — backfill without it if short.
-            if (selectedQuestions.length < questionLimit) {
-              selectedQuestions = await selectUnexcluded();
-            }
+            // block a game from starting. Keep the unseen results already
+            // found and backfill only the deficit from the excluded pool,
+            // preferring the oldest-seen ids first.
+            const deficit = questionLimit - unseen.length;
+            const eligibleSeen = await tx
+              .select({ id: questions.id })
+              .from(questions)
+              .where(and(...questionConditions, inArray(questions.id, excludeQuestionIds)));
+
+            const seenOrder = new Map(excludeQuestionIds.map((id, index) => [id, index]));
+            const backfill = eligibleSeen
+              .sort((a, b) => (seenOrder.get(a.id) ?? 0) - (seenOrder.get(b.id) ?? 0))
+              .slice(0, deficit);
+
+            selectedQuestions = [...unseen, ...backfill];
           } else {
-            selectedQuestions = await selectUnexcluded();
+            selectedQuestions = unseen;
           }
+        } else {
+          selectedQuestions = await tx
+            .select({ id: questions.id })
+            .from(questions)
+            .where(and(...questionConditions))
+            .orderBy(sql`random()`)
+            .limit(questionLimit);
         }
 
         if (selectedQuestions.length < questionLimit) {

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -1,6 +1,6 @@
 import { randomBytes, randomInt } from 'crypto';
 import type { Express, Request, Response } from 'express';
-import { and, asc, eq, isNull, lte, or, sql } from 'drizzle-orm';
+import { and, asc, eq, isNull, lte, notInArray, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from './db';
@@ -406,7 +406,7 @@ export function registerRoomRoutes(app: Express): void {
   app.post('/api/rooms/:code/start', async (req, res) => {
     try {
       const code = parseRoomCode(req.params.code);
-      startRoomRequestSchema.parse(req.body);
+      const { excludeQuestionIds = [] } = startRoomRequestSchema.parse(req.body);
       const userId = getUserId(req);
 
       const updatedRoom = await db.transaction(async (tx) => {
@@ -474,12 +474,30 @@ export function registerRoomRoutes(app: Express): void {
             )
             .limit(questionLimit);
         } else {
-          selectedQuestions = await tx
-            .select({ id: questions.id })
-            .from(questions)
-            .where(and(...questionConditions))
-            .orderBy(sql`random()`)
-            .limit(questionLimit);
+          const selectUnexcluded = () =>
+            tx
+              .select({ id: questions.id })
+              .from(questions)
+              .where(and(...questionConditions))
+              .orderBy(sql`random()`)
+              .limit(questionLimit);
+
+          if (excludeQuestionIds.length > 0) {
+            selectedQuestions = await tx
+              .select({ id: questions.id })
+              .from(questions)
+              .where(and(...questionConditions, notInArray(questions.id, excludeQuestionIds)))
+              .orderBy(sql`random()`)
+              .limit(questionLimit);
+
+            // The exclusion list (guest's locally-seen questions) must never
+            // block a game from starting — backfill without it if short.
+            if (selectedQuestions.length < questionLimit) {
+              selectedQuestions = await selectUnexcluded();
+            }
+          } else {
+            selectedQuestions = await selectUnexcluded();
+          }
         }
 
         if (selectedQuestions.length < questionLimit) {

--- a/shared/models/rooms.ts
+++ b/shared/models/rooms.ts
@@ -228,7 +228,18 @@ export const createRoomRequestSchema = z.object({
   numRounds: roomRoundsSchema,
 });
 export const joinRoomRequestSchema = z.object({ nickname: roomNicknameSchema });
-export const startRoomRequestSchema = z.object({}).strict();
+export const excludeQuestionIdsSchema = z
+  .array(z.string().trim().min(1))
+  .max(500)
+  .refine((ids) => new Set(ids).size === ids.length, {
+    message: 'excludeQuestionIds must not contain duplicates',
+  });
+
+export const startRoomRequestSchema = z
+  .object({
+    excludeQuestionIds: excludeQuestionIdsSchema.optional(),
+  })
+  .strict();
 export const answerRoomRequestSchema = z.object({ answer: z.string().trim().min(1).nullable() });
 export const advanceRoomRequestSchema = z.object({}).strict();
 export const continueRoomRequestSchema = z.object({}).strict();


### PR DESCRIPTION
## Summary

Guest (non-signed-in) players had no persisted question history, so consecutive solo games and guest-hosted rooms could repeat a question the browser had already seen — signed-in players already got this via the server-side `seen_questions` table.

- **`client/src/lib/guest-seen.ts`** (new): versioned, FIFO-capped (500) localStorage history. Trims/dedupes ids, moves re-seen ids to the newest position, and degrades to a no-op when storage is unavailable, throws, or holds malformed JSON.
- **Solo game (`store.tsx`)**: guest `startGame` selects from the already-loaded question catalog (no extra padded network fetch), excludes locally-seen ids, and backfills oldest-seen first if the unseen pool runs short — a game never fails to start due to the exclusion list. Each question is recorded the moment it's displayed (not batched at `GAME_OVER`), so an abandoned game still preserves history, and only actually-shown questions are recorded. Guests no longer POST to the authenticated-only `/api/questions/seen` (this silently 401'd before). Signed-in behavior is byte-for-byte unchanged.
- **Multiplayer rooms**: `startRoomRequestSchema` gains an optional `excludeQuestionIds` (trimmed, deduped, max 500). The guest branch of `POST /api/rooms/:code/start` excludes those ids and backfills without exclusion if the pool comes up short; the authenticated branch (server-side `seen_questions` cooldown) is untouched and ignores the field entirely. The Lobby host sends its local history on start; a new `useRecordGuestRoomQuestion` hook records each displayed room question for any guest client (host or joiner) — only the host's list affects room selection.
- Home's Start Game button is disabled while auth status is resolving, so a guest-vs-signed-in decision is never made against a stale loading state.

## Test plan

- [x] `npm test` — 459/459 passing (42 files), including new coverage:
  - `guest-seen.test.ts` — add/get, FIFO cap, dedup/trim, malformed JSON, storage-unavailable/throwing
  - `store.test.tsx` — guest exclusion, oldest-first backfill, no extra fetch when catalog loaded, abandonment records only shown questions, authenticated path unchanged
  - `use-record-guest-room-question.test.ts` — records for guests, skips while auth loading, skips for signed-in, no double-record
  - `routes.rooms.test.ts` — exclusion honored, backfill, authenticated host ignores client exclusion, genuine-409 after backfill, >500 ids → 422
  - `Lobby.test.tsx`, `Room.test.tsx`, `Home.test.tsx`, `Game.test.tsx` — updated for the new behavior/mocks
- [x] `tsc --noEmit` clean
- [x] `eslint .` — 0 errors (only pre-existing warnings)
- [x] Manual click-through in a browser — not done; this environment's dev server can't boot (missing `OPENAI_API_KEY`, unrelated to this change)
- [x] E2E consecutive-game regression spec (called out in the Linear ticket's Required Tests) — not added in this PR; flagging as a follow-up since I can't run Playwright locally here to verify it (same missing-env-var blocker)

Linear: [STE-235](https://linear.app/stephs-vibe-coding/issue/STE-235/fixgameplay-prevent-guest-question-repeats-across-games)

🤖 Generated with [Claude Code](https://claude.com/claude-code)