### PR TITLE
feat(admin): add dispute vote audit [STE-244]

### DIFF
--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -28,15 +28,18 @@ export function AdminLayout({ children }: AdminLayoutProps) {
   ];
 
   return (
-    <div className="min-h-screen bg-background flex">
+    <div className="min-h-screen bg-background flex flex-col md:flex-row">
       {/* Sidebar */}
-      <div className="w-64 border-r border-white/10 bg-muted/5 p-4 flex flex-col">
-        <div className="mb-8 px-4 py-2">
+      <div className="w-full shrink-0 border-b border-white/10 bg-muted/5 p-3 md:w-64 md:border-b-0 md:border-r md:p-4 flex flex-col">
+        <div className="mb-3 px-2 py-1 md:mb-8 md:px-4 md:py-2">
           <h1 className="text-xl font-bold tracking-tight text-primary">Trivia Admin</h1>
           <p className="text-xs text-muted-foreground">Control Panel</p>
         </div>
 
-        <nav className="flex-1 space-y-1">
+        <nav
+          className="flex flex-1 gap-1 overflow-x-auto pb-1 md:block md:space-y-1 md:overflow-visible md:pb-0"
+          aria-label="Admin sections"
+        >
           {navItems.map((item) => {
             const isActive = location === item.href;
             return (
@@ -44,7 +47,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  'flex items-center gap-3 px-4 py-2 text-sm font-medium rounded-md transition-colors',
+                  'flex shrink-0 items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors md:gap-3 md:px-4',
                   isActive
                     ? 'bg-primary/10 text-primary'
                     : 'text-muted-foreground hover:bg-white/5 hover:text-foreground'
@@ -57,7 +60,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
           })}
         </nav>
 
-        <div className="pt-4 border-t border-white/10">
+        <div className="hidden pt-4 border-t border-white/10 md:block">
           <Link href="/" className="block">
             <Button
               variant="ghost"
@@ -71,8 +74,8 @@ export function AdminLayout({ children }: AdminLayoutProps) {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 overflow-auto">
-        <div className="p-8 max-w-6xl mx-auto">{children}</div>
+      <div className="min-w-0 flex-1 overflow-auto">
+        <div className="mx-auto max-w-6xl p-4 sm:p-6 lg:p-8">{children}</div>
       </div>
     </div>
   );

--- a/client/src/components/admin/DisputeVoteAudit.test.tsx
+++ b/client/src/components/admin/DisputeVoteAudit.test.tsx
@@ -1,0 +1,139 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AdminDispute } from '@shared/schema';
+
+import { DisputeVoteAudit } from './DisputeVoteAudit';
+
+const VOTER_ONE = '11111111-1111-4111-8111-111111111111';
+const VOTER_TWO = '22222222-2222-4222-8222-222222222222';
+
+function makeDispute(overrides: Partial<AdminDispute> = {}): AdminDispute {
+  return {
+    id: 'dispute-1',
+    questionId: 'q-1',
+    questionText: 'What is the capital of Canada?',
+    correctAnswer: 'Ottawa',
+    teamName: 'Alpha',
+    submittedAnswer: 'Toronto',
+    teamExplanation: 'The clue was ambiguous.',
+    timestamp: new Date('2026-07-14T12:00:00Z'),
+    status: 'pending',
+    resolutionNote: null,
+    aiAnalysis: null,
+    roomId: '33333333-3333-4333-8333-333333333333',
+    roomCode: 'ABCD2',
+    attemptKey: '33333333-3333-4333-8333-333333333333:4',
+    disputingPlayerId: '44444444-4444-4444-8444-444444444444',
+    disputingPlayerName: 'Alpha',
+    votingEnabled: true,
+    eligibleVoterSnapshot: [
+      { playerId: VOTER_ONE, displayName: 'Bravo' },
+      { playerId: VOTER_TWO, displayName: 'Charlie' },
+    ],
+    threshold: 2,
+    outcome: 'approved',
+    originalPointsDelta: -3,
+    finalPointsDelta: 5,
+    decidedAt: new Date('2026-07-14T12:01:00Z'),
+    ballots: [
+      {
+        id: 'ballot-1',
+        disputeId: 'dispute-1',
+        voterPlayerId: VOTER_ONE,
+        voterPlayerName: 'Bravo',
+        approve: true,
+        castAt: new Date('2026-07-14T12:00:30Z'),
+      },
+    ],
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe('DisputeVoteAudit', () => {
+  it('renders outcome, threshold, totals, score transition, context, and non-responders', () => {
+    render(<DisputeVoteAudit dispute={makeDispute()} />);
+
+    expect(screen.getByText('Opponent vote')).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    expect(screen.getByText('1 yes / 0 no / 1 no response')).toBeInTheDocument();
+    expect(screen.getByText('Threshold: 2')).toBeInTheDocument();
+    expect(screen.getByText('-3 → +5')).toBeInTheDocument();
+    expect(screen.getByText('ABCD2')).toBeInTheDocument();
+    expect(screen.getByText(/33333333-3333-4333-8333-333333333333:4/)).toBeInTheDocument();
+    expect(screen.getByTestId(`ballot-row-${VOTER_ONE}`)).toHaveTextContent('Agree');
+    expect(screen.getByTestId(`ballot-row-${VOTER_TWO}`)).toHaveTextContent('No response');
+  });
+
+  it.each(['approved', 'rejected', 'tied', 'expired', 'canceled'] as const)(
+    'renders the %s gameplay outcome independently from rejected QA status',
+    (outcome) => {
+      render(<DisputeVoteAudit dispute={makeDispute({ outcome, status: 'rejected' })} />);
+
+      expect(screen.getAllByText(outcome)).not.toHaveLength(0);
+      expect(screen.getByText('Independent QA review').parentElement).toHaveTextContent('rejected');
+      expect(
+        screen.getByText(/Gameplay scoring and content QA are reviewed independently/)
+      ).toBeInTheDocument();
+    }
+  );
+
+  it('keeps legacy solo records safe without invented vote metadata', () => {
+    render(
+      <DisputeVoteAudit
+        dispute={makeDispute({
+          roomId: null,
+          roomCode: null,
+          attemptKey: null,
+          disputingPlayerId: null,
+          disputingPlayerName: null,
+          votingEnabled: false,
+          eligibleVoterSnapshot: null,
+          threshold: null,
+          outcome: null,
+          originalPointsDelta: null,
+          finalPointsDelta: null,
+          decidedAt: null,
+          ballots: [],
+        })}
+      />
+    );
+
+    expect(screen.getByText('Solo dispute')).toBeInTheDocument();
+    expect(screen.getByText('Not applicable')).toBeInTheDocument();
+    expect(screen.getAllByText('Not recorded')).not.toHaveLength(0);
+    expect(screen.queryByText(/Ballot details/)).not.toBeInTheDocument();
+  });
+
+  it('renders partial multiplayer records and unexpected ballots without crashing', () => {
+    render(
+      <DisputeVoteAudit
+        dispute={makeDispute({
+          roomCode: null,
+          attemptKey: null,
+          disputingPlayerName: null,
+          eligibleVoterSnapshot: null,
+          threshold: null,
+          outcome: null,
+          originalPointsDelta: null,
+          finalPointsDelta: null,
+        })}
+      />
+    );
+
+    expect(screen.getAllByText('Not recorded')).not.toHaveLength(0);
+    expect(screen.getByText(/missing from eligible snapshot/)).toBeInTheDocument();
+    expect(
+      screen.getByText('Ballot details (1 recorded; eligible snapshot unavailable)')
+    ).toBeInTheDocument();
+  });
+
+  it('labels disabled multiplayer disputes as manual awards', () => {
+    render(<DisputeVoteAudit dispute={makeDispute({ votingEnabled: false })} />);
+    expect(screen.getByText('Manual multiplayer')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/admin/DisputeVoteAudit.tsx
+++ b/client/src/components/admin/DisputeVoteAudit.tsx
@@ -1,0 +1,206 @@
+import { Badge } from '@/components/ui/badge';
+import type { AdminDispute, DisputeBallot, DisputeVoterSnapshot } from '@shared/schema';
+
+interface DisputeVoteAuditProps {
+  dispute: AdminDispute;
+}
+
+function formatTimestamp(value: Date | string | null | undefined): string {
+  if (!value) return 'Not recorded';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Not recorded' : date.toLocaleString();
+}
+
+function signedPoints(value: number): string {
+  return `${value > 0 ? '+' : ''}${value}`;
+}
+
+function outcomeClasses(outcome: AdminDispute['outcome']): string {
+  switch (outcome) {
+    case 'approved':
+      return 'border-green-500/30 bg-green-500/10 text-green-400';
+    case 'rejected':
+    case 'tied':
+      return 'border-red-500/30 bg-red-500/10 text-red-400';
+    case 'expired':
+    case 'canceled':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-400';
+    default:
+      return 'border-white/20 bg-white/5 text-muted-foreground';
+  }
+}
+
+function ballotForVoter(ballots: DisputeBallot[], playerId: string): DisputeBallot | undefined {
+  return ballots.find((ballot) => ballot.voterPlayerId === playerId);
+}
+
+export function DisputeVoteAudit({ dispute }: DisputeVoteAuditProps) {
+  const ballots = dispute.ballots ?? [];
+  const eligibleVoters: DisputeVoterSnapshot[] = dispute.eligibleVoterSnapshot ?? [];
+  const eligibleIds = new Set(eligibleVoters.map((voter) => voter.playerId));
+  const eligibleBallots = ballots.filter((ballot) => eligibleIds.has(ballot.voterPlayerId));
+  const countedBallots = eligibleVoters.length > 0 ? eligibleBallots : ballots;
+  const yesCount = countedBallots.filter((ballot) => ballot.approve).length;
+  const noCount = countedBallots.filter((ballot) => !ballot.approve).length;
+  const nonResponseCount = Math.max(eligibleVoters.length - eligibleBallots.length, 0);
+  const isMultiplayer = Boolean(dispute.roomId || dispute.roomCode || dispute.attemptKey);
+  const mode = !isMultiplayer
+    ? 'Solo dispute'
+    : dispute.votingEnabled
+      ? 'Opponent vote'
+      : 'Manual multiplayer';
+  const orphanBallots = ballots.filter((ballot) => !eligibleIds.has(ballot.voterPlayerId));
+  const scoreDeltaAvailable =
+    dispute.originalPointsDelta !== null && dispute.finalPointsDelta !== null;
+
+  return (
+    <section
+      className="rounded-lg border border-sky-500/20 bg-sky-500/5 p-4 space-y-4"
+      aria-label="Dispute decision audit"
+      data-testid={`vote-audit-${dispute.id}`}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-sky-300">
+            Gameplay decision audit
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Gameplay scoring and content QA are reviewed independently.
+          </p>
+        </div>
+        <Badge variant="outline">{mode}</Badge>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 text-sm">
+        <div className="rounded-md bg-black/10 p-3">
+          <p className="text-xs uppercase text-muted-foreground">Gameplay outcome</p>
+          <Badge variant="outline" className={`mt-1 capitalize ${outcomeClasses(dispute.outcome)}`}>
+            {dispute.outcome ?? (isMultiplayer ? 'Not recorded' : 'Not applicable')}
+          </Badge>
+        </div>
+        <div className="rounded-md bg-black/10 p-3">
+          <p className="text-xs uppercase text-muted-foreground">Independent QA review</p>
+          <p className="mt-1 font-semibold capitalize">{dispute.status}</p>
+        </div>
+        <div className="rounded-md bg-black/10 p-3">
+          <p className="text-xs uppercase text-muted-foreground">Vote totals</p>
+          <p className="mt-1 font-semibold">
+            {yesCount} yes / {noCount} no / {nonResponseCount} no response
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Threshold: {dispute.threshold ?? 'Not recorded'}
+          </p>
+        </div>
+        <div className="rounded-md bg-black/10 p-3">
+          <p className="text-xs uppercase text-muted-foreground">Score delta</p>
+          <p className="mt-1 font-semibold">
+            {scoreDeltaAvailable
+              ? `${signedPoints(dispute.originalPointsDelta!)} → ${signedPoints(dispute.finalPointsDelta!)}`
+              : 'Not recorded'}
+          </p>
+        </div>
+      </div>
+
+      {isMultiplayer && (
+        <div className="grid gap-2 sm:grid-cols-2 text-xs text-muted-foreground">
+          <p>
+            Room: <span className="font-mono text-foreground">{dispute.roomCode ?? 'Unknown'}</span>
+          </p>
+          <p className="min-w-0 break-all">
+            Attempt:{' '}
+            <span className="font-mono text-foreground">
+              {dispute.attemptKey ?? 'Not recorded'}
+            </span>
+          </p>
+          <p>
+            Disputing player:{' '}
+            <span className="text-foreground">
+              {dispute.disputingPlayerName ?? dispute.teamName ?? 'Unknown'}
+            </span>
+          </p>
+          <p>
+            Voting:{' '}
+            <span className="text-foreground">
+              {dispute.votingEnabled ? 'Enabled' : 'Disabled'}
+            </span>
+          </p>
+          <p>
+            Submitted: <span className="text-foreground">{formatTimestamp(dispute.timestamp)}</span>
+          </p>
+          <p>
+            Decided: <span className="text-foreground">{formatTimestamp(dispute.decidedAt)}</span>
+          </p>
+        </div>
+      )}
+
+      {isMultiplayer && (
+        <details className="rounded-md border border-white/10 bg-black/10">
+          <summary className="cursor-pointer px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary">
+            {eligibleVoters.length > 0
+              ? `Ballot details (${eligibleBallots.length}/${eligibleVoters.length} responded)`
+              : `Ballot details (${ballots.length} recorded; eligible snapshot unavailable)`}
+          </summary>
+          <div className="space-y-2 border-t border-white/10 p-3">
+            {eligibleVoters.length === 0 && ballots.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No eligible-voter snapshot was recorded.
+              </p>
+            ) : (
+              <>
+                {eligibleVoters.map((voter) => {
+                  const ballot = ballotForVoter(ballots, voter.playerId);
+                  return (
+                    <div
+                      key={voter.playerId}
+                      className="grid gap-1 rounded-md bg-white/5 p-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center sm:gap-4"
+                      data-testid={`ballot-row-${voter.playerId}`}
+                    >
+                      <div className="min-w-0">
+                        <p className="font-medium">{voter.displayName}</p>
+                        <p className="break-all font-mono text-[11px] text-muted-foreground">
+                          {voter.playerId}
+                        </p>
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className={
+                          !ballot
+                            ? 'border-amber-500/30 text-amber-400'
+                            : ballot.approve
+                              ? 'border-green-500/30 text-green-400'
+                              : 'border-red-500/30 text-red-400'
+                        }
+                      >
+                        {!ballot ? 'No response' : ballot.approve ? 'Agree' : 'Disagree'}
+                      </Badge>
+                      <p className="text-xs text-muted-foreground">
+                        {ballot ? formatTimestamp(ballot.castAt) : 'Not cast'}
+                      </p>
+                    </div>
+                  );
+                })}
+                {orphanBallots.map((ballot) => (
+                  <div
+                    key={ballot.id}
+                    className="grid gap-1 rounded-md border border-amber-500/20 bg-amber-500/5 p-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center sm:gap-4"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-medium">{ballot.voterPlayerName}</p>
+                      <p className="break-all font-mono text-[11px] text-muted-foreground">
+                        {ballot.voterPlayerId} · missing from eligible snapshot
+                      </p>
+                    </div>
+                    <Badge variant="outline">{ballot.approve ? 'Agree' : 'Disagree'}</Badge>
+                    <p className="text-xs text-muted-foreground">
+                      {formatTimestamp(ballot.castAt)}
+                    </p>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        </details>
+      )}
+    </section>
+  );
+}

--- a/client/src/pages/admin-disputes.tsx
+++ b/client/src/pages/admin-disputes.tsx
@@ -23,6 +23,8 @@ import { useToast } from '@/hooks/use-toast';
 import { useGame, Question } from '@/lib/store';
 import { useAuth } from '@/hooks/use-auth';
 import { useAdmin } from '@/hooks/use-admin';
+import { DisputeVoteAudit } from '@/components/admin/DisputeVoteAudit';
+import type { AdminDispute } from '@shared/schema';
 
 type ResolutionField = 'question' | 'answer' | 'explanation';
 
@@ -39,7 +41,12 @@ export default function AdminDisputes() {
   const { user, isLoading: authLoading, isAuthenticated } = useAuth();
   const { isAdmin, isLoading: adminLoading } = useAdmin();
   const { state, updateQuestion } = useGame();
-  const { data: disputes = [], isLoading } = useQuery<Dispute[]>({
+  const {
+    data: disputes = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<AdminDispute[]>({
     queryKey: ['/api/disputes'],
   });
 
@@ -75,7 +82,8 @@ export default function AdminDisputes() {
     analysis: AIAnalysis | null
   ): ResolutionDraft => {
     return {
-      question: analysis?.suggestedFix?.question || sourceQuestion?.question || dispute.questionText,
+      question:
+        analysis?.suggestedFix?.question || sourceQuestion?.question || dispute.questionText,
       answer: analysis?.suggestedFix?.answer || sourceQuestion?.answer || dispute.correctAnswer,
       explanation: analysis?.suggestedFix?.explanation || sourceQuestion?.explanation || '',
       touched: {
@@ -98,7 +106,9 @@ export default function AdminDisputes() {
       ...baseDraft,
       question: storedDraft.touched.question ? storedDraft.question : baseDraft.question,
       answer: storedDraft.touched.answer ? storedDraft.answer : baseDraft.answer,
-      explanation: storedDraft.touched.explanation ? storedDraft.explanation : baseDraft.explanation,
+      explanation: storedDraft.touched.explanation
+        ? storedDraft.explanation
+        : baseDraft.explanation,
       touched: { ...storedDraft.touched },
     };
   };
@@ -111,7 +121,8 @@ export default function AdminDisputes() {
     value: string
   ) => {
     setResolutionDrafts((prev) => {
-      const existingDraft = prev[dispute.id] ?? buildResolutionDraft(dispute, sourceQuestion, analysis);
+      const existingDraft =
+        prev[dispute.id] ?? buildResolutionDraft(dispute, sourceQuestion, analysis);
       return {
         ...prev,
         [dispute.id]: {
@@ -170,7 +181,7 @@ export default function AdminDisputes() {
         description: `The dispute has been marked as ${status}.`,
       });
       return true;
-    } catch (error) {
+    } catch {
       toast({
         title: 'Action Failed',
         description: 'Could not update dispute status.',
@@ -182,10 +193,7 @@ export default function AdminDisputes() {
     }
   };
 
-  const handleApplyFix = async (
-    dispute: Dispute,
-    analysis: AIAnalysis | null
-  ) => {
+  const handleApplyFix = async (dispute: Dispute, analysis: AIAnalysis | null) => {
     const sourceQuestion = state.questions.find((q) => q.id === dispute.questionId);
     if (!sourceQuestion) {
       toast({
@@ -241,7 +249,8 @@ export default function AdminDisputes() {
     } catch {
       toast({
         title: 'Error',
-        description: 'Failed to update question. The dispute was resolved but the fix was not applied.',
+        description:
+          'Failed to update question. The dispute was resolved but the fix was not applied.',
         variant: 'destructive',
       });
     }
@@ -396,6 +405,21 @@ export default function AdminDisputes() {
               <Skeleton className="h-32 w-full" />
               <Skeleton className="h-32 w-full" />
             </div>
+          ) : isError ? (
+            <Card className="border-red-500/30 bg-red-500/5">
+              <CardContent className="flex flex-col items-center justify-center gap-3 p-12 text-center">
+                <XCircle className="h-12 w-12 text-red-400" />
+                <div>
+                  <p className="font-semibold">Could not load disputes.</p>
+                  <p className="text-sm text-muted-foreground">
+                    Your existing review data is unchanged. Try loading it again.
+                  </p>
+                </div>
+                <Button variant="outline" onClick={() => refetch()}>
+                  Retry
+                </Button>
+              </CardContent>
+            </Card>
           ) : disputes.length === 0 ? (
             <Card className="bg-muted/5 border-dashed">
               <CardContent className="flex flex-col items-center justify-center p-12 text-center text-muted-foreground">
@@ -479,6 +503,8 @@ export default function AdminDisputes() {
                         <div className="text-sm bg-muted/20 p-3 rounded italic text-muted-foreground border-l-2 border-primary/50">
                           "{dispute.teamExplanation}"
                         </div>
+
+                        <DisputeVoteAudit dispute={dispute} />
                       </div>
                     </div>
 
@@ -563,7 +589,9 @@ export default function AdminDisputes() {
                             </div>
 
                             <div className="space-y-1">
-                              <p className="text-[10px] uppercase text-muted-foreground">Current question</p>
+                              <p className="text-[10px] uppercase text-muted-foreground">
+                                Current question
+                              </p>
                               <p className="text-xs text-muted-foreground">
                                 {sourceQuestion?.question || dispute.questionText}
                               </p>
@@ -584,7 +612,9 @@ export default function AdminDisputes() {
                             </div>
 
                             <div className="space-y-1">
-                              <p className="text-[10px] uppercase text-muted-foreground">Current answer</p>
+                              <p className="text-[10px] uppercase text-muted-foreground">
+                                Current answer
+                              </p>
                               <p className="text-xs text-muted-foreground">
                                 {sourceQuestion?.answer || dispute.correctAnswer}
                               </p>

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -114,3 +114,93 @@ test.describe('SETUP → QUESTION → REVEAL loop', () => {
     await expect(teamAScore).toHaveText(String(EXPECTED_POINTS_DELTA));
   });
 });
+
+test.describe('admin dispute audit', () => {
+  test('shows multiplayer vote evidence separately from QA status on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.route('**/api/auth/user', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'admin-user', email: 'admin@example.com' }),
+      })
+    );
+    await page.route('**/api/admin/check', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ isAdmin: true }),
+      })
+    );
+    await page.route('**/api/questions**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(fixtureData),
+      })
+    );
+    await page.route('**/api/disputes', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'audit-dispute',
+            questionId: 'smoke-q1',
+            questionText: 'What is the chemical formula for water?',
+            correctAnswer: 'H2O',
+            teamName: 'Alpha',
+            submittedAnswer: 'Water',
+            teamExplanation: 'The plain-language answer should count.',
+            timestamp: '2026-07-14T12:00:00.000Z',
+            status: 'pending',
+            resolutionNote: null,
+            aiAnalysis: null,
+            roomId: '33333333-3333-4333-8333-333333333333',
+            roomCode: 'ABCD2',
+            attemptKey: '33333333-3333-4333-8333-333333333333:0',
+            disputingPlayerId: '44444444-4444-4444-8444-444444444444',
+            disputingPlayerName: 'Alpha',
+            votingEnabled: true,
+            eligibleVoterSnapshot: [
+              { playerId: '11111111-1111-4111-8111-111111111111', displayName: 'Bravo' },
+              { playerId: '22222222-2222-4222-8222-222222222222', displayName: 'Charlie' },
+            ],
+            threshold: 2,
+            outcome: 'approved',
+            originalPointsDelta: -1,
+            finalPointsDelta: 1,
+            decidedAt: '2026-07-14T12:01:00.000Z',
+            ballots: [
+              {
+                id: 'ballot-1',
+                disputeId: 'audit-dispute',
+                voterPlayerId: '11111111-1111-4111-8111-111111111111',
+                voterPlayerName: 'Bravo',
+                approve: true,
+                castAt: '2026-07-14T12:00:30.000Z',
+              },
+            ],
+          },
+        ]),
+      })
+    );
+
+    await page.goto('/admin/disputes');
+
+    const audit = page.getByTestId('vote-audit-audit-dispute');
+    await expect(audit.getByText('Gameplay decision audit')).toBeVisible();
+    await expect(audit.getByText('approved')).toBeVisible();
+    await expect(audit.getByText('pending')).toBeVisible();
+    await expect(audit.getByText('1 yes / 0 no / 1 no response')).toBeVisible();
+    await expect(audit.getByText('-1 → +1')).toBeVisible();
+
+    await page.getByText('Ballot details (1/2 responded)').click();
+    await expect(
+      page.getByTestId('ballot-row-11111111-1111-4111-8111-111111111111').getByText('Agree')
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('ballot-row-22222222-2222-4222-8222-222222222222').getByText('No response')
+    ).toBeVisible();
+  });
+});

--- a/server/routes.disputes.test.ts
+++ b/server/routes.disputes.test.ts
@@ -80,6 +80,18 @@ const disputeRow = {
   timestamp: new Date('2026-01-01T00:00:00Z'),
   resolutionNote: null,
   aiAnalysis: null,
+  roomId: null,
+  roomCode: null,
+  attemptKey: null,
+  disputingPlayerId: null,
+  disputingPlayerName: null,
+  votingEnabled: false,
+  eligibleVoterSnapshot: null,
+  threshold: null,
+  outcome: null,
+  originalPointsDelta: null,
+  finalPointsDelta: null,
+  decidedAt: null,
 };
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
@@ -201,7 +213,8 @@ describe('dispute routes', () => {
   it('lists disputes for admins', async () => {
     dbMocks.select
       .mockReturnValueOnce(createQueryMock([adminRole]))
-      .mockReturnValueOnce(createQueryMock([disputeRow]));
+      .mockReturnValueOnce(createQueryMock([disputeRow]))
+      .mockReturnValueOnce(createQueryMock([]));
     const app = await buildTestApp();
 
     const response = await request(app)
@@ -209,7 +222,60 @@ describe('dispute routes', () => {
       .set('x-test-user-id', 'admin-user')
       .expect(200);
 
-    expect(response.body).toMatchObject([{ id: 'dispute-1', teamName: 'Alpha' }]);
+    expect(response.body).toMatchObject([{ id: 'dispute-1', teamName: 'Alpha', ballots: [] }]);
+    expect(dbMocks.select).toHaveBeenCalledTimes(3);
+  });
+
+  it('loads all admin ballots in one query and groups them by dispute', async () => {
+    const multiplayerDispute = {
+      ...disputeRow,
+      id: 'dispute-2',
+      roomId: '11111111-1111-4111-8111-111111111111',
+      roomCode: 'ABCD2',
+      votingEnabled: true,
+    };
+    const ballot = {
+      id: 'ballot-1',
+      disputeId: multiplayerDispute.id,
+      voterPlayerId: '22222222-2222-4222-8222-222222222222',
+      voterPlayerName: 'Bravo',
+      approve: true,
+      castAt: new Date('2026-01-01T00:01:00Z'),
+    };
+    const disputesQuery = createQueryMock([disputeRow, multiplayerDispute]);
+    const ballotsQuery = createQueryMock([ballot]);
+    dbMocks.select
+      .mockReturnValueOnce(createQueryMock([adminRole]))
+      .mockReturnValueOnce(disputesQuery)
+      .mockReturnValueOnce(ballotsQuery);
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/disputes')
+      .set('x-test-user-id', 'admin-user')
+      .expect(200);
+
+    expect(dbMocks.select).toHaveBeenCalledTimes(3);
+    expect(ballotsQuery.where).toHaveBeenCalledOnce();
+    expect(response.body).toMatchObject([
+      { id: 'dispute-1', ballots: [] },
+      { id: 'dispute-2', ballots: [{ id: 'ballot-1', approve: true }] },
+    ]);
+  });
+
+  it('does not query ballots when there are no disputes', async () => {
+    dbMocks.select
+      .mockReturnValueOnce(createQueryMock([adminRole]))
+      .mockReturnValueOnce(createQueryMock([]));
+    const app = await buildTestApp();
+
+    const response = await request(app)
+      .get('/api/disputes')
+      .set('x-test-user-id', 'admin-user')
+      .expect(200);
+
+    expect(response.body).toEqual([]);
+    expect(dbMocks.select).toHaveBeenCalledTimes(2);
   });
 
   it.each(['resolved', 'rejected'])('updates disputes to %s for admins', async (status) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5,6 +5,7 @@ import { setupAuth, registerAuthRoutes, isAuthenticated } from './replit_integra
 import { db } from './db';
 import {
   disputes,
+  disputeBallots,
   adminRoles,
   publicDisputeRequestSchema,
   appConfig,
@@ -207,7 +208,31 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
   app.get('/api/disputes', isAuthenticated, isAdmin, async (req, res) => {
     try {
       const allDisputes = await db.select().from(disputes);
-      res.json(allDisputes);
+      if (allDisputes.length === 0) {
+        return res.json([]);
+      }
+
+      // Ballots are admin-only. Fetch them in one bounded query instead of one
+      // query per dispute, then attach at most the persisted rows for each ID.
+      const disputeIds = allDisputes.map((dispute) => dispute.id);
+      const allBallots = await db
+        .select()
+        .from(disputeBallots)
+        .where(inArray(disputeBallots.disputeId, disputeIds));
+      const ballotsByDispute = new Map<string, typeof allBallots>();
+
+      for (const ballot of allBallots) {
+        const ballots = ballotsByDispute.get(ballot.disputeId) ?? [];
+        ballots.push(ballot);
+        ballotsByDispute.set(ballot.disputeId, ballots);
+      }
+
+      res.json(
+        allDisputes.map((dispute) => ({
+          ...dispute,
+          ballots: ballotsByDispute.get(dispute.id) ?? [],
+        }))
+      );
     } catch (error) {
       console.error('Error fetching disputes:', error);
       res.status(500).json({ message: 'Failed to fetch disputes' });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -145,6 +145,7 @@ export const insertDisputeBallotSchema = createInsertSchema(disputeBallots, {
 
 export type InsertDisputeBallot = z.infer<typeof insertDisputeBallotSchema>;
 export type DisputeBallot = typeof disputeBallots.$inferSelect;
+export type AdminDispute = Dispute & { ballots: DisputeBallot[] };
 
 // App configuration for LLM settings (stored securely)
 export const appConfig = pgTable('app_config', {


### PR DESCRIPTION
## Summary

- add a legacy-safe admin dispute decision audit showing solo, manual multiplayer, and opponent-vote modes
- show gameplay outcome, QA status, threshold, yes/no/non-response totals, eligible voter snapshots, individual admin-only ballots, timestamps, room/attempt context, and original-to-final score delta
- fetch ballots for all returned disputes in one protected admin query to avoid N+1 behavior
- add safe loading/error/empty/partial-data handling and make the shared admin layout usable on mobile
- preserve existing filters, AI analysis, editable corrections, resolve, reject, and legacy solo rendering
- add focused component, route, and mobile Playwright coverage

Individual ballot choices remain confined to the authenticated admin dispute endpoint. Public room snapshots were not changed.

## Validation

- `npx vitest run client/src/components/admin/DisputeVoteAudit.test.tsx server/routes.disputes.test.ts` — 27 passed
- `npm test` — 45 files, 527 tests passed
- `npm run check`
- `npm run lint` — 0 errors (22 existing warnings)
- `npm run build`
- focused Playwright mobile admin audit — 1 passed using an isolated client server with intercepted admin APIs

## Trade-offs

- vote totals and non-responses are derived from the persisted eligible snapshot plus ballot rows instead of adding duplicate aggregate columns
- legacy or partially populated multiplayer rows display explicit “Not recorded” values rather than inferring missing decisions
- full production-server E2E still needs the configured `DATABASE_URL`; the focused browser test avoids database mutation by intercepting the protected APIs

Linear: https://linear.app/stephs-vibe-coding/issue/STE-244/featadmin-surface-multiplayer-dispute-ballots-and-scoring-decisions

No release is created here; release handling remains with STE-245 / final STE-125 closeout.