### PR TITLE
feat(api): add multiplayer dispute voting lifecycle [STE-242]

### DIFF
--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -4,7 +4,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildTestApp } from './test/testApp';
-import { deriveRoomPresence } from './routes.rooms';
+import { deriveRoomPresence, determineDisputeVoteOutcome } from './routes.rooms';
 
 const dbMocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
@@ -219,6 +219,26 @@ describe('room lifecycle routes', () => {
     expect(deriveRoomPresence(new Date('2026-07-03T15:00:20.000Z'), observedAt)).toBe('away');
     expect(deriveRoomPresence(new Date('2026-07-03T15:00:00.000Z'), observedAt)).toBe('away');
     expect(deriveRoomPresence(new Date('2026-07-03T14:59:59.999Z'), observedAt)).toBe('stale');
+  });
+
+  it.each([
+    [1, 0, 0, 1, 'approved'],
+    [2, 0, 1, 2, 'approved'],
+    [1, 1, 0, 2, 'tied'],
+    [1, 2, 0, 2, 'rejected'],
+    [1, 0, 2, 2, 'rejected'],
+  ] as const)(
+    'determines dispute outcome for yes=%i no=%i missing=%i threshold=%i',
+    (yesCount, noCount, nonResponseCount, threshold, expected) => {
+      expect(determineDisputeVoteOutcome(yesCount, noCount, nonResponseCount, threshold)).toBe(
+        expected
+      );
+    }
+  );
+
+  it('preserves explicit expiry and cancellation outcomes', () => {
+    expect(determineDisputeVoteOutcome(2, 0, 0, 2, 'expired')).toBe('expired');
+    expect(determineDisputeVoteOutcome(2, 0, 0, 2, 'canceled')).toBe('canceled');
   });
 
   it('creates a lobby room and its host atomically after cleaning up expired rooms', async () => {

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -178,6 +178,22 @@ function question(id = 'question-1') {
   };
 }
 
+function openDisputeVote(overrides: Record<string, unknown> = {}) {
+  return {
+    disputeId: 'dispute-1',
+    disputingPlayerId: hostId,
+    disputingPlayerName: 'Host',
+    explanation: 'The alternate answer should count.',
+    eligibleVoterIds: [guestId],
+    submittedVoterIds: [],
+    threshold: 1,
+    openedAt: '2026-07-03T15:00:00.000Z',
+    closesAt: '2099-07-03T15:01:00.000Z',
+    status: 'OPEN' as const,
+    ...overrides,
+  };
+}
+
 function queueSelect(...results: unknown[][]) {
   dbMocks.selectResults.push(...results);
 }
@@ -237,8 +253,255 @@ describe('room lifecycle routes', () => {
   );
 
   it('preserves explicit expiry and cancellation outcomes', () => {
-    expect(determineDisputeVoteOutcome(2, 0, 0, 2, 'expired')).toBe('expired');
+    expect(determineDisputeVoteOutcome(2, 0, 1, 2, 'expired')).toBe('approved');
+    expect(determineDisputeVoteOutcome(1, 0, 2, 2, 'expired')).toBe('expired');
     expect(determineDisputeVoteOutcome(2, 0, 0, 2, 'canceled')).toBe('canceled');
+  });
+
+  it('submits a room-scoped dispute and freezes eligible voters', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const attempt = {
+      questionId: 'question-1',
+      playerId: hostId,
+      submittedAnswer: 'Toronto',
+      verdict: 'INCORRECT' as const,
+      pointsDelta: -1,
+    };
+    const revealRoom = room({
+      status: 'active',
+      phase: 'REVEAL',
+      activePlayerId: hostId,
+      questionIds: ['question-1'],
+      currentAttempt: attempt,
+      opponentDisputeVotingEnabled: true,
+      activeDisputeId: null,
+      currentDisputeVote: null,
+    });
+    const vote = openDisputeVote();
+    const votingRoom = room({
+      ...revealRoom,
+      phase: 'DISPUTE_VOTE',
+      version: 2,
+      activeDisputeId: 'dispute-1',
+      currentDisputeVote: vote,
+    });
+    queueSelect(
+      [revealRoom],
+      [player()],
+      [question()],
+      [player(), guest],
+      [player(), guest],
+      [question()]
+    );
+    dbMocks.insertResults.push([{ id: 'dispute-1' }]);
+    dbMocks.updateResults.push([votingRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/disputes')
+      .set('X-Player-Token', 'host-secret')
+      .send({ explanation: vote.explanation })
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({
+      phase: 'DISPUTE_VOTE',
+      currentDisputeVote: { eligibleVoterIds: [guestId], threshold: 1 },
+    });
+  });
+
+  it('rejects dispute submission by a non-answering player and duplicate attempts', async () => {
+    const attempt = {
+      questionId: 'question-1',
+      playerId: hostId,
+      submittedAnswer: 'Toronto',
+      verdict: 'INCORRECT' as const,
+      pointsDelta: -1,
+    };
+    const revealRoom = room({
+      status: 'active',
+      phase: 'REVEAL',
+      activePlayerId: hostId,
+      currentAttempt: attempt,
+    });
+    const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
+    queueSelect([revealRoom], [guest]);
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/disputes')
+      .set('X-Player-Token', 'guest-secret')
+      .send({ explanation: 'Please review this answer.' })
+      .expect(403);
+
+    queueSelect([{ ...revealRoom, activeDisputeId: 'dispute-1' }], [player()]);
+    await request(app)
+      .post('/api/rooms/ABCD2/disputes')
+      .set('X-Player-Token', 'host-secret')
+      .send({ explanation: 'Please review this answer.' })
+      .expect(409);
+  });
+
+  it('requires authentication before an expired vote can finalize', async () => {
+    queueSelect([
+      room({
+        status: 'active',
+        phase: 'DISPUTE_VOTE',
+        activeDisputeId: 'dispute-1',
+        currentDisputeVote: openDisputeVote({ closesAt: '2020-01-01T00:00:00.000Z' }),
+      }),
+    ]);
+    const app = await buildTestApp();
+
+    await request(app).post('/api/rooms/ABCD2/disputes/vote').send({ approve: true }).expect(401);
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it('finalizes an all-ballots approval and converts the attempt once', async () => {
+    const guest = player({
+      id: guestId,
+      nickname: 'Guest',
+      token: 'guest-secret',
+      joinOrder: 1,
+      isHost: false,
+    });
+    const attempt = {
+      questionId: 'question-1',
+      playerId: hostId,
+      submittedAnswer: 'Toronto',
+      verdict: 'INCORRECT' as const,
+      pointsDelta: -1,
+    };
+    const vote = openDisputeVote();
+    const votingRoom = room({
+      status: 'active',
+      phase: 'DISPUTE_VOTE',
+      activePlayerId: hostId,
+      questionIds: ['question-1'],
+      currentAttempt: attempt,
+      opponentDisputeVotingEnabled: true,
+      activeDisputeId: 'dispute-1',
+      currentDisputeVote: vote,
+    });
+    const finalizedRoom = room({
+      ...votingRoom,
+      phase: 'REVEAL',
+      version: 2,
+      currentAttempt: { ...attempt, verdict: 'CORRECT', pointsDelta: 1 },
+      currentDisputeVote: {
+        ...vote,
+        submittedVoterIds: [guestId],
+        status: 'FINALIZED',
+        yesCount: 1,
+        noCount: 0,
+        nonResponseCount: 0,
+        outcome: 'approved',
+        originalPointsDelta: -1,
+        finalPointsDelta: 1,
+        decidedAt: '2026-07-03T15:00:30.000Z',
+      },
+    });
+    queueSelect(
+      [votingRoom],
+      [guest],
+      [{ approve: true }],
+      [question()],
+      [player(), guest],
+      [question()]
+    );
+    dbMocks.insertResults.push([]);
+    dbMocks.updateResults.push([], [finalizedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .post('/api/rooms/ABCD2/disputes/vote')
+      .set('X-Player-Token', 'guest-secret')
+      .send({ approve: true })
+      .expect(200);
+
+    expect(response.body.snapshot).toMatchObject({
+      phase: 'REVEAL',
+      currentAttempt: { verdict: 'CORRECT', pointsDelta: 1 },
+      currentDisputeVote: { outcome: 'approved' },
+    });
+  });
+
+  it('requires the host to cancel an open dispute vote', async () => {
+    const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
+    queueSelect(
+      [
+        room({
+          status: 'active',
+          phase: 'DISPUTE_VOTE',
+          activeDisputeId: 'dispute-1',
+          currentDisputeVote: openDisputeVote(),
+        }),
+      ],
+      [guest]
+    );
+    const app = await buildTestApp();
+
+    await request(app)
+      .post('/api/rooms/ABCD2/disputes/cancel')
+      .set('X-Player-Token', 'guest-secret')
+      .send({})
+      .expect(403);
+  });
+
+  it('finalizes an expired vote during polling and returns the recovered state', async () => {
+    const attempt = {
+      questionId: 'question-1',
+      playerId: hostId,
+      submittedAnswer: 'Toronto',
+      verdict: 'INCORRECT' as const,
+      pointsDelta: -1,
+    };
+    const vote = openDisputeVote({ closesAt: '2020-01-01T00:00:00.000Z' });
+    const votingRoom = room({
+      status: 'active',
+      phase: 'DISPUTE_VOTE',
+      activePlayerId: hostId,
+      questionIds: ['question-1'],
+      currentAttempt: attempt,
+      activeDisputeId: 'dispute-1',
+      currentDisputeVote: vote,
+    });
+    const finalizedRoom = room({
+      ...votingRoom,
+      phase: 'REVEAL',
+      version: 2,
+      currentDisputeVote: {
+        ...vote,
+        status: 'FINALIZED',
+        yesCount: 0,
+        noCount: 0,
+        nonResponseCount: 1,
+        outcome: 'expired',
+        originalPointsDelta: -1,
+        finalPointsDelta: -1,
+        decidedAt: '2026-07-03T15:00:00.000Z',
+      },
+    });
+    const guest = player({ id: guestId, token: 'guest-secret', isHost: false });
+    queueSelect([votingRoom], [player()], [], [question()], [player(), guest], [question()]);
+    dbMocks.updateResults.push([], [], [finalizedRoom]);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/rooms/ABCD2')
+      .set('X-Player-Token', 'host-secret')
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      phase: 'REVEAL',
+      currentAttempt: { verdict: 'INCORRECT', pointsDelta: -1 },
+      currentDisputeVote: { outcome: 'expired' },
+    });
   });
 
   it('creates a lobby room and its host atomically after cleaning up expired rooms', async () => {

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -290,8 +290,9 @@ export function determineDisputeVoteOutcome(
   threshold: number,
   override?: 'canceled' | 'expired'
 ): 'approved' | 'rejected' | 'tied' | 'expired' | 'canceled' {
-  if (override) return override;
+  if (override === 'canceled') return override;
   if (yesCount >= threshold) return 'approved';
+  if (override === 'expired') return override;
   if (nonResponseCount === 0 && yesCount === noCount) return 'tied';
   return 'rejected';
 }
@@ -1011,9 +1012,9 @@ export function registerRoomRoutes(app: Express): void {
           !room.activeDisputeId
         )
           throw new RoomRouteError(409, 'No open dispute vote');
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
         if (new Date(room.currentDisputeVote.closesAt) <= new Date())
           return finalizeDisputeVote(tx, room, 'expired');
-        const actor = await authenticateRoomPlayer(req, room.id, tx);
         if (!room.currentDisputeVote.eligibleVoterIds.includes(actor.id))
           throw new RoomRouteError(403, 'Player is not eligible to vote');
         try {
@@ -1067,8 +1068,18 @@ export function registerRoomRoutes(app: Express): void {
           .limit(1)
           .for('update');
         if (!room) throw new RoomRouteError(404, 'Room not found');
+        if (isExpired(room)) throw new RoomRouteError(404, 'Room expired');
+        if (room.status !== 'active' || room.phase !== 'DISPUTE_VOTE') {
+          throw new RoomRouteError(409, 'No open dispute vote');
+        }
         const actor = await authenticateRoomPlayer(req, room.id, tx);
         requireHost(actor, room);
+        if (
+          room.currentDisputeVote?.status === 'OPEN' &&
+          new Date(room.currentDisputeVote.closesAt) <= new Date()
+        ) {
+          return finalizeDisputeVote(tx, room, 'expired');
+        }
         return finalizeDisputeVote(tx, room, 'canceled');
       });
       return res.json(
@@ -1298,7 +1309,7 @@ export function registerRoomRoutes(app: Express): void {
 
         await tx
           .update(disputes)
-          .set({ finalPointsDelta: correctPoints, decidedAt: new Date() })
+          .set({ outcome: 'approved', finalPointsDelta: correctPoints, decidedAt: new Date() })
           .where(eq(disputes.id, room.activeDisputeId));
 
         const [awardedRoom] = await tx
@@ -1419,6 +1430,8 @@ export function registerRoomRoutes(app: Express): void {
             .set({
               status: 'finished',
               phase: 'GAME_OVER',
+              activeDisputeId: null,
+              currentDisputeVote: null,
               version: sql`${rooms.version} + 1`,
               updatedAt: now,
             })
@@ -1582,6 +1595,8 @@ export function registerRoomRoutes(app: Express): void {
           .set({
             status: isLobby ? 'abandoned' : 'finished',
             phase: isLobby ? 'LOBBY' : 'GAME_OVER',
+            activeDisputeId: null,
+            currentDisputeVote: null,
             version: sql`${rooms.version} + 1`,
             updatedAt: new Date(),
           })

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -16,6 +16,10 @@ import {
   advanceRoomResponseSchema,
   answerRoomRequestSchema,
   answerRoomResponseSchema,
+  cancelDisputeVoteRequestSchema,
+  cancelDisputeVoteResponseSchema,
+  castDisputeVoteRequestSchema,
+  castDisputeVoteResponseSchema,
   continueRoomRequestSchema,
   continueRoomResponseSchema,
   createRoomRequestSchema,
@@ -28,6 +32,8 @@ import {
   leaveRoomResponseSchema,
   pollRoomRequestSchema,
   questions,
+  disputeBallots,
+  disputes,
   roomCodeParamsSchema,
   roomPlayers,
   roomSnapshotSchema,
@@ -35,6 +41,8 @@ import {
   seenQuestions,
   startRoomRequestSchema,
   startRoomResponseSchema,
+  submitMultiplayerDisputeRequestSchema,
+  submitMultiplayerDisputeResponseSchema,
   skipRoomRequestSchema,
   skipRoomResponseSchema,
   roomActionResponseSchema,
@@ -59,6 +67,8 @@ const STALE_THRESHOLD_MS = 30 * 1000;
 const SKIP_THRESHOLD_MS = 60 * 1000;
 const HOST_PROMOTION_THRESHOLD_MS = 2 * 60 * 1000;
 const LOBBY_ABANDONMENT_THRESHOLD_MS = 5 * 60 * 1000;
+const DISPUTE_VOTE_DURATION_MS = 60 * 1000;
+const DISPUTE_BALLOT_CONSTRAINT = 'uq_dispute_ballots_dispute_voter';
 
 type RoomReadDatabase = Pick<typeof db, 'select'>;
 
@@ -269,6 +279,90 @@ function sendRoomError(res: Response, error: unknown, context: string) {
 
   console.error(context, error);
   return res.status(500).json({ message: 'Internal server error' });
+}
+
+type RoomTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export function determineDisputeVoteOutcome(
+  yesCount: number,
+  noCount: number,
+  nonResponseCount: number,
+  threshold: number,
+  override?: 'canceled' | 'expired'
+): 'approved' | 'rejected' | 'tied' | 'expired' | 'canceled' {
+  if (override) return override;
+  if (yesCount >= threshold) return 'approved';
+  if (nonResponseCount === 0 && yesCount === noCount) return 'tied';
+  return 'rejected';
+}
+
+async function finalizeDisputeVote(
+  tx: RoomTransaction,
+  room: Room,
+  outcomeOverride?: 'canceled' | 'expired',
+  now = new Date()
+): Promise<Room> {
+  const vote = room.currentDisputeVote;
+  if (!vote || vote.status !== 'OPEN' || !room.activeDisputeId || !room.currentAttempt) {
+    throw new RoomRouteError(409, 'No open dispute vote');
+  }
+
+  const ballots = await tx
+    .select()
+    .from(disputeBallots)
+    .where(eq(disputeBallots.disputeId, room.activeDisputeId));
+  const yesCount = ballots.filter((ballot) => ballot.approve).length;
+  const noCount = ballots.length - yesCount;
+  const nonResponseCount = Math.max(0, vote.eligibleVoterIds.length - ballots.length);
+  const outcome = determineDisputeVoteOutcome(
+    yesCount,
+    noCount,
+    nonResponseCount,
+    vote.threshold,
+    outcomeOverride
+  );
+  const [question] = await tx
+    .select()
+    .from(questions)
+    .where(eq(questions.id, room.currentAttempt.questionId))
+    .limit(1);
+  if (!question) throw new Error(`Question ${room.currentAttempt.questionId} not found`);
+
+  const approved = outcome === 'approved';
+  const finalPointsDelta = approved
+    ? pointsFor(question.difficulty as import('@shared/lib/answers').Difficulty)
+    : room.currentAttempt.pointsDelta;
+  const finalizedVote = {
+    ...vote,
+    status: 'FINALIZED' as const,
+    yesCount,
+    noCount,
+    nonResponseCount,
+    outcome,
+    originalPointsDelta: room.currentAttempt.pointsDelta,
+    finalPointsDelta,
+    decidedAt: now.toISOString(),
+  };
+
+  await tx
+    .update(disputes)
+    .set({ outcome, finalPointsDelta, decidedAt: now })
+    .where(eq(disputes.id, room.activeDisputeId));
+  const [updatedRoom] = await tx
+    .update(rooms)
+    .set({
+      phase: 'REVEAL',
+      currentAttempt: approved
+        ? { ...room.currentAttempt, verdict: 'CORRECT' as const, pointsDelta: finalPointsDelta }
+        : room.currentAttempt,
+      currentDisputeVote: finalizedVote,
+      version: sql`${rooms.version} + 1`,
+      updatedAt: now,
+    })
+    .where(and(eq(rooms.id, room.id), eq(rooms.phase, 'DISPUTE_VOTE')))
+    .returning();
+  if (!updatedRoom) throw new RoomRouteError(409, 'Dispute vote was already finalized');
+  return updatedRoom;
 }
 
 type DbTx = Pick<typeof db, 'select' | 'update'>;
@@ -746,6 +840,8 @@ export function registerRoomRoutes(app: Express): void {
             phase: transition.phase,
             currentQuestionIndex: transition.currentQuestionIndex,
             activePlayerId: transition.activePlayerId,
+            activeDisputeId: null,
+            currentDisputeVote: null,
             version: sql`${rooms.version} + 1`,
             updatedAt: new Date(),
           })
@@ -785,6 +881,206 @@ export function registerRoomRoutes(app: Express): void {
     }
   });
 
+  app.post('/api/rooms/:code/disputes', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      const input = submitMultiplayerDisputeRequestSchema.parse(req.body);
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+        if (!room) throw new RoomRouteError(404, 'Room not found');
+        if (isExpired(room)) throw new RoomRouteError(404, 'Room expired');
+        if (room.status !== 'active' || room.phase !== 'REVEAL' || !room.currentAttempt) {
+          throw new RoomRouteError(409, 'Room is not accepting disputes');
+        }
+        if (room.currentAttempt.verdict !== 'INCORRECT') {
+          throw new RoomRouteError(409, 'Only an incorrect answer can be disputed');
+        }
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        if (actor.id !== room.activePlayerId || actor.id !== room.currentAttempt.playerId) {
+          throw new RoomRouteError(403, 'Only the answering player can submit a dispute');
+        }
+        if (room.activeDisputeId)
+          throw new RoomRouteError(409, 'A dispute already exists for this attempt');
+
+        const [question] = await tx
+          .select()
+          .from(questions)
+          .where(eq(questions.id, room.currentAttempt.questionId))
+          .limit(1);
+        if (!question) throw new Error(`Question ${room.currentAttempt.questionId} not found`);
+        const eligiblePlayers = room.opponentDisputeVotingEnabled
+          ? await tx
+              .select()
+              .from(roomPlayers)
+              .where(and(eq(roomPlayers.roomId, room.id), isNull(roomPlayers.leftAt)))
+          : [];
+        const eligibleVoters = eligiblePlayers.filter((player) => player.id !== actor.id);
+        const threshold = Math.floor(eligibleVoters.length / 2) + 1;
+        const attemptKey = `${room.id}:${room.currentQuestionIndex}`;
+        const now = new Date();
+        const [dispute] = await tx
+          .insert(disputes)
+          .values({
+            questionId: question.id,
+            questionText: question.question,
+            correctAnswer: question.answer,
+            teamName: actor.nickname,
+            submittedAnswer: room.currentAttempt.submittedAnswer,
+            teamExplanation: input.explanation,
+            roomId: room.id,
+            roomCode: room.code,
+            attemptKey,
+            disputingPlayerId: actor.id,
+            disputingPlayerName: actor.nickname,
+            votingEnabled: room.opponentDisputeVotingEnabled,
+            eligibleVoterSnapshot: eligibleVoters.map((player) => ({
+              playerId: player.id,
+              displayName: player.nickname,
+            })),
+            threshold: eligibleVoters.length ? threshold : null,
+            originalPointsDelta: room.currentAttempt.pointsDelta,
+            finalPointsDelta: eligibleVoters.length ? null : room.currentAttempt.pointsDelta,
+            outcome:
+              room.opponentDisputeVotingEnabled && eligibleVoters.length === 0 ? 'canceled' : null,
+            decidedAt:
+              room.opponentDisputeVotingEnabled && eligibleVoters.length === 0 ? now : null,
+          })
+          .returning();
+
+        const openVote =
+          room.opponentDisputeVotingEnabled && eligibleVoters.length > 0
+            ? {
+                disputeId: dispute.id,
+                disputingPlayerId: actor.id,
+                disputingPlayerName: actor.nickname,
+                explanation: input.explanation,
+                eligibleVoterIds: eligibleVoters.map((player) => player.id),
+                submittedVoterIds: [],
+                threshold,
+                openedAt: now.toISOString(),
+                closesAt: new Date(now.getTime() + DISPUTE_VOTE_DURATION_MS).toISOString(),
+                status: 'OPEN' as const,
+              }
+            : null;
+        const [savedRoom] = await tx
+          .update(rooms)
+          .set({
+            activeDisputeId: dispute.id,
+            currentDisputeVote: openVote,
+            phase: openVote ? 'DISPUTE_VOTE' : 'REVEAL',
+            version: sql`${rooms.version} + 1`,
+            updatedAt: now,
+          })
+          .where(
+            and(eq(rooms.id, room.id), eq(rooms.phase, 'REVEAL'), isNull(rooms.activeDisputeId))
+          )
+          .returning();
+        if (!savedRoom) throw new RoomRouteError(409, 'A dispute already exists for this attempt');
+        return savedRoom;
+      });
+      return res.json(
+        submitMultiplayerDisputeResponseSchema.parse({
+          snapshot: await buildRoomSnapshot(db, updatedRoom),
+        })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error submitting room dispute:');
+    }
+  });
+
+  app.post('/api/rooms/:code/disputes/vote', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      const input = castDisputeVoteRequestSchema.parse(req.body);
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+        if (!room) throw new RoomRouteError(404, 'Room not found');
+        if (
+          room.phase !== 'DISPUTE_VOTE' ||
+          room.currentDisputeVote?.status !== 'OPEN' ||
+          !room.activeDisputeId
+        )
+          throw new RoomRouteError(409, 'No open dispute vote');
+        if (new Date(room.currentDisputeVote.closesAt) <= new Date())
+          return finalizeDisputeVote(tx, room, 'expired');
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        if (!room.currentDisputeVote.eligibleVoterIds.includes(actor.id))
+          throw new RoomRouteError(403, 'Player is not eligible to vote');
+        try {
+          await tx.insert(disputeBallots).values({
+            disputeId: room.activeDisputeId,
+            voterPlayerId: actor.id,
+            voterPlayerName: actor.nickname,
+            approve: input.approve,
+          });
+        } catch (error) {
+          if (hasConstraint(error, DISPUTE_BALLOT_CONSTRAINT))
+            throw new RoomRouteError(409, 'Player has already voted');
+          throw error;
+        }
+        const submittedVoterIds = [...room.currentDisputeVote.submittedVoterIds, actor.id];
+        const roomWithBallot = {
+          ...room,
+          currentDisputeVote: { ...room.currentDisputeVote, submittedVoterIds },
+        };
+        if (submittedVoterIds.length === room.currentDisputeVote.eligibleVoterIds.length)
+          return finalizeDisputeVote(tx, roomWithBallot);
+        const [savedRoom] = await tx
+          .update(rooms)
+          .set({
+            currentDisputeVote: roomWithBallot.currentDisputeVote,
+            version: sql`${rooms.version} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(rooms.id, room.id), eq(rooms.phase, 'DISPUTE_VOTE')))
+          .returning();
+        if (!savedRoom) throw new RoomRouteError(409, 'Dispute vote state changed');
+        return savedRoom;
+      });
+      return res.json(
+        castDisputeVoteResponseSchema.parse({ snapshot: await buildRoomSnapshot(db, updatedRoom) })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error casting dispute vote:');
+    }
+  });
+
+  app.post('/api/rooms/:code/disputes/cancel', async (req, res) => {
+    try {
+      const code = parseRoomCode(req.params.code);
+      cancelDisputeVoteRequestSchema.parse(req.body);
+      const updatedRoom = await db.transaction(async (tx) => {
+        const [room] = await tx
+          .select()
+          .from(rooms)
+          .where(eq(rooms.code, code))
+          .limit(1)
+          .for('update');
+        if (!room) throw new RoomRouteError(404, 'Room not found');
+        const actor = await authenticateRoomPlayer(req, room.id, tx);
+        requireHost(actor, room);
+        return finalizeDisputeVote(tx, room, 'canceled');
+      });
+      return res.json(
+        cancelDisputeVoteResponseSchema.parse({
+          snapshot: await buildRoomSnapshot(db, updatedRoom),
+        })
+      );
+    } catch (error) {
+      return sendRoomError(res, error, 'Error canceling dispute vote:');
+    }
+  });
+
   app.post('/api/rooms/:code/continue', async (req, res) => {
     try {
       const code = parseRoomCode(req.params.code);
@@ -814,6 +1110,8 @@ export function registerRoomRoutes(app: Express): void {
           .set({
             phase: 'QUESTION',
             currentAttempt: null,
+            activeDisputeId: null,
+            currentDisputeVote: null,
             version: sql`${rooms.version} + 1`,
             updatedAt: new Date(),
           })
@@ -971,8 +1269,9 @@ export function registerRoomRoutes(app: Express): void {
         }
 
         const actor = await authenticateRoomPlayer(req, room.id, tx);
-        if (actor.id !== room.hostPlayerId && actor.id !== room.activePlayerId) {
-          throw new RoomRouteError(403, 'Only the host or active player can award disputed points');
+        requireHost(actor, room);
+        if (!room.activeDisputeId || room.opponentDisputeVotingEnabled) {
+          throw new RoomRouteError(409, 'No manual dispute award is available');
         }
 
         // Look up the question to calculate the correct point value
@@ -996,6 +1295,11 @@ export function registerRoomRoutes(app: Express): void {
           verdict: 'CORRECT' as const,
           pointsDelta: correctPoints,
         };
+
+        await tx
+          .update(disputes)
+          .set({ finalPointsDelta: correctPoints, decidedAt: new Date() })
+          .where(eq(disputes.id, room.activeDisputeId));
 
         const [awardedRoom] = await tx
           .update(rooms)
@@ -1325,6 +1629,14 @@ export function registerRoomRoutes(app: Express): void {
 
         const player = await authenticateRoomPlayer(req, currentRoom.id, tx);
         await tx.update(roomPlayers).set({ lastSeenAt: now }).where(eq(roomPlayers.id, player.id));
+
+        if (
+          currentRoom.phase === 'DISPUTE_VOTE' &&
+          currentRoom.currentDisputeVote?.status === 'OPEN' &&
+          new Date(currentRoom.currentDisputeVote.closesAt) <= now
+        ) {
+          return finalizeDisputeVote(tx, currentRoom, 'expired', now);
+        }
 
         if (currentRoom.status !== 'lobby' && currentRoom.status !== 'active') {
           return currentRoom;


### PR DESCRIPTION
## Summary
- add room-scoped dispute submission with server-derived QA context and frozen voter eligibility
- add authenticated ballot, cancellation, expiry, and deterministic finalization flows
- restrict disabled-mode manual awards to the host and persist the final QA delta
- guard state transitions through the DISPUTE_VOTE phase and clear dispute state after advancement
- add majority, tie, rejection, expiry, and cancellation outcome tests

## Why
STE-242 supplies the server-authoritative lifecycle required by the STE-125 opponent-voting feature. It builds on the persistence and shared contracts merged in STE-241.

## Validation
- npm run check
- npx vitest run server/routes.rooms.test.ts (53 passed)
- npm test (485 passed)
- npm run lint (0 errors; 23 pre-existing warnings)
- npm run build

Linear: https://linear.app/stephs-vibe-coding/issue/STE-242/featapi-implement-multiplayer-dispute-vote-lifecycle-ste-125