### PR TITLE
feat(client): add dispute voting UI [STE-243]

### DIFF
--- a/client/src/components/DisputeModal.test.tsx
+++ b/client/src/components/DisputeModal.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DisputeModal } from './DisputeModal';
+
+const mockSaveDispute = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock('@/lib/disputes', () => ({
+  saveDispute: (...args: unknown[]) => mockSaveDispute(...args),
+}));
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  questionId: 'q1',
+  questionText: 'Which planet is closest to the Sun?',
+  correctAnswer: 'Mercury',
+  teamName: 'Alice',
+  submittedAnswer: 'Venus',
+  onDisputeSubmitted: vi.fn(),
+};
+
+describe('DisputeModal', () => {
+  beforeEach(() => {
+    mockSaveDispute.mockReset();
+    mockToast.mockReset();
+    baseProps.onOpenChange.mockReset();
+    baseProps.onDisputeSubmitted.mockReset();
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves the generic solo dispute submission flow', async () => {
+    mockSaveDispute.mockResolvedValue({ success: true });
+    render(<DisputeModal {...baseProps} />);
+    fireEvent.change(screen.getByPlaceholderText(/explain why/i), {
+      target: { value: 'The accepted source says Venus.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Dispute' }));
+
+    await waitFor(() => expect(mockSaveDispute).toHaveBeenCalled());
+    expect(mockSaveDispute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        questionId: 'q1',
+        teamExplanation: 'The accepted source says Venus.',
+      })
+    );
+    expect(baseProps.onDisputeSubmitted).toHaveBeenCalled();
+    expect(baseProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('uses the room-scoped callback without calling the generic endpoint', async () => {
+    const submitDispute = vi.fn().mockResolvedValue(undefined);
+    render(<DisputeModal {...baseProps} submitDispute={submitDispute} />);
+    fireEvent.change(screen.getByPlaceholderText(/explain why/i), {
+      target: { value: '  The room answer should be accepted.  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Dispute' }));
+
+    await waitFor(() =>
+      expect(submitDispute).toHaveBeenCalledWith('The room answer should be accepted.')
+    );
+    expect(mockSaveDispute).not.toHaveBeenCalled();
+    expect(baseProps.onDisputeSubmitted).toHaveBeenCalled();
+  });
+
+  it('keeps the modal open and shows a server error for a failed room submission', async () => {
+    const submitDispute = vi.fn().mockRejectedValue(new Error('Room is not accepting disputes'));
+    render(<DisputeModal {...baseProps} submitDispute={submitDispute} />);
+    fireEvent.change(screen.getByPlaceholderText(/explain why/i), {
+      target: { value: 'Evidence' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Dispute' }));
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Room is not accepting disputes' })
+      )
+    );
+    expect(baseProps.onDisputeSubmitted).not.toHaveBeenCalled();
+    expect(baseProps.onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/client/src/components/DisputeModal.tsx
+++ b/client/src/components/DisputeModal.tsx
@@ -21,8 +21,10 @@ interface DisputeModalProps {
   correctAnswer: string;
   teamName: string;
   submittedAnswer: string | null;
-  /** Callback invoked after a dispute is successfully submitted. In solo mode, this should call markDisputeSubmitted from the game store. In multiplayer, it sets local state. */
+  /** Callback invoked after a dispute is successfully submitted. */
   onDisputeSubmitted: () => void;
+  /** Optional room-scoped submission. Solo callers omit this and keep using saveDispute. */
+  submitDispute?: (explanation: string) => Promise<void>;
 }
 
 export function DisputeModal({
@@ -34,8 +36,10 @@ export function DisputeModal({
   teamName,
   submittedAnswer,
   onDisputeSubmitted,
+  submitDispute,
 }: DisputeModalProps) {
   const [explanation, setExplanation] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
 
   const handleSubmit = async () => {
@@ -48,30 +52,46 @@ export function DisputeModal({
       return;
     }
 
-    const result = await saveDispute({
-      questionId,
-      questionText,
-      correctAnswer,
-      teamName,
-      submittedAnswer,
-      teamExplanation: explanation,
-    });
+    setIsSubmitting(true);
+    try {
+      if (submitDispute) {
+        await submitDispute(explanation.trim());
+      } else {
+        const result = await saveDispute({
+          questionId,
+          questionText,
+          correctAnswer,
+          teamName,
+          submittedAnswer,
+          teamExplanation: explanation,
+        });
 
-    if (!result.success) {
-      toast({
-        title: 'Error',
-        description: result.message || 'Failed to submit dispute. Please try again.',
-        variant: 'destructive',
-      });
+        if (!result.success) throw new Error(result.message || 'Failed to submit dispute.');
+      }
+    } catch (error) {
+      if ((error as { status?: number }).status !== 409) {
+        toast({
+          title: 'Error',
+          description:
+            error instanceof Error && error.message
+              ? error.message
+              : 'Failed to submit dispute. Please try again.',
+          variant: 'destructive',
+        });
+      }
       return;
+    } finally {
+      setIsSubmitting(false);
+    }
+
+    if (!submitDispute) {
+      toast({
+        title: 'Dispute Submitted',
+        description: "Thank you for helping us improve the game. We'll review this.",
+      });
     }
 
     onDisputeSubmitted();
-
-    toast({
-      title: 'Dispute Submitted',
-      description: "Thank you for helping us improve the game. We'll review this.",
-    });
 
     setExplanation('');
     onOpenChange(false);
@@ -120,9 +140,16 @@ export function DisputeModal({
         </div>
 
         <div className="flex gap-2 justify-end">
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleSubmit} className="bg-primary">
-            Submit Dispute
+          <AlertDialogCancel disabled={isSubmitting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(event) => {
+              event.preventDefault();
+              void handleSubmit();
+            }}
+            className="bg-primary"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Submitting…' : 'Submit Dispute'}
           </AlertDialogAction>
         </div>
       </AlertDialogContent>

--- a/client/src/components/room/DisputeVoteView.test.tsx
+++ b/client/src/components/room/DisputeVoteView.test.tsx
@@ -1,0 +1,168 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { CastDisputeVoteResponse, RoomSnapshot } from '@shared/models/rooms';
+
+import { DisputeVoteView } from './DisputeVoteView';
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => toastError(...args) } }));
+
+type VoteSnapshot = Extract<RoomSnapshot, { phase: 'DISPUTE_VOTE' }>;
+
+function mutation(mutate = vi.fn(), isPending = false) {
+  return { mutate, isPending } as unknown as UseMutationResult<
+    CastDisputeVoteResponse,
+    Error,
+    { approve: boolean }
+  >;
+}
+
+function makeSnapshot(overrides: Partial<VoteSnapshot> = {}): VoteSnapshot {
+  const now = Date.now();
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    code: 'ABCD2',
+    status: 'active',
+    phase: 'DISPUTE_VOTE',
+    version: 3,
+    hostPlayerId: '22222222-2222-4222-8222-222222222222',
+    categories: ['All'],
+    numRounds: 5,
+    currentQuestionIndex: 0,
+    activePlayerId: '11111111-1111-4111-8111-111111111111',
+    currentAttempt: {
+      questionId: 'q1',
+      playerId: '11111111-1111-4111-8111-111111111111',
+      submittedAnswer: 'Venus',
+      verdict: 'INCORRECT',
+      pointsDelta: -3,
+    },
+    opponentDisputeVotingEnabled: true,
+    activeDisputeId: 'dispute-1',
+    currentDisputeVote: {
+      disputeId: 'dispute-1',
+      disputingPlayerId: '11111111-1111-4111-8111-111111111111',
+      disputingPlayerName: 'Alice',
+      explanation: 'The wording allows Venus.',
+      eligibleVoterIds: [
+        '22222222-2222-4222-8222-222222222222',
+        '33333333-3333-4333-8333-333333333333',
+      ],
+      submittedVoterIds: [],
+      threshold: 2,
+      openedAt: new Date(now - 10_000).toISOString(),
+      closesAt: new Date(now + 60_000).toISOString(),
+      status: 'OPEN',
+    },
+    currentQuestion: {
+      id: 'q1',
+      category: 'Science',
+      difficulty: 'Medium',
+      question: 'Which planet is closest to the Sun?',
+      pillar: 'Astronomy',
+      tags: [],
+      sourceUrl: null,
+      sourceName: null,
+      answer: 'Mercury',
+      acceptableAnswers: ['Mercury'],
+      explanation: 'Mercury is closest.',
+    },
+    players: [],
+    createdAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + 60_000).toISOString(),
+    ...overrides,
+  } as VoteSnapshot;
+}
+
+function renderVote(snapshot: VoteSnapshot, currentPlayerId: string, mutate = vi.fn()) {
+  return render(
+    <DisputeVoteView
+      snapshot={snapshot}
+      currentPlayerId={currentPlayerId}
+      castDisputeVote={mutation(mutate)}
+      cancelDisputeVote={mutation() as never}
+      refetch={vi.fn()}
+    />
+  );
+}
+
+describe('DisputeVoteView', () => {
+  beforeEach(() => toastError.mockClear());
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('shows the question, answers, explanation, private progress, and server deadline', () => {
+    renderVote(makeSnapshot(), '33333333-3333-4333-8333-333333333333');
+    expect(screen.getByText('Which planet is closest to the Sun?')).toBeInTheDocument();
+    expect(screen.getByText('Venus')).toBeInTheDocument();
+    expect(screen.getByText('Mercury')).toBeInTheDocument();
+    expect(screen.getByText('The wording allows Venus.')).toBeInTheDocument();
+    expect(screen.getByTestId('text-vote-progress')).toHaveTextContent('0 of 2 votes submitted');
+    expect(screen.getByTestId('text-vote-countdown')).toHaveTextContent(/\d+s/);
+    expect(screen.queryByText(/yes vote|no vote/i)).toBeNull();
+  });
+
+  it('shows vote controls only to an eligible opponent and submits one boolean choice', () => {
+    const mutate = vi.fn();
+    renderVote(makeSnapshot(), '33333333-3333-4333-8333-333333333333', mutate);
+    fireEvent.click(screen.getByRole('button', { name: 'Agree and award points' }));
+    expect(mutate).toHaveBeenCalledWith({ approve: true }, expect.any(Object));
+    expect(screen.getByRole('button', { name: 'Disagree with dispute' })).toBeInTheDocument();
+  });
+
+  it('locks an eligible opponent after reconnecting with their submitted ID', () => {
+    const snapshot = makeSnapshot({
+      currentDisputeVote: {
+        ...makeSnapshot().currentDisputeVote,
+        submittedVoterIds: ['33333333-3333-4333-8333-333333333333'],
+      },
+    });
+    renderVote(snapshot, '33333333-3333-4333-8333-333333333333');
+    expect(screen.getByTestId('text-vote-locked')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Agree and award points' })).toBeNull();
+  });
+
+  it('gives the disputing player waiting state without vote controls', () => {
+    renderVote(makeSnapshot(), '11111111-1111-4111-8111-111111111111');
+    expect(screen.getByTestId('text-disputant-waiting')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Agree and award points' })).toBeNull();
+  });
+
+  it('gives an ineligible observer progress without controls', () => {
+    renderVote(makeSnapshot(), '44444444-4444-4444-8444-444444444444');
+    expect(screen.getByTestId('text-observer-waiting')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Agree and award points' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Cancel dispute vote' })).toBeNull();
+  });
+
+  it('lets an eligible host vote and cancel without revealing ballot choices', () => {
+    renderVote(makeSnapshot(), '22222222-2222-4222-8222-222222222222');
+    expect(screen.getByRole('button', { name: 'Agree and award points' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel dispute vote' })).toBeInTheDocument();
+    expect(screen.queryByText(/alice voted/i)).toBeNull();
+  });
+
+  it('reconciles a 409 vote conflict by refetching without a toast', () => {
+    const refetch = vi.fn();
+    const error = Object.assign(new Error('Player has already voted'), { status: 409 });
+    const mutate = vi.fn((_body, options) => options.onError(error));
+    render(
+      <DisputeVoteView
+        snapshot={makeSnapshot()}
+        currentPlayerId="33333333-3333-4333-8333-333333333333"
+        castDisputeVote={mutation(mutate)}
+        cancelDisputeVote={mutation() as never}
+        refetch={refetch}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Disagree with dispute' }));
+    expect(refetch).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/room/DisputeVoteView.tsx
+++ b/client/src/components/room/DisputeVoteView.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Ban, Check, Clock } from 'lucide-react';
+import type { UseMutationResult } from '@tanstack/react-query';
+import type {
+  CancelDisputeVoteResponse,
+  CastDisputeVoteRequest,
+  CastDisputeVoteResponse,
+  RoomSnapshot,
+} from '@shared/models/rooms';
+
+import { isRoomConflict } from '@/hooks/use-room';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn, getDifficultyBadgeClass } from '@/lib/utils';
+
+type DisputeVoteSnapshot = Extract<RoomSnapshot, { phase: 'DISPUTE_VOTE' }>;
+
+interface DisputeVoteViewProps {
+  snapshot: DisputeVoteSnapshot;
+  currentPlayerId: string;
+  castDisputeVote: UseMutationResult<CastDisputeVoteResponse, Error, CastDisputeVoteRequest>;
+  cancelDisputeVote: UseMutationResult<CancelDisputeVoteResponse, Error, void>;
+  refetch: () => void;
+}
+
+function secondsRemaining(closesAt: string): number {
+  return Math.max(0, Math.ceil((new Date(closesAt).getTime() - Date.now()) / 1000));
+}
+
+export function DisputeVoteView({
+  snapshot,
+  currentPlayerId,
+  castDisputeVote,
+  cancelDisputeVote,
+  refetch,
+}: DisputeVoteViewProps) {
+  const vote = snapshot.currentDisputeVote;
+  const attempt = snapshot.currentAttempt;
+  const [remaining, setRemaining] = useState(() => secondsRemaining(vote.closesAt));
+  const isHost = snapshot.hostPlayerId === currentPlayerId;
+  const isDisputingPlayer = vote.disputingPlayerId === currentPlayerId;
+  const isEligible = vote.eligibleVoterIds.includes(currentPlayerId);
+  const hasVoted = vote.submittedVoterIds.includes(currentPlayerId);
+  const canVote = isEligible && !hasVoted;
+  const submittedCount = vote.submittedVoterIds.length;
+  const eligibleCount = vote.eligibleVoterIds.length;
+
+  useEffect(() => {
+    const updateRemaining = () => setRemaining(secondsRemaining(vote.closesAt));
+    updateRemaining();
+    const timer = window.setInterval(updateRemaining, 1000);
+    return () => window.clearInterval(timer);
+  }, [vote.closesAt]);
+
+  function handleVote(approve: boolean) {
+    if (castDisputeVote.isPending || !canVote) return;
+    castDisputeVote.mutate(
+      { approve },
+      {
+        onError: (error) => {
+          if (isRoomConflict(error)) {
+            refetch();
+            return;
+          }
+          toast.error(error.message || 'Failed to submit vote.');
+        },
+      }
+    );
+  }
+
+  function handleCancel() {
+    if (cancelDisputeVote.isPending || !isHost) return;
+    cancelDisputeVote.mutate(undefined, {
+      onError: (error) => {
+        if (isRoomConflict(error)) {
+          refetch();
+          return;
+        }
+        toast.error(error.message || 'Failed to cancel dispute vote.');
+      },
+    });
+  }
+
+  return (
+    <div className="w-full max-w-lg space-y-4" data-testid="dispute-vote-view">
+      <Card className="border-white/10 bg-white/5 backdrop-blur-md shadow-2xl">
+        <CardContent className="p-6 space-y-2 text-center">
+          <div className="flex flex-wrap gap-2 justify-center">
+            <Badge variant="outline" className="border-white/20 bg-white/5">
+              {snapshot.currentQuestion.category}
+            </Badge>
+            <Badge
+              className={cn(
+                'border-none',
+                getDifficultyBadgeClass(snapshot.currentQuestion.difficulty)
+              )}
+            >
+              {snapshot.currentQuestion.difficulty}
+            </Badge>
+          </div>
+          <h1 className="text-xl md:text-2xl font-bold leading-tight font-display">
+            {snapshot.currentQuestion.question}
+          </h1>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Card className="border-red-500/30 bg-red-500/10">
+          <CardContent className="p-4 text-center">
+            <div className="text-sm uppercase tracking-widest opacity-70 mb-1">
+              {vote.disputingPlayerName} answered
+            </div>
+            <div className="text-xl font-bold">{attempt?.submittedAnswer || '(Passed)'}</div>
+          </CardContent>
+        </Card>
+        <Card className="bg-primary/10 border-primary/20">
+          <CardContent className="p-4 text-center">
+            <div className="text-sm uppercase tracking-widest opacity-70 mb-1">Expected answer</div>
+            <div className="text-xl font-bold text-primary">{snapshot.currentQuestion.answer}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-white/10 bg-white/5">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Why this answer is disputed</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">{vote.explanation}</CardContent>
+      </Card>
+
+      <Card className="border-primary/30 bg-primary/5">
+        <CardContent className="p-5 space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="font-semibold">Opponent vote in progress</div>
+              <div
+                className="text-sm text-muted-foreground"
+                aria-live="polite"
+                data-testid="text-vote-progress"
+              >
+                {submittedCount} of {eligibleCount} votes submitted
+              </div>
+            </div>
+            <div
+              className="flex items-center gap-2 font-mono font-bold"
+              aria-label={`${remaining} seconds remaining`}
+              data-testid="text-vote-countdown"
+            >
+              <Clock className="size-4" /> {remaining}s
+            </div>
+          </div>
+          <div
+            className="h-2 overflow-hidden rounded-full bg-white/10"
+            role="progressbar"
+            aria-label="Votes submitted"
+            aria-valuemin={0}
+            aria-valuemax={eligibleCount}
+            aria-valuenow={submittedCount}
+          >
+            <div
+              className="h-full bg-primary transition-all"
+              style={{ width: `${eligibleCount ? (submittedCount / eligibleCount) * 100 : 0}%` }}
+            />
+          </div>
+
+          {isDisputingPlayer && (
+            <p className="text-center text-muted-foreground" data-testid="text-disputant-waiting">
+              Your dispute was submitted. Waiting for eligible opponents to vote…
+            </p>
+          )}
+          {!isDisputingPlayer && hasVoted && (
+            <p
+              className="text-center font-medium"
+              aria-live="polite"
+              data-testid="text-vote-locked"
+            >
+              Vote submitted. Your choice is locked.
+            </p>
+          )}
+          {!isDisputingPlayer && !isEligible && (
+            <p className="text-center text-muted-foreground" data-testid="text-observer-waiting">
+              Waiting for eligible opponents to vote…
+            </p>
+          )}
+
+          {canVote && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Button
+                onClick={() => handleVote(true)}
+                disabled={castDisputeVote.isPending}
+                className="h-12"
+                aria-label="Agree and award points"
+              >
+                <Check className="size-4 mr-2" /> Agree, award points
+              </Button>
+              <Button
+                onClick={() => handleVote(false)}
+                disabled={castDisputeVote.isPending}
+                variant="outline"
+                className="h-12"
+                aria-label="Disagree with dispute"
+              >
+                <Ban className="size-4 mr-2" /> Disagree
+              </Button>
+            </div>
+          )}
+
+          {isHost && (
+            <Button
+              onClick={handleCancel}
+              disabled={cancelDisputeVote.isPending}
+              variant="ghost"
+              className="w-full"
+              aria-label="Cancel dispute vote"
+            >
+              {cancelDisputeVote.isPending ? 'Canceling…' : 'Cancel vote'}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/components/room/RevealView.test.tsx
+++ b/client/src/components/room/RevealView.test.tsx
@@ -260,6 +260,35 @@ describe('RevealView', () => {
     expect(screen.getByRole('button', { name: /group agreed/i })).toBeInTheDocument();
   });
 
+  it('hides the pending dispute banner after a disabled-mode manual award', () => {
+    const snapshot = makeSnapshot({
+      hostPlayerId: 'p2',
+      activePlayerId: 'p1',
+      activeDisputeId: 'dispute-1',
+      opponentDisputeVotingEnabled: false,
+      currentAttempt: {
+        questionId: 'q1',
+        playerId: 'p1',
+        submittedAnswer: 'Venus',
+        verdict: 'CORRECT',
+        pointsDelta: 3,
+      },
+    });
+
+    render(
+      <RevealView
+        snapshot={snapshot}
+        currentPlayerId="p2"
+        advance={makeMutation()}
+        awardDispute={makeMutation()}
+        refetch={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('text-dispute-submitted')).toBeNull();
+    expect(screen.queryByRole('button', { name: /group agreed/i })).toBeNull();
+  });
+
   it.each([
     ['approved', 5, 'Dispute approved', '+5'],
     ['rejected', -3, 'Dispute rejected', '-3'],

--- a/client/src/components/room/RevealView.test.tsx
+++ b/client/src/components/room/RevealView.test.tsx
@@ -51,6 +51,9 @@ function makeSnapshot(overrides: Partial<RevealSnapshot> = {}): RevealSnapshot {
       verdict: 'CORRECT',
       pointsDelta: 5,
     },
+    opponentDisputeVotingEnabled: false,
+    activeDisputeId: null,
+    currentDisputeVote: null,
     currentQuestion: {
       id: 'q1',
       category: 'Science',
@@ -64,7 +67,10 @@ function makeSnapshot(overrides: Partial<RevealSnapshot> = {}): RevealSnapshot {
       acceptableAnswers: ['Mercury'],
       explanation: 'Mercury orbits closest to the sun.',
     },
-    players: [makePlayer({ id: 'p1', nickname: 'Alice' }), makePlayer({ id: 'p2', nickname: 'Bob', isHost: false })],
+    players: [
+      makePlayer({ id: 'p1', nickname: 'Alice' }),
+      makePlayer({ id: 'p2', nickname: 'Bob', isHost: false }),
+    ],
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     expiresAt: new Date().toISOString(),
@@ -96,7 +102,12 @@ describe('RevealView', () => {
   it('shows the submitted answer, verdict, points, and correct answer', () => {
     const snapshot = makeSnapshot();
     render(
-      <RevealView snapshot={snapshot} currentPlayerId="p1" advance={makeMutation()} refetch={vi.fn()} />
+      <RevealView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        advance={makeMutation()}
+        refetch={vi.fn()}
+      />
     );
 
     expect(screen.getByText('Mercury', { selector: '.text-primary' })).toBeInTheDocument();
@@ -107,7 +118,12 @@ describe('RevealView', () => {
   it('shows the Next button for the active player', () => {
     const snapshot = makeSnapshot({ activePlayerId: 'p1', hostPlayerId: 'p2' });
     render(
-      <RevealView snapshot={snapshot} currentPlayerId="p1" advance={makeMutation()} refetch={vi.fn()} />
+      <RevealView
+        snapshot={snapshot}
+        currentPlayerId="p1"
+        advance={makeMutation()}
+        refetch={vi.fn()}
+      />
     );
 
     expect(screen.getByTestId('button-next')).toBeInTheDocument();
@@ -117,7 +133,12 @@ describe('RevealView', () => {
   it('shows the Next button for the host even when not active', () => {
     const snapshot = makeSnapshot({ activePlayerId: 'p1', hostPlayerId: 'p2' });
     render(
-      <RevealView snapshot={snapshot} currentPlayerId="p2" advance={makeMutation()} refetch={vi.fn()} />
+      <RevealView
+        snapshot={snapshot}
+        currentPlayerId="p2"
+        advance={makeMutation()}
+        refetch={vi.fn()}
+      />
     );
 
     expect(screen.getByTestId('button-next')).toBeInTheDocument();
@@ -134,7 +155,12 @@ describe('RevealView', () => {
       ],
     });
     render(
-      <RevealView snapshot={snapshot} currentPlayerId="p3" advance={makeMutation()} refetch={vi.fn()} />
+      <RevealView
+        snapshot={snapshot}
+        currentPlayerId="p3"
+        advance={makeMutation()}
+        refetch={vi.fn()}
+      />
     );
 
     expect(screen.queryByTestId('button-next')).toBeNull();
@@ -181,4 +207,101 @@ describe('RevealView', () => {
     expect(refetch).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
   });
+
+  it('only shows Dispute to the answering player for an undisputed incorrect answer', () => {
+    const snapshot = makeSnapshot({
+      activePlayerId: 'p1',
+      currentAttempt: {
+        questionId: 'q1',
+        playerId: 'p1',
+        submittedAnswer: 'Venus',
+        verdict: 'INCORRECT',
+        pointsDelta: -3,
+      },
+    });
+    const props = {
+      snapshot,
+      advance: makeMutation(),
+      awardDispute: makeMutation(),
+      refetch: vi.fn(),
+    };
+    const { rerender } = render(<RevealView {...props} currentPlayerId="p2" />);
+    expect(screen.queryByRole('button', { name: /dispute/i })).toBeNull();
+
+    rerender(<RevealView {...props} currentPlayerId="p1" />);
+    expect(screen.getByRole('button', { name: /dispute/i })).toBeInTheDocument();
+  });
+
+  it('shows synchronized disabled-mode submission state and manual award only to the host', () => {
+    const snapshot = makeSnapshot({
+      hostPlayerId: 'p2',
+      activePlayerId: 'p1',
+      activeDisputeId: 'dispute-1',
+      opponentDisputeVotingEnabled: false,
+      currentAttempt: {
+        questionId: 'q1',
+        playerId: 'p1',
+        submittedAnswer: 'Venus',
+        verdict: 'INCORRECT',
+        pointsDelta: -3,
+      },
+    });
+    const props = {
+      snapshot,
+      advance: makeMutation(),
+      awardDispute: makeMutation(),
+      refetch: vi.fn(),
+    };
+    const { rerender } = render(<RevealView {...props} currentPlayerId="p1" />);
+    expect(screen.getByTestId('text-dispute-submitted')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /group agreed/i })).toBeNull();
+
+    rerender(<RevealView {...props} currentPlayerId="p2" />);
+    expect(screen.getByRole('button', { name: /group agreed/i })).toBeInTheDocument();
+  });
+
+  it.each([
+    ['approved', 5, 'Dispute approved', '+5'],
+    ['rejected', -3, 'Dispute rejected', '-3'],
+    ['tied', -3, 'Dispute tied', '-3'],
+    ['expired', -3, 'Dispute expired', '-3'],
+    ['canceled', -3, 'Dispute canceled', '-3'],
+  ] as const)(
+    'renders the server-finalized %s outcome and delta',
+    (outcome, delta, label, points) => {
+      const snapshot = makeSnapshot({
+        activeDisputeId: 'dispute-1',
+        currentDisputeVote: {
+          disputeId: 'dispute-1',
+          disputingPlayerId: 'p1',
+          disputingPlayerName: 'Alice',
+          explanation: 'Mercury was intended.',
+          eligibleVoterIds: ['p2'],
+          submittedVoterIds: ['p2'],
+          threshold: 1,
+          openedAt: '2026-01-01T00:00:00.000Z',
+          closesAt: '2026-01-01T00:01:00.000Z',
+          status: 'FINALIZED',
+          yesCount: outcome === 'approved' ? 1 : 0,
+          noCount: outcome === 'rejected' ? 1 : 0,
+          nonResponseCount: outcome === 'rejected' || outcome === 'approved' ? 0 : 1,
+          outcome,
+          originalPointsDelta: -3,
+          finalPointsDelta: delta,
+          decidedAt: '2026-01-01T00:00:30.000Z',
+        },
+      });
+      render(
+        <RevealView
+          snapshot={snapshot}
+          currentPlayerId="p1"
+          advance={makeMutation()}
+          awardDispute={makeMutation()}
+          refetch={vi.fn()}
+        />
+      );
+      expect(screen.getByTestId('card-dispute-outcome')).toHaveTextContent(label);
+      expect(screen.getByTestId('card-dispute-outcome')).toHaveTextContent(points);
+    }
+  );
 });

--- a/client/src/components/room/RevealView.tsx
+++ b/client/src/components/room/RevealView.tsx
@@ -2,7 +2,13 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import { ArrowRight, ExternalLink, Flag } from 'lucide-react';
 import type { UseMutationResult } from '@tanstack/react-query';
-import type { AdvanceRoomResponse, RoomActionResponse, RoomSnapshot } from '@shared/models/rooms';
+import type {
+  AdvanceRoomResponse,
+  RoomActionResponse,
+  RoomSnapshot,
+  SubmitMultiplayerDisputeRequest,
+  SubmitMultiplayerDisputeResponse,
+} from '@shared/models/rooms';
 
 import { isRoomConflict } from '@/hooks/use-room';
 import { Badge } from '@/components/ui/badge';
@@ -18,6 +24,11 @@ export interface RevealViewProps {
   currentPlayerId: string;
   advance: UseMutationResult<AdvanceRoomResponse, Error, void>;
   awardDispute: UseMutationResult<RoomActionResponse, Error, void>;
+  submitDispute: UseMutationResult<
+    SubmitMultiplayerDisputeResponse,
+    Error,
+    SubmitMultiplayerDisputeRequest
+  >;
   refetch: () => void;
 }
 
@@ -26,6 +37,7 @@ export function RevealView({
   currentPlayerId,
   advance,
   awardDispute,
+  submitDispute,
   refetch,
 }: RevealViewProps) {
   const attempt = snapshot.currentAttempt;
@@ -37,12 +49,15 @@ export function RevealView({
     : undefined;
 
   const [disputeOpen, setDisputeOpen] = useState(false);
-  const [disputeSubmitted, setDisputeSubmitted] = useState(false);
-
-  // Show dispute button when the attempt is INCORRECT and hasn't been disputed yet
-  const canDispute = attempt?.verdict === 'INCORRECT' && !disputeSubmitted;
-  // Show award-points button after a dispute has been submitted (and points not yet awarded)
-  const canAwardPoints = disputeSubmitted && attempt?.verdict === 'INCORRECT';
+  const disputeSubmitted = snapshot.activeDisputeId !== null;
+  const finalizedVote = snapshot.currentDisputeVote;
+  const canDispute =
+    isActive && attempt?.verdict === 'INCORRECT' && snapshot.activeDisputeId === null;
+  const canAwardPoints =
+    isHost &&
+    !snapshot.opponentDisputeVotingEnabled &&
+    disputeSubmitted &&
+    attempt?.verdict === 'INCORRECT';
 
   function handleNext() {
     if (advance.isPending) return;
@@ -62,7 +77,6 @@ export function RevealView({
     awardDispute.mutate(undefined, {
       onSuccess: () => {
         toast.success(`Points awarded to ${answeringPlayer?.nickname || 'player'}.`);
-        setDisputeSubmitted(false);
       },
       onError: (error) => {
         if (isRoomConflict(error)) {
@@ -72,6 +86,16 @@ export function RevealView({
         toast.error(error.message || 'Failed to award points.');
       },
     });
+  }
+
+  async function handleSubmitDispute(explanation: string) {
+    try {
+      await submitDispute.mutateAsync({ explanation });
+      toast.success('Dispute submitted.');
+    } catch (error) {
+      if (isRoomConflict(error)) refetch();
+      throw error;
+    }
   }
 
   return (
@@ -139,6 +163,37 @@ export function RevealView({
         {snapshot.currentQuestion.explanation}
       </div>
 
+      {finalizedVote && (
+        <Card
+          className={cn(
+            'border-2',
+            finalizedVote.outcome === 'approved'
+              ? 'border-green-500/50 bg-green-500/10'
+              : 'border-amber-500/50 bg-amber-500/10'
+          )}
+          aria-live="polite"
+          data-testid="card-dispute-outcome"
+        >
+          <CardContent className="p-4 text-center">
+            <div className="font-bold capitalize">Dispute {finalizedVote.outcome}</div>
+            <div className="text-sm text-muted-foreground">
+              Final score change: {finalizedVote.finalPointsDelta > 0 ? '+' : ''}
+              {finalizedVote.finalPointsDelta}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {disputeSubmitted && !finalizedVote && (
+        <p
+          className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-center text-sm"
+          aria-live="polite"
+          data-testid="text-dispute-submitted"
+        >
+          Dispute submitted. The host can award points if the group agrees.
+        </p>
+      )}
+
       {snapshot.currentQuestion.sourceUrl && (
         <div className="flex justify-center">
           <a
@@ -204,7 +259,8 @@ export function RevealView({
           correctAnswer={snapshot.currentQuestion.answer}
           teamName={answeringPlayer?.nickname || 'Unknown'}
           submittedAnswer={attempt.submittedAnswer}
-          onDisputeSubmitted={() => setDisputeSubmitted(true)}
+          onDisputeSubmitted={() => undefined}
+          submitDispute={handleSubmitDispute}
         />
       )}
     </div>

--- a/client/src/components/room/RevealView.tsx
+++ b/client/src/components/room/RevealView.tsx
@@ -58,6 +58,8 @@ export function RevealView({
     !snapshot.opponentDisputeVotingEnabled &&
     disputeSubmitted &&
     attempt?.verdict === 'INCORRECT';
+  const hasPendingManualDispute =
+    disputeSubmitted && !finalizedVote && attempt?.verdict === 'INCORRECT';
 
   function handleNext() {
     if (advance.isPending) return;
@@ -184,7 +186,7 @@ export function RevealView({
         </Card>
       )}
 
-      {disputeSubmitted && !finalizedVote && (
+      {hasPendingManualDispute && (
         <p
           className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-center text-sm"
           aria-live="polite"

--- a/client/src/hooks/use-room.test.tsx
+++ b/client/src/hooks/use-room.test.tsx
@@ -19,6 +19,9 @@ const baseSnapshot: RoomSnapshot = {
   currentQuestionIndex: 0,
   activePlayerId: null,
   currentAttempt: null,
+  opponentDisputeVotingEnabled: false,
+  activeDisputeId: null,
+  currentDisputeVote: null,
   currentQuestion: null,
   players: [],
   createdAt: '2026-01-01T00:00:00.000Z',
@@ -44,9 +47,12 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 describe('getPollIntervalMs', () => {
-  it.each(['LOBBY', 'QUESTION', 'REVEAL'] as const)('polls every 2s during %s', (phase) => {
-    expect(getPollIntervalMs(phase)).toBe(2000);
-  });
+  it.each(['LOBBY', 'QUESTION', 'REVEAL', 'DISPUTE_VOTE'] as const)(
+    'polls every 2s during %s',
+    (phase) => {
+      expect(getPollIntervalMs(phase)).toBe(2000);
+    }
+  );
 
   it.each(['ROUND_SCORE', 'GAME_OVER'] as const)('polls every 5s during %s', (phase) => {
     expect(getPollIntervalMs(phase)).toBe(5000);
@@ -131,7 +137,10 @@ describe('useRoom', () => {
 
     await waitFor(() => expect(result.current.snapshot).toBeDefined());
 
-    expect(fetchMock).toHaveBeenCalledWith(buildPollUrl('ABCD2'), expect.objectContaining({ headers: {} }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      buildPollUrl('ABCD2'),
+      expect.objectContaining({ headers: {} })
+    );
   });
 
   it('requests sinceVersion on the next poll and keeps the same snapshot reference when unchanged', async () => {
@@ -157,7 +166,9 @@ describe('useRoom', () => {
 
   it('marks the room disconnected after two consecutive poll failures and recovers on the next success', async () => {
     vi.useFakeTimers();
-    fetchMock.mockResolvedValue(new Response('Server error', { status: 500, statusText: 'Server error' }));
+    fetchMock.mockResolvedValue(
+      new Response('Server error', { status: 500, statusText: 'Server error' })
+    );
 
     const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper().Wrapper });
 
@@ -239,5 +250,54 @@ describe('useRoom', () => {
     });
 
     await waitFor(() => expect(result.current.snapshot).toEqual(newer));
+  });
+
+  it('posts room-scoped dispute actions with shared payloads and the player token', async () => {
+    saveRoomSession({ code: 'ABCD2', playerId: 'player-1', token: 'secret-token' });
+    fetchMock.mockResolvedValueOnce(jsonResponse(baseSnapshot));
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper().Wrapper });
+    await waitFor(() => expect(result.current.snapshot).toBeDefined());
+
+    for (const [mutation, response] of [
+      [
+        () => result.current.submitDispute.mutateAsync({ explanation: 'The source supports us.' }),
+        2,
+      ],
+      [() => result.current.castDisputeVote.mutateAsync({ approve: true }), 3],
+      [() => result.current.cancelDisputeVote.mutateAsync(), 4],
+    ] as const) {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ snapshot: { ...baseSnapshot, version: response } })
+      );
+      await act(async () => {
+        await mutation();
+      });
+    }
+
+    const postCalls = fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST');
+    expect(postCalls.map(([url]) => url)).toEqual([
+      '/api/rooms/ABCD2/disputes',
+      '/api/rooms/ABCD2/disputes/vote',
+      '/api/rooms/ABCD2/disputes/cancel',
+    ]);
+    expect(postCalls.map(([, init]) => JSON.parse(init.body as string))).toEqual([
+      { explanation: 'The source supports us.' },
+      { approve: true },
+      {},
+    ]);
+    for (const [, init] of postCalls) {
+      expect(init.headers).toMatchObject({ 'X-Player-Token': 'secret-token' });
+    }
+  });
+
+  it('preserves 409 status on dispute action errors for caller refetch handling', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(baseSnapshot));
+    const { result } = renderHook(() => useRoom('ABCD2'), { wrapper: createWrapper().Wrapper });
+    await waitFor(() => expect(result.current.snapshot).toBeDefined());
+    fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'Player has already voted' }, 409));
+
+    await expect(
+      result.current.castDisputeVote.mutateAsync({ approve: false })
+    ).rejects.toMatchObject({ status: 409, message: 'Player has already voted' });
   });
 });

--- a/client/src/hooks/use-room.ts
+++ b/client/src/hooks/use-room.ts
@@ -10,6 +10,10 @@ import type {
   AdvanceRoomResponse,
   AnswerRoomRequest,
   AnswerRoomResponse,
+  CancelDisputeVoteRequest,
+  CancelDisputeVoteResponse,
+  CastDisputeVoteRequest,
+  CastDisputeVoteResponse,
   ContinueRoomResponse,
   EndRoomResponse,
   JoinRoomRequest,
@@ -22,13 +26,15 @@ import type {
   SkipRoomResponse,
   StartRoomRequest,
   StartRoomResponse,
+  SubmitMultiplayerDisputeRequest,
+  SubmitMultiplayerDisputeResponse,
 } from '@shared/models/rooms';
 
 import { getRoomSession, saveRoomSession } from '@/lib/room-session';
 
 const FAST_POLL_MS = 2000;
 const SLOW_POLL_MS = 5000;
-const FAST_POLL_PHASES: readonly RoomPhase[] = ['LOBBY', 'QUESTION', 'REVEAL'];
+const FAST_POLL_PHASES: readonly RoomPhase[] = ['LOBBY', 'QUESTION', 'REVEAL', 'DISPUTE_VOTE'];
 const DISCONNECT_THRESHOLD = 2;
 
 export function getPollIntervalMs(phase: RoomPhase | undefined): number {
@@ -130,6 +136,13 @@ export interface UseRoomResult {
   end: UseMutationResult<EndRoomResponse, Error, void>;
   leave: UseMutationResult<LeaveRoomResponse, Error, void>;
   awardDispute: UseMutationResult<RoomActionResponse, Error, void>;
+  submitDispute: UseMutationResult<
+    SubmitMultiplayerDisputeResponse,
+    Error,
+    SubmitMultiplayerDisputeRequest
+  >;
+  castDisputeVote: UseMutationResult<CastDisputeVoteResponse, Error, CastDisputeVoteRequest>;
+  cancelDisputeVote: UseMutationResult<CancelDisputeVoteResponse, Error, void>;
 }
 
 export interface UseRoomOptions {
@@ -243,6 +256,32 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
     onSuccess: onActionSuccess,
   });
 
+  const submitDispute = useMutation({
+    mutationFn: (body: SubmitMultiplayerDisputeRequest) =>
+      postRoomAction<SubmitMultiplayerDisputeRequest, SubmitMultiplayerDisputeResponse>(
+        code,
+        'disputes',
+        body
+      ),
+    onSuccess: onActionSuccess,
+  });
+
+  const castDisputeVote = useMutation({
+    mutationFn: (body: CastDisputeVoteRequest) =>
+      postRoomAction<CastDisputeVoteRequest, CastDisputeVoteResponse>(code, 'disputes/vote', body),
+    onSuccess: onActionSuccess,
+  });
+
+  const cancelDisputeVote = useMutation({
+    mutationFn: () =>
+      postRoomAction<CancelDisputeVoteRequest, CancelDisputeVoteResponse>(
+        code,
+        'disputes/cancel',
+        {}
+      ),
+    onSuccess: onActionSuccess,
+  });
+
   const leave = useMutation({
     mutationFn: () => postRoomAction<Record<string, never>, LeaveRoomResponse>(code, 'leave', {}),
     onSuccess: (response) => {
@@ -267,5 +306,8 @@ export function useRoom(code: string, options: UseRoomOptions = {}): UseRoomResu
     end,
     leave,
     awardDispute,
+    submitDispute,
+    castDisputeVote,
+    cancelDisputeVote,
   };
 }

--- a/client/src/pages/HostGame.test.tsx
+++ b/client/src/pages/HostGame.test.tsx
@@ -104,6 +104,14 @@ function renderHostGame() {
 describe('HostGame', () => {
   beforeEach(() => {
     stubLocalStorage();
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    );
     localStorage.clear();
     mockSetLocation.mockClear();
     toastError.mockClear();
@@ -194,6 +202,45 @@ describe('HostGame', () => {
       code: 'ABCD2',
       playerId: '11111111-1111-4111-8111-111111111111',
       token: 'test-token',
+    });
+  });
+
+  it('sends opponent dispute voting off by default', async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+    renderHostGame();
+
+    fireEvent.change(await screen.findByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-create-room'));
+
+    await waitFor(() => expect(mockSetLocation).toHaveBeenCalled());
+    const roomRequest = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes('/api/rooms')
+    );
+    expect(JSON.parse((roomRequest?.[1] as RequestInit).body as string)).toMatchObject({
+      opponentDisputeVotingEnabled: false,
+    });
+  });
+
+  it('sends opponent dispute voting when the host enables it', async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+    renderHostGame();
+
+    const toggle = await screen.findByRole('switch', { name: 'Opponent dispute voting' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.change(screen.getByTestId('input-nickname'), { target: { value: 'Steph' } });
+    fireEvent.click(screen.getByTestId('button-create-room'));
+
+    await waitFor(() => expect(mockSetLocation).toHaveBeenCalled());
+    const roomRequest = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes('/api/rooms')
+    );
+    expect(JSON.parse((roomRequest?.[1] as RequestInit).body as string)).toMatchObject({
+      opponentDisputeVotingEnabled: true,
     });
   });
 });

--- a/client/src/pages/HostGame.tsx
+++ b/client/src/pages/HostGame.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
+import { Switch } from '@/components/ui/switch';
 
 async function createRoom(body: CreateRoomRequest): Promise<CreateRoomResponse> {
   const res = await fetch('/api/rooms', {
@@ -46,6 +47,7 @@ export default function HostGame() {
   const [, setLocation] = useLocation();
   const { state, toggleCategory, setNumRounds } = useGame();
   const [nickname, setNickname] = useState('');
+  const [opponentDisputeVotingEnabled, setOpponentDisputeVotingEnabled] = useState(false);
 
   const categoryCounts = useCategoryCounts(state.questions);
 
@@ -80,6 +82,7 @@ export default function HostGame() {
       nickname: trimmedNickname,
       categories: categories.data,
       numRounds: numRounds.data,
+      opponentDisputeVotingEnabled,
     });
   };
 
@@ -193,6 +196,28 @@ export default function HostGame() {
                 ))}
               </div>
             </CardContent>
+          </Card>
+
+          <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between gap-4">
+                <div className="space-y-1">
+                  <CardTitle className="text-lg">Opponent dispute voting</CardTitle>
+                  <CardDescription id="opponent-dispute-voting-description">
+                    Opposing players vote on disputed incorrect answers; majority approval awards
+                    normal points.
+                  </CardDescription>
+                </div>
+                <Switch
+                  checked={opponentDisputeVotingEnabled}
+                  onCheckedChange={setOpponentDisputeVotingEnabled}
+                  disabled={createRoomMutation.isPending}
+                  aria-label="Opponent dispute voting"
+                  aria-describedby="opponent-dispute-voting-description"
+                  data-testid="switch-opponent-dispute-voting"
+                />
+              </div>
+            </CardHeader>
           </Card>
 
           <Button

--- a/client/src/pages/Room.test.tsx
+++ b/client/src/pages/Room.test.tsx
@@ -74,6 +74,10 @@ vi.mock('@/components/room/RevealView', () => ({
   RevealView: () => <div data-testid="reveal-view-mock" />,
 }));
 
+vi.mock('@/components/room/DisputeVoteView', () => ({
+  DisputeVoteView: () => <div data-testid="dispute-vote-view-mock" />,
+}));
+
 vi.mock('@/components/room/RoundScore', () => ({
   RoundScore: () => <div data-testid="round-score-mock" />,
 }));
@@ -132,6 +136,9 @@ function makeUseRoomResult(overrides: Record<string, unknown> = {}) {
     end: {},
     leave: { isPending: false, mutate: vi.fn() },
     awardDispute: {},
+    submitDispute: {},
+    castDisputeVote: {},
+    cancelDisputeVote: {},
     ...overrides,
   };
 }
@@ -232,6 +239,18 @@ describe('Room', () => {
     expect(screen.getByTestId('reveal-view-mock')).toBeInTheDocument();
   });
 
+  it('renders DisputeVoteView when reconnecting into DISPUTE_VOTE', () => {
+    mockGetRoomSession.mockReturnValue(SESSION);
+    mockUseRoom.mockReturnValue(
+      makeUseRoomResult({
+        snapshot: makeSnapshot({ phase: 'DISPUTE_VOTE', activePlayerId: 'host-1' }),
+      })
+    );
+    render(<Room />);
+    expect(screen.getByTestId('dispute-vote-view-mock')).toBeInTheDocument();
+    expect(screen.queryByTestId('reveal-view-mock')).toBeNull();
+  });
+
   it('renders RoundScore when phase is ROUND_SCORE', () => {
     mockGetRoomSession.mockReturnValue(SESSION);
     mockUseRoom.mockReturnValue(
@@ -282,6 +301,7 @@ describe('Room', () => {
       ['LOBBY', 'lobby-mock'],
       ['QUESTION', 'question-view-mock'],
       ['REVEAL', 'reveal-view-mock'],
+      ['DISPUTE_VOTE', 'dispute-vote-view-mock'],
       ['ROUND_SCORE', 'round-score-mock'],
       ['GAME_OVER', 'final-results-mock'],
     ] as const)(

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { QUESTIONS_PER_TEAM_ROTATION } from '@shared/lib/answers';
 
 import { FinalResults } from '@/components/room/FinalResults';
+import { DisputeVoteView } from '@/components/room/DisputeVoteView';
 import { LeaveConfirmModal } from '@/components/room/LeaveConfirmModal';
 import { LeaveGameButton } from '@/components/room/LeaveGameButton';
 import { Lobby } from '@/components/room/Lobby';
@@ -38,6 +39,9 @@ export default function Room() {
     end,
     leave,
     awardDispute,
+    submitDispute,
+    castDisputeVote,
+    cancelDisputeVote,
     refetch,
   } = useRoom(code, { enabled: !!session });
   const { isAuthenticated, isLoading: authLoading } = useAuth();
@@ -115,7 +119,10 @@ export default function Room() {
     return <RoomAbandoned snapshot={snapshot} />;
   }
 
-  const showProgress = snapshot.phase === 'QUESTION' || snapshot.phase === 'REVEAL';
+  const showProgress =
+    snapshot.phase === 'QUESTION' ||
+    snapshot.phase === 'REVEAL' ||
+    snapshot.phase === 'DISPUTE_VOTE';
   const activePlayerCount = snapshot.players.filter((player) => !player.leftAt).length;
   const totalQuestions = snapshot.numRounds * activePlayerCount * QUESTIONS_PER_TEAM_ROTATION;
   const progressPercent =
@@ -210,6 +217,17 @@ export default function Room() {
               currentPlayerId={session.playerId}
               advance={advance}
               awardDispute={awardDispute}
+              submitDispute={submitDispute}
+              refetch={refetch}
+            />
+          )}
+
+          {snapshot.phase === 'DISPUTE_VOTE' && (
+            <DisputeVoteView
+              snapshot={snapshot}
+              currentPlayerId={session.playerId}
+              castDisputeVote={castDisputeVote}
+              cancelDisputeVote={cancelDisputeVote}
               refetch={refetch}
             />
           )}

--- a/e2e/multiplayer.spec.ts
+++ b/e2e/multiplayer.spec.ts
@@ -189,6 +189,22 @@ function normalizedFinalRanking(page: Page) {
 }
 
 test.describe('two-device multiplayer', () => {
+  test('host setup offers opponent dispute voting off by default', async ({ page }) => {
+    await installQuestionFixture(page.context());
+    await page.goto('/host');
+
+    const toggle = page.getByRole('switch', { name: 'Opponent dispute voting' });
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(
+      page.getByText(
+        'Opposing players vote on disputed incorrect answers; majority approval awards normal points.'
+      )
+    ).toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
   test('host and guest complete a synchronized full game', async ({
     browser,
     request,

--- a/server/routes.rooms.test.ts
+++ b/server/routes.rooms.test.ts
@@ -311,6 +311,7 @@ describe('room lifecycle routes', () => {
 
     expect(response.body.snapshot).toMatchObject({
       phase: 'DISPUTE_VOTE',
+      activeDisputeId: 'dispute-1',
       currentDisputeVote: { eligibleVoterIds: [guestId], threshold: 1 },
     });
   });

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -234,6 +234,7 @@ async function buildRoomSnapshot(
     activePlayerId: room.activePlayerId,
     currentAttempt: room.currentAttempt,
     opponentDisputeVotingEnabled: room.opponentDisputeVotingEnabled,
+    activeDisputeId: room.activeDisputeId,
     currentDisputeVote: room.currentDisputeVote ?? null,
     currentQuestion,
     players: players.map((player) => serializePlayer(player, now)),

--- a/shared/models/rooms.ts
+++ b/shared/models/rooms.ts
@@ -317,6 +317,7 @@ const roomSnapshotBaseSchema = z.object({
   activePlayerId: z.string().uuid().nullable(),
   currentAttempt: roomAttemptSchema.nullable(),
   opponentDisputeVotingEnabled: z.boolean().default(false),
+  activeDisputeId: disputeIdSchema.nullable().default(null),
   currentDisputeVote: roomDisputeVoteSnapshotSchema.nullable().default(null),
   players: z.array(roomPlayerSnapshotSchema),
   createdAt: z.string().datetime(),

--- a/shared/schema.test.ts
+++ b/shared/schema.test.ts
@@ -316,6 +316,7 @@ describe('RoomSnapshot contract', () => {
   it('defaults voting off and clears active vote state for legacy snapshots', () => {
     const parsed = roomSnapshotSchema.parse(validSnapshot);
     expect(parsed.opponentDisputeVotingEnabled).toBe(false);
+    expect(parsed.activeDisputeId).toBeNull();
     expect(parsed.currentDisputeVote).toBeNull();
   });
 
@@ -324,9 +325,11 @@ describe('RoomSnapshot contract', () => {
       ...validSnapshot,
       phase: 'DISPUTE_VOTE',
       currentQuestion: revealedQuestion,
+      activeDisputeId: validOpenDisputeVote.disputeId,
       currentDisputeVote: validOpenDisputeVote,
     });
 
+    expect(parsed.activeDisputeId).toBe(validOpenDisputeVote.disputeId);
     expect(parsed.currentDisputeVote).toEqual(validOpenDisputeVote);
     expect(parsed.currentDisputeVote).not.toHaveProperty('approve');
     expect(


### PR DESCRIPTION
## Summary

- add the multiplayer-only **Opponent dispute voting** setup toggle, off by default
- add room-scoped submit, vote, and cancel mutations using the shared STE-241 contracts
- replace multiplayer local dispute authority with synchronized snapshot state
- add a focused `DisputeVoteView` with role-based voting, locked ballots, private progress, deadline countdown, host cancellation, and accessible live updates
- restore server-finalized outcomes and host-only disabled-mode manual awards after reconnect
- preserve the generic solo dispute flow
- expose `activeDisputeId` in authenticated room snapshots so disabled-mode submissions synchronize across devices
- hide the pending manual-dispute banner as soon as the server-awarded attempt becomes correct

## Why

STE-243 completes the client side of the STE-125 opponent dispute-voting flow now that STE-241 and STE-242 are merged. It removes the legacy component-local `disputeSubmitted` flag and renders all multiplayer authority from server snapshots.

## Validation

- `npm run check`
- `npm test` — 44 files, 516 tests
- `npm run lint` — 0 errors (23 existing warnings)
- `npm run build`
- focused client suite — 69 tests
- added focused Playwright coverage for the setup toggle; local execution requires `DATABASE_URL`, so CI should run it in the configured environment

Linear: https://linear.app/stephs-vibe-coding/issue/STE-243/featclient-add-multiplayer-dispute-voting-setup-and-role-based-ui-ste