### PR TITLE
feat(setup): allow multiple category selection during game setup [STE-140]

### DIFF
--- a/client/src/components/room/Lobby.test.tsx
+++ b/client/src/components/room/Lobby.test.tsx
@@ -71,7 +71,7 @@ function makeSnapshot(overrides: Partial<LobbySnapshot> = {}): LobbySnapshot {
     phase: 'LOBBY',
     version: 1,
     hostPlayerId: 'host-1',
-    category: 'All',
+    categories: ['All'],
     numRounds: 10,
     currentQuestionIndex: 0,
     activePlayerId: null,

--- a/client/src/components/room/Lobby.tsx
+++ b/client/src/components/room/Lobby.tsx
@@ -124,7 +124,10 @@ export function Lobby({ snapshot, currentPlayerId, start, end, leave }: LobbyPro
         <CardHeader className="pb-3">
           <CardTitle className="text-lg">Settings</CardTitle>
           <CardDescription>
-            {snapshot.category} &middot; {snapshot.numRounds} rounds
+            {snapshot.categories.includes('All')
+              ? 'All categories'
+              : snapshot.categories.join(', ')}{' '}
+            &middot; {snapshot.numRounds} rounds
           </CardDescription>
         </CardHeader>
       </Card>

--- a/client/src/lib/store.test.tsx
+++ b/client/src/lib/store.test.tsx
@@ -73,15 +73,16 @@ function createFetchMock(options?: { questions?: Array<(typeof ALL_TEST_QUESTION
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
     }
 
-    // GET /api/questions?shuffle=true&limit=...&category=...
+    // GET /api/questions?shuffle=true&limit=...&categories=...
     if (url.includes('/api/questions')) {
       const parsed = new URL(url, 'http://localhost');
-      const category = parsed.searchParams.get('category');
+      const categoriesParam = parsed.searchParams.get('categories');
       const limit = parsed.searchParams.get('limit');
 
       let questions = [...questionPool];
-      if (category) {
-        questions = questions.filter((q) => q.category === category);
+      if (categoriesParam) {
+        const selectedCats = categoriesParam.split(',').map((s) => decodeURIComponent(s.trim()));
+        questions = questions.filter((q) => selectedCats.includes(q.category));
       }
       // Shuffle (deterministic for tests: just reverse)
       questions = questions.reverse();
@@ -135,7 +136,7 @@ async function setupAndStart(opts?: {
   });
 
   if (opts?.category) {
-    act(() => result.current.setCategory(opts.category!));
+    act(() => result.current.toggleCategory(opts.category!));
   }
   if (opts?.numRounds) {
     act(() => result.current.setNumRounds(opts.numRounds!));
@@ -578,7 +579,7 @@ describe('GameProvider state machine', () => {
     expect(result.current.state.teams).toHaveLength(0);
     expect(result.current.state.currentQuestionIndex).toBe(0);
     expect(result.current.state.activeTeamId).toBeNull();
-    expect(result.current.state.selectedCategory).toBe('All');
+    expect(result.current.state.selectedCategories).toEqual([]);
     expect(result.current.state.numRounds).toBe(10);
   });
 

--- a/client/src/lib/store.tsx
+++ b/client/src/lib/store.tsx
@@ -43,7 +43,7 @@ export interface GameState {
   teams: Team[];
   questions: Question[];
   categories: string[];
-  selectedCategory: string;
+  selectedCategories: string[];
   currentQuestionIndex: number;
   phase: Phase;
   activeTeamId: string | null;
@@ -57,7 +57,7 @@ interface GameContextType {
   state: GameState;
   addTeam: (name: string) => void;
   removeTeam: (id: string) => void;
-  setCategory: (category: string) => void;
+  toggleCategory: (category: string) => void;
   setNumRounds: (rounds: number) => void;
   startGame: (isAuthenticated?: boolean) => Promise<void>;
   setTypedAnswer: (text: string) => void;
@@ -81,7 +81,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     teams: [],
     questions: [],
     categories: [],
-    selectedCategory: 'All',
+    selectedCategories: [],
     currentQuestionIndex: 0,
     phase: 'SETUP',
     activeTeamId: null,
@@ -162,14 +162,23 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     }));
   };
 
-  const setCategory = (category: string) => setState((s) => ({ ...s, selectedCategory: category }));
+  const toggleCategory = (category: string) => {
+    setState((s) => {
+      if (category === 'All') return { ...s, selectedCategories: [] };
+      const isSelected = s.selectedCategories.includes(category);
+      const next = isSelected
+        ? s.selectedCategories.filter((c) => c !== category)
+        : [...s.selectedCategories, category];
+      return { ...s, selectedCategories: next };
+    });
+  };
   const setNumRounds = (rounds: number) => setState((s) => ({ ...s, numRounds: rounds }));
 
   const startGame = async (isAuthenticated = false) => {
     const totalNeeded = state.numRounds * state.teams.length * QUESTIONS_PER_TEAM_ROTATION;
     const categoryParam =
-      state.selectedCategory !== 'All'
-        ? `&category=${encodeURIComponent(state.selectedCategory)}`
+      state.selectedCategories.length > 0
+        ? `&categories=${state.selectedCategories.map(encodeURIComponent).join(',')}`
         : '';
 
     try {
@@ -199,9 +208,9 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         }
 
         const categoryFiltered =
-          state.selectedCategory === 'All'
+          state.selectedCategories.length === 0
             ? catalog
-            : catalog.filter((q) => q.category === state.selectedCategory);
+            : catalog.filter((q) => state.selectedCategories.includes(q.category));
 
         const guestSeenIds = getGuestSeenIds();
         const seenSet = new Set(guestSeenIds);
@@ -233,9 +242,9 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       // Fallback to client-side shuffle of already-loaded questions
       setState((prev) => {
         let filtered =
-          prev.selectedCategory === 'All'
+          prev.selectedCategories.length === 0
             ? [...prev.questions]
-            : prev.questions.filter((q) => q.category === prev.selectedCategory);
+            : prev.questions.filter((q) => prev.selectedCategories.includes(q.category));
         filtered = filtered.sort(() => Math.random() - 0.5);
         const finalQuestions = filtered.slice(0, totalNeeded);
         return {
@@ -427,7 +436,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       phase: 'SETUP',
       teams: [],
       questions: [],
-      selectedCategory: 'All',
+      selectedCategories: [],
       currentQuestionIndex: 0,
       activeTeamId: null,
       typedAnswer: '',
@@ -522,7 +531,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         state,
         addTeam,
         removeTeam,
-        setCategory,
+        toggleCategory,
         setNumRounds,
         startGame,
         setTypedAnswer,

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -164,7 +164,7 @@ function ModeChooser({
 
 function SoloSetup() {
   const [_, setLocation] = useLocation();
-  const { state, addTeam, removeTeam, setCategory, setNumRounds, startGame } = useGame();
+  const { state, addTeam, removeTeam, toggleCategory, setNumRounds, startGame } = useGame();
   const { user, isAuthenticated, isLoading: authLoading, logout } = useAuth();
   const { isAdmin } = useAdmin();
   const [newTeamName, setNewTeamName] = useState('');
@@ -172,7 +172,10 @@ function SoloSetup() {
   const categoryCounts = useCategoryCounts(state.questions);
 
   const totalNeeded = state.numRounds * state.teams.length * QUESTIONS_PER_TEAM_ROTATION;
-  const availableCount = categoryCounts[state.selectedCategory] || 0;
+  const availableCount =
+    state.selectedCategories.length === 0
+      ? categoryCounts['All'] || 0
+      : state.selectedCategories.reduce((sum, cat) => sum + (categoryCounts[cat] || 0), 0);
   const hasInsufficientQuestions =
     state.teams.length >= 2 && availableCount < totalNeeded && availableCount > 0;
 
@@ -287,15 +290,15 @@ function SoloSetup() {
         <Card className="border-white/10 bg-white/5 backdrop-blur-md">
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-lg">Category</CardTitle>
-            <CardDescription>Choose a topic for this round.</CardDescription>
+            <CardDescription>Choose one or more topics for this round.</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-2 gap-2 max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
               <Button
-                variant={state.selectedCategory === 'All' ? 'default' : 'outline'}
-                onClick={() => setCategory('All')}
+                variant={state.selectedCategories.length === 0 ? 'default' : 'outline'}
+                onClick={() => toggleCategory('All')}
                 className={`border-white/10 hover:bg-white/10 ${
-                  state.selectedCategory === 'All'
+                  state.selectedCategories.length === 0
                     ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
                     : ''
                 }`}
@@ -307,10 +310,10 @@ function SoloSetup() {
                 .map((category) => (
                   <Button
                     key={category}
-                    variant={state.selectedCategory === category ? 'default' : 'outline'}
-                    onClick={() => setCategory(category)}
+                    variant={state.selectedCategories.includes(category) ? 'default' : 'outline'}
+                    onClick={() => toggleCategory(category)}
                     className={`border-white/10 hover:bg-white/10 ${
-                      state.selectedCategory === category
+                      state.selectedCategories.includes(category)
                         ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
                         : ''
                     }`}
@@ -356,9 +359,11 @@ function SoloSetup() {
               <div>
                 <p className="font-semibold text-yellow-300">Not enough questions</p>
                 <p className="mt-1">
-                  {state.selectedCategory === 'All'
+                  {state.selectedCategories.length === 0
                     ? 'All categories have'
-                    : `"${state.selectedCategory}" has`}{' '}
+                    : state.selectedCategories.length === 1
+                      ? `"${state.selectedCategories[0]}" has`
+                      : `The selected categories have`}{' '}
                   only <span className="font-bold">{availableCount}</span> question
                   {availableCount !== 1 ? 's' : ''}, but your setup needs{' '}
                   <span className="font-bold">{totalNeeded}</span> ({state.numRounds} rounds ×{' '}

--- a/client/src/pages/HostGame.tsx
+++ b/client/src/pages/HostGame.tsx
@@ -6,7 +6,7 @@ import { motion } from 'framer-motion';
 import { UserPlus, Zap } from 'lucide-react';
 import {
   ROOM_ROUND_OPTIONS,
-  roomCategorySchema,
+  roomCategoriesSchema,
   roomRoundsSchema,
   type CreateRoomRequest,
   type CreateRoomResponse,
@@ -44,7 +44,7 @@ async function createRoom(body: CreateRoomRequest): Promise<CreateRoomResponse> 
 
 export default function HostGame() {
   const [, setLocation] = useLocation();
-  const { state, setCategory, setNumRounds } = useGame();
+  const { state, toggleCategory, setNumRounds } = useGame();
   const [nickname, setNickname] = useState('');
 
   const categoryCounts = useCategoryCounts(state.questions);
@@ -67,16 +67,18 @@ export default function HostGame() {
     e.preventDefault();
     if (!isNicknameValid || createRoomMutation.isPending) return;
 
-    const category = roomCategorySchema.safeParse(state.selectedCategory);
+    const categoriesValue =
+      state.selectedCategories.length === 0 ? ['All'] : state.selectedCategories;
+    const categories = roomCategoriesSchema.safeParse(categoriesValue);
     const numRounds = roomRoundsSchema.safeParse(state.numRounds);
-    if (!category.success || !numRounds.success) {
+    if (!categories.success || !numRounds.success) {
       toast.error('Invalid category or rounds selection. Please try again.');
       return;
     }
 
     createRoomMutation.mutate({
       nickname: trimmedNickname,
-      category: category.data,
+      categories: categories.data,
       numRounds: numRounds.data,
     });
   };
@@ -128,17 +130,17 @@ export default function HostGame() {
           <Card className="border-white/10 bg-white/5 backdrop-blur-md">
             <CardHeader className="pb-3">
               <CardTitle className="flex items-center gap-2 text-lg">Category</CardTitle>
-              <CardDescription>Choose a topic for this room.</CardDescription>
+              <CardDescription>Choose one or more topics for this room.</CardDescription>
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-2 gap-2 max-h-[200px] overflow-y-auto pr-2 custom-scrollbar">
                 <Button
                   type="button"
-                  variant={state.selectedCategory === 'All' ? 'default' : 'outline'}
-                  onClick={() => setCategory('All')}
+                  variant={state.selectedCategories.length === 0 ? 'default' : 'outline'}
+                  onClick={() => toggleCategory('All')}
                   disabled={createRoomMutation.isPending}
                   className={`border-white/10 hover:bg-white/10 ${
-                    state.selectedCategory === 'All'
+                    state.selectedCategories.length === 0
                       ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
                       : ''
                   }`}
@@ -151,11 +153,11 @@ export default function HostGame() {
                     <Button
                       key={category}
                       type="button"
-                      variant={state.selectedCategory === category ? 'default' : 'outline'}
-                      onClick={() => setCategory(category)}
+                      variant={state.selectedCategories.includes(category) ? 'default' : 'outline'}
+                      onClick={() => toggleCategory(category)}
                       disabled={createRoomMutation.isPending}
                       className={`border-white/10 hover:bg-white/10 ${
-                        state.selectedCategory === category
+                        state.selectedCategories.includes(category)
                           ? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
                           : ''
                       }`}

--- a/client/src/pages/Room.test.tsx
+++ b/client/src/pages/Room.test.tsx
@@ -102,7 +102,7 @@ function makeSnapshot(overrides: Partial<RoomSnapshot> = {}): RoomSnapshot {
     phase: 'LOBBY',
     version: 1,
     hostPlayerId: 'host-1',
-    category: 'All',
+    categories: ['All'],
     numRounds: 10,
     currentQuestionIndex: 0,
     activePlayerId: null,

--- a/e2e/multiplayer.spec.ts
+++ b/e2e/multiplayer.spec.ts
@@ -113,7 +113,7 @@ async function joinRoom(request: APIRequestContext, code: string, nickname: stri
 
 async function createRoom(request: APIRequestContext, nickname: string) {
   const response = await request.post('/api/rooms', {
-    data: { nickname, category: 'All', numRounds: 5 },
+    data: { nickname, categories: ['All'], numRounds: 5 },
   });
   return readJson<CreateRoomResponse>(response, `create room for ${nickname}`);
 }

--- a/migrations/0004_room_multi_category.sql
+++ b/migrations/0004_room_multi_category.sql
@@ -1,0 +1,2 @@
+-- Extend the category column to hold comma-separated multi-category values
+ALTER TABLE rooms ALTER COLUMN category TYPE varchar(255);

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -227,7 +227,7 @@ describe('room lifecycle routes', () => {
 
     const response = await request(app)
       .post('/api/rooms')
-      .send({ nickname: 'Host', category: 'All', numRounds: 5 })
+      .send({ nickname: 'Host', categories: ['All'], numRounds: 5 })
       .expect(201);
 
     expect(response.body).toMatchObject({ code: 'ABCD2', playerId: hostId, token: 'host-secret' });
@@ -249,7 +249,7 @@ describe('room lifecycle routes', () => {
 
     await request(app)
       .post('/api/rooms')
-      .send({ nickname: 'Host', category: 'All', numRounds: 5 })
+      .send({ nickname: 'Host', categories: ['All'], numRounds: 5 })
       .expect(201);
 
     expect(dbMocks.transaction).toHaveBeenCalledTimes(2);
@@ -261,7 +261,7 @@ describe('room lifecycle routes', () => {
 
     await request(app)
       .post('/api/rooms')
-      .send({ nickname: 'Host', category: 'All', numRounds: 5 })
+      .send({ nickname: 'Host', categories: ['All'], numRounds: 5 })
       .expect(500);
 
     expect(dbMocks.transaction).toHaveBeenCalledTimes(5);
@@ -272,7 +272,7 @@ describe('room lifecycle routes', () => {
 
     await request(app)
       .post('/api/rooms')
-      .send({ nickname: '', category: 'All', numRounds: 3 })
+      .send({ nickname: '', categories: ['All'], numRounds: 3 })
       .expect(422);
 
     expect(dbMocks.delete).not.toHaveBeenCalled();

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -42,6 +42,7 @@ import {
   type Question,
   type Room,
   type RoomAttempt,
+  type RoomCategories,
   type RoomPlayer,
   type RoomSnapshot,
 } from '@shared/schema';
@@ -94,6 +95,19 @@ function parseRoomCode(rawCode: string): string {
 
 function isExpired(room: Room, now = new Date()): boolean {
   return room.expiresAt.getTime() <= now.getTime();
+}
+
+function parseRoomCategories(categoryStr: string): RoomCategories {
+  if (!categoryStr || categoryStr === 'All') return ['All'];
+  return categoryStr
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) as RoomCategories;
+}
+
+function serializeRoomCategories(categories: RoomCategories): string {
+  if (categories.length === 1 && categories[0] === 'All') return 'All';
+  return categories.filter((c) => c !== 'All').join(',');
 }
 
 function getUserId(req: Request): string | undefined {
@@ -204,7 +218,7 @@ async function buildRoomSnapshot(
     phase: room.phase,
     version: room.version,
     hostPlayerId: room.hostPlayerId,
-    category: room.category,
+    categories: parseRoomCategories(room.category),
     numRounds: room.numRounds,
     currentQuestionIndex: room.currentQuestionIndex,
     activePlayerId: room.activePlayerId,
@@ -301,7 +315,7 @@ export function registerRoomRoutes(app: Express): void {
               .insert(rooms)
               .values({
                 code,
-                category: input.category,
+                category: serializeRoomCategories(input.categories),
                 numRounds: input.numRounds,
                 status: 'lobby',
                 phase: 'LOBBY',
@@ -471,8 +485,13 @@ export function registerRoomRoutes(app: Express): void {
 
         const questionLimit = room.numRounds * players.length * QUESTIONS_PER_TEAM_ROTATION;
         const questionConditions = [eq(questions.status, 'approved')];
-        if (room.category !== 'All') {
-          questionConditions.push(eq(questions.category, room.category));
+        const roomCategories = parseRoomCategories(room.category);
+        if (!roomCategories.includes('All')) {
+          if (roomCategories.length === 1) {
+            questionConditions.push(eq(questions.category, roomCategories[0]));
+          } else {
+            questionConditions.push(inArray(questions.category, roomCategories));
+          }
         }
 
         let selectedQuestions: { id: string }[];

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -388,11 +388,26 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   // Questions API
   app.get('/api/questions', async (req, res) => {
     try {
-      const { category, pillar, difficulty, excludeSeen, limit, shuffle } = req.query;
+      const { category, categories, pillar, difficulty, excludeSeen, limit, shuffle } = req.query;
 
       const conditions = [];
-      if (category && category !== 'All') {
-        conditions.push(eq(questions.category, category as string));
+      // Support comma-separated multi-category filter (?categories=Tech,Science) as well as
+      // the legacy single-value ?category= param used by older callers.
+      const categoryList: string[] = [];
+      if (categories && typeof categories === 'string') {
+        categoryList.push(
+          ...categories
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        );
+      } else if (category && category !== 'All') {
+        categoryList.push(category as string);
+      }
+      if (categoryList.length === 1) {
+        conditions.push(eq(questions.category, categoryList[0]));
+      } else if (categoryList.length > 1) {
+        conditions.push(inArray(questions.category, categoryList));
       }
       if (pillar) {
         conditions.push(eq(questions.pillar, pillar as string));
@@ -1245,9 +1260,7 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             hasSource: !!(q.sourceUrl && q.sourceName),
             difficulty: q.difficulty,
             sourceDomain:
-              q.sourceUrl && q.sourceName
-                ? extractSourceDomain(q.sourceUrl, q.sourceName)
-                : null,
+              q.sourceUrl && q.sourceName ? extractSourceDomain(q.sourceUrl, q.sourceName) : null,
           };
         }
 

--- a/shared/models/rooms.ts
+++ b/shared/models/rooms.ts
@@ -48,7 +48,8 @@ export const rooms = pgTable('rooms', {
   hostPlayerId: uuid('host_player_id').references((): AnyPgColumn => roomPlayers.id, {
     onDelete: 'set null',
   }),
-  category: varchar('category', { length: 80 }).notNull(),
+  // Stores comma-separated categories or 'All' (extended to 255 by migration 0004)
+  category: varchar('category', { length: 255 }).notNull(),
   numRounds: integer('num_rounds').notNull(),
   questionIds: jsonb('question_ids').$type<string[]>().notNull().default([]),
   currentQuestionIndex: integer('current_question_index').notNull().default(0),
@@ -97,6 +98,8 @@ export const roomPresenceSchema = z.enum(ROOM_PRESENCES);
 export const roomCodeSchema = z.string().regex(ROOM_CODE_PATTERN);
 export const roomNicknameSchema = z.string().trim().min(1).max(20);
 export const roomCategorySchema = z.enum(['All', ...VALID_CATEGORIES]);
+// Multi-select: ['All'] means no filter; otherwise a non-empty list of specific categories
+export const roomCategoriesSchema = z.array(roomCategorySchema).min(1);
 export const roomRoundsSchema = z.union([
   z.literal(ROOM_ROUND_OPTIONS[0]),
   z.literal(ROOM_ROUND_OPTIONS[1]),
@@ -109,6 +112,7 @@ export type RoomPhase = z.infer<typeof roomPhaseSchema>;
 export type RoomVerdict = z.infer<typeof roomVerdictSchema>;
 export type RoomPresence = z.infer<typeof roomPresenceSchema>;
 export type RoomCategory = z.infer<typeof roomCategorySchema>;
+export type RoomCategories = z.infer<typeof roomCategoriesSchema>;
 export type RoomRounds = z.infer<typeof roomRoundsSchema>;
 
 export const insertRoomSchema = createInsertSchema(rooms, {
@@ -181,7 +185,7 @@ const roomSnapshotBaseSchema = z.object({
   status: roomStatusSchema,
   version: z.number().int().positive(),
   hostPlayerId: z.string().uuid().nullable(),
-  category: roomCategorySchema,
+  categories: roomCategoriesSchema,
   numRounds: roomRoundsSchema,
   currentQuestionIndex: z.number().int().nonnegative(),
   activePlayerId: z.string().uuid().nullable(),
@@ -224,7 +228,7 @@ export type RoomSnapshot = z.infer<typeof roomSnapshotSchema>;
 export const roomCodeParamsSchema = z.object({ code: roomCodeSchema });
 export const createRoomRequestSchema = z.object({
   nickname: roomNicknameSchema,
-  category: roomCategorySchema,
+  categories: roomCategoriesSchema,
   numRounds: roomRoundsSchema,
 });
 export const joinRoomRequestSchema = z.object({ nickname: roomNicknameSchema });

--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -79,7 +79,7 @@ const validSnapshot = {
   phase: 'QUESTION' as const,
   version: 2,
   hostPlayerId,
-  category: 'All' as const,
+  categories: ['All' as const],
   numRounds: 5 as const,
   currentQuestionIndex: 0,
   activePlayerId: hostPlayerId,
@@ -274,7 +274,7 @@ describe('RoomSnapshot contract', () => {
     ['status', 'waiting'],
     ['phase', 'VERIFYING'],
     ['code', 'OOPS1'],
-    ['category', 'History'],
+    ['categories', ['History']],
     ['numRounds', 7],
   ])('rejects an invalid snapshot %s', (field, value) => {
     expect(roomSnapshotSchema.safeParse({ ...validSnapshot, [field]: value }).success).toBe(false);
@@ -296,7 +296,8 @@ describe('RoomSnapshot contract', () => {
 describe('rooms endpoint contract', () => {
   it('validates create, join, code params, poll query, and error payloads', () => {
     expect(
-      createRoomRequestSchema.safeParse({ nickname: 'Host', category: 'All', numRounds: 5 }).success
+      createRoomRequestSchema.safeParse({ nickname: 'Host', categories: ['All'], numRounds: 5 })
+        .success
     ).toBe(true);
     expect(joinRoomRequestSchema.safeParse({ nickname: 'Guest' }).success).toBe(true);
     expect(roomCodeParamsSchema.safeParse({ code: 'ABCD2' }).success).toBe(true);
@@ -345,7 +346,7 @@ describe('rooms endpoint contract', () => {
 
   it('rejects invalid endpoint inputs', () => {
     expect(
-      createRoomRequestSchema.safeParse({ nickname: '', category: 'All', numRounds: 5 }).success
+      createRoomRequestSchema.safeParse({ nickname: '', categories: ['All'], numRounds: 5 }).success
     ).toBe(false);
     expect(answerRoomRequestSchema.safeParse({ answer: '' }).success).toBe(false);
     expect(startRoomRequestSchema.safeParse({ unexpected: true }).success).toBe(false);


### PR DESCRIPTION
## Summary

- **Multi-select categories**: Players can now select multiple categories (e.g. Technology + Science) instead of being limited to one or All. Clicking a category toggles it on/off; clicking "All" clears back to no filter.
- **Store**: `selectedCategory: string` → `selectedCategories: string[]` (empty = All); `setCategory` → `toggleCategory` with toggle semantics.
- **Server (`/api/questions`)**: Accepts new `?categories=Cat1,Cat2` comma-separated param alongside legacy `?category=`; uses `inArray` for multi-category filtering.
- **Multiplayer rooms**: `category` column extended to `varchar(255)` (migration `0004`) and stores comma-separated category lists. `createRoomRequestSchema` now takes `categories: string[]`; `buildRoomSnapshot` parses it back to an array. Lobby displays the full category list.
- **All tests updated** to use `categories: ['All']` / `selectedCategories: []` / `toggleCategory`.

## Test plan

- [ ] Start a solo game with "All" selected (no categories) — works as before
- [ ] Select one category (e.g. Technology) → questions are filtered to that category only
- [ ] Select two categories (e.g. Technology + Science) → questions from both categories appear
- [ ] Deselect all specific categories → falls back to "All"
- [ ] Host a multiplayer room with mixed categories → room stores and questions respect the selection
- [ ] `npm test` — 467/467 passing
- [ ] `npm run check` — TypeScript clean

## Linear

Closes STE-140

🤖 Generated with [Claude Code](https://claude.ai/claude-code)