### PR TITLE
feat(api): add 3-tier question pool fallback [STE-138]

### DIFF
--- a/server/lib/question-pool.test.ts
+++ b/server/lib/question-pool.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Avoid pulling in the real schema (which can drag in pg drivers) -- the
+// SQL expressions only need column-shaped placeholders to build correctly.
+vi.mock('@shared/schema', () => ({
+  seenQuestions: {
+    questionId: 'seen_questions.question_id',
+    seenAt: 'seen_questions.seen_at',
+    seenCount: 'seen_questions.seen_count',
+    userId: 'seen_questions.user_id',
+  },
+}));
+
+import { logQuestionPoolBackfill } from './question-pool';
+
+describe('logQuestionPoolBackfill', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('stays silent for a tier-0-only pool', () => {
+    logQuestionPoolBackfill('test', [0, 0, 0]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for an empty pool', () => {
+    logQuestionPoolBackfill('test', []);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when tier 1 (cooldown-expired) questions are present', () => {
+    logQuestionPoolBackfill('solo question selection', [0, 0, 1]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0];
+    expect(message).toContain('solo question selection');
+    expect(message).toContain('backfilled from cooldown pool');
+    expect(message).toContain('never-seen=2');
+    expect(message).toContain('cooldown-expired=1');
+    expect(message).toContain('in-cooldown=0');
+  });
+
+  it('warns when tier 2 (still-in-cooldown) questions are present', () => {
+    logQuestionPoolBackfill('room start', [2]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0];
+    expect(message).toContain('room start');
+    expect(message).toContain('never-seen=0');
+    expect(message).toContain('cooldown-expired=0');
+    expect(message).toContain('in-cooldown=1');
+  });
+
+  it('counts a mixed pool of all three tiers correctly', () => {
+    logQuestionPoolBackfill('test', [0, 0, 1, 1, 1, 2]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0];
+    expect(message).toContain('never-seen=2');
+    expect(message).toContain('cooldown-expired=3');
+    expect(message).toContain('in-cooldown=1');
+  });
+
+  it('ignores out-of-range tier values when counting', () => {
+    logQuestionPoolBackfill('test', [0, 0, -1, 3, 1]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0];
+    expect(message).toContain('never-seen=2');
+    expect(message).toContain('cooldown-expired=1');
+    expect(message).toContain('in-cooldown=0');
+  });
+});

--- a/server/lib/question-pool.ts
+++ b/server/lib/question-pool.ts
@@ -1,0 +1,48 @@
+// Shared 3-tier question preference ordering (STE-138), built on top of the
+// escalating cooldown cycle from STE-120 (1 -> 3 -> 5 months, repeating).
+//
+// A game must always be able to start if approved questions exist, so
+// candidates are never hard-excluded for being in cooldown -- they are only
+// deprioritized:
+//   Tier 0: never seen by this user
+//   Tier 1: seen before, but the cooldown window has elapsed
+//   Tier 2: seen before and still within the cooldown window (last resort,
+//           soonest-to-expire first)
+import { sql } from 'drizzle-orm';
+import { seenQuestions } from '@shared/schema';
+
+export const cooldownIntervalExpr = sql`
+  CASE (${seenQuestions.seenCount} - 1) % 3
+    WHEN 0 THEN INTERVAL '1 month'
+    WHEN 1 THEN INTERVAL '3 months'
+    WHEN 2 THEN INTERVAL '5 months'
+  END
+`;
+
+export const cooldownExpiresAtExpr = sql`${seenQuestions.seenAt} + ${cooldownIntervalExpr}`;
+
+export const questionTierExpr = sql<number>`
+  CASE
+    WHEN ${seenQuestions.questionId} IS NULL THEN 0
+    WHEN ${cooldownExpiresAtExpr} <= NOW() THEN 1
+    ELSE 2
+  END::int
+`;
+
+const TIER_LABELS = ['never-seen', 'cooldown-expired', 'in-cooldown'] as const;
+
+/**
+ * Logs a warning when the selected pool had to reach past never-seen
+ * questions (tier 0) into cooldown-expired or still-in-cooldown ones, so
+ * unexpectedly small pools are observable in server logs.
+ */
+export function logQuestionPoolBackfill(context: string, tiers: number[]): void {
+  const counts = [0, 0, 0];
+  for (const tier of tiers) {
+    if (tier >= 0 && tier <= 2) counts[tier] += 1;
+  }
+  if (counts[1] === 0 && counts[2] === 0) return;
+
+  const breakdown = TIER_LABELS.map((label, tier) => `${label}=${counts[tier]}`).join(', ');
+  console.warn(`[question-pool] ${context}: backfilled from cooldown pool (${breakdown})`);
+}

--- a/server/routes.rooms.ts
+++ b/server/routes.rooms.ts
@@ -5,6 +5,11 @@ import { z } from 'zod';
 
 import { db } from './db';
 import { advanceRoomEngine, createRoomAttempt } from './lib/room-engine';
+import {
+  questionTierExpr,
+  cooldownExpiresAtExpr,
+  logQuestionPoolBackfill,
+} from './lib/question-pool';
 import type { AuthenticatedRequest } from './types';
 import {
   QUESTIONS_PER_TEAM_ROTATION,
@@ -604,31 +609,26 @@ export function registerRoomRoutes(app: Express): void {
 
         let selectedQuestions: { id: string }[];
         if (userId) {
-          const cooldownExpr = sql`
-            CASE (${seenQuestions.seenCount} - 1) % 3
-              WHEN 0 THEN INTERVAL '1 month'
-              WHEN 1 THEN INTERVAL '3 months'
-              WHEN 2 THEN INTERVAL '5 months'
-            END
-          `;
-          selectedQuestions = await tx
-            .select({ id: questions.id })
+          // Never hard-exclude on cooldown -- rank by preference tier
+          // (never-seen, cooldown-expired, then still-in-cooldown) so a
+          // full game is always possible. See server/lib/question-pool.ts
+          // (STE-138).
+          const tiered = await tx
+            .select({ id: questions.id, tier: questionTierExpr })
             .from(questions)
             .leftJoin(
               seenQuestions,
               and(eq(questions.id, seenQuestions.questionId), eq(seenQuestions.userId, userId))
             )
-            .where(
-              and(
-                ...questionConditions,
-                sql`(${seenQuestions.questionId} IS NULL OR ${seenQuestions.seenAt} + ${cooldownExpr} <= NOW())`
-              )
-            )
-            .orderBy(
-              sql`CASE WHEN ${seenQuestions.questionId} IS NULL THEN 0 ELSE 1 END`,
-              sql`random()`
-            )
+            .where(and(...questionConditions))
+            .orderBy(questionTierExpr, cooldownExpiresAtExpr, sql`random()`)
             .limit(questionLimit);
+
+          logQuestionPoolBackfill(
+            'room start',
+            tiered.map((row) => row.tier)
+          );
+          selectedQuestions = tiered.map(({ id }) => ({ id }));
         } else if (excludeQuestionIds.length > 0) {
           const unseen = await tx
             .select({ id: questions.id })
@@ -652,6 +652,11 @@ export function registerRoomRoutes(app: Express): void {
             const backfill = eligibleSeen
               .sort((a, b) => (seenOrder.get(a.id) ?? 0) - (seenOrder.get(b.id) ?? 0))
               .slice(0, deficit);
+
+            console.warn(
+              `[question-pool] room start (guest): backfilled from locally-seen pool ` +
+                `(never-seen=${unseen.length}, previously-seen=${backfill.length})`
+            );
 
             selectedQuestions = [...unseen, ...backfill];
           } else {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,6 +27,11 @@ import { detectDuplicates } from './lib/duplicate-detector';
 import { batchFactCheck } from './lib/verifier';
 import { selectTopicContext } from './lib/topic-context';
 import { filterNovelQuestions } from './lib/novelty-filter';
+import {
+  questionTierExpr,
+  cooldownExpiresAtExpr,
+  logQuestionPoolBackfill,
+} from './lib/question-pool';
 import { z } from 'zod';
 import { aiLimiter } from './middleware/rateLimiter';
 import type { AuthenticatedRequest } from './types';
@@ -450,16 +455,10 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
 
       let results;
       if (shouldExcludeSeen) {
-        // Escalating cooldown cycle: 1 month → 3 months → 5 months, repeating
-        const cooldownExpr = sql`
-          CASE (${seenQuestions.seenCount} - 1) % 3
-            WHEN 0 THEN INTERVAL '1 month'
-            WHEN 1 THEN INTERVAL '3 months'
-            WHEN 2 THEN INTERVAL '5 months'
-          END
-        `;
-
-        // LEFT JOIN to find unseen or cooldown-expired questions
+        // Never hard-exclude on cooldown -- a full pool must always be
+        // selectable. Instead, rank by preference tier (never-seen,
+        // cooldown-expired, then still-in-cooldown) so a full game is
+        // always possible. See server/lib/question-pool.ts (STE-138).
         const query = db
           .select({
             id: questions.id,
@@ -473,34 +472,32 @@ export async function registerRoutes(httpServer: Server, app: Express): Promise<
             tags: questions.tags,
             sourceUrl: questions.sourceUrl,
             sourceName: questions.sourceName,
+            tier: questionTierExpr,
           })
           .from(questions)
           .leftJoin(
             seenQuestions,
             and(eq(questions.id, seenQuestions.questionId), eq(seenQuestions.userId, userId))
           )
-          .where(
-            and(
-              ...conditions,
-              sql`(${seenQuestions.questionId} IS NULL OR ${seenQuestions.seenAt} + ${cooldownExpr} <= NOW())`
-            )
-          );
+          .where(and(...conditions));
 
-        // Prefer never-seen questions first; only backfill with
-        // cooldown-expired ones when unseen supply is exhausted.
+        // Tier ascending first; within the in-cooldown tier, soonest-to-expire
+        // first; shuffle only breaks ties within a tier.
+        const orderBy = [questionTierExpr, cooldownExpiresAtExpr];
         if (shuffle === 'true') {
-          query.orderBy(
-            sql`CASE WHEN ${seenQuestions.questionId} IS NULL THEN 0 ELSE 1 END`,
-            sql`random()`
-          );
-        } else {
-          query.orderBy(sql`CASE WHEN ${seenQuestions.questionId} IS NULL THEN 0 ELSE 1 END`);
+          orderBy.push(sql`random()`);
         }
+        query.orderBy(...orderBy);
         if (limit) {
           query.limit(parseInt(limit as string, 10));
         }
 
-        results = await query;
+        const tiered = await query;
+        logQuestionPoolBackfill(
+          'solo question selection',
+          tiered.map((row) => row.tier)
+        );
+        results = tiered.map(({ tier: _tier, ...question }) => question);
       } else {
         const query = db.select().from(questions);
 


### PR DESCRIPTION
## Summary

When a logged-in user has seen most or all approved questions, the game must still be able to start. This replaces the previous hard-exclude-on-cooldown filter with a 3-tier preference ordering, so candidates are deprioritized instead of removed:

- **Tier 0** — never seen by this user
- **Tier 1** — seen before, but the cooldown window has elapsed (escalating cycle: 1mo → 3mo → 5mo, repeating)
- **Tier 2** — seen before and still within the cooldown window (last resort, soonest-to-expire first)

### Changes

- **`server/lib/question-pool.ts`** (new) — shared drizzle SQL expressions (`cooldownIntervalExpr`, `cooldownExpiresAtExpr`, `questionTierExpr`) computing each question's tier relative to a user's `seen_questions` history, plus `logQuestionPoolBackfill`, which logs a warning (with a tier breakdown) whenever a selection had to reach into tier 1/2, so unexpectedly small never-seen pools are observable in server logs.
- **`server/routes.ts`** — `GET /api/questions` now LEFT JOINs `seen_questions` and orders by tier → cooldown expiry → random instead of filtering rows out. Emits a `logQuestionPoolBackfill` warning on backfill.
- **`server/routes.rooms.ts`** — `POST /api/rooms/:code/start` applies the same tiered ordering for authenticated users selecting questions for a multiplayer game. The guest path (localStorage-based `excludeQuestionIds`) is unchanged aside from an added log line when it backfills from the locally-seen pool.

## Test plan

- [x] Added `server/lib/question-pool.test.ts` covering `logQuestionPoolBackfill` (silent on tier-0-only/empty pools, warns with correct tier breakdown on tier 1/2 presence, ignores out-of-range tier values). The SQL expressions themselves are drizzle template literals that only resolve inside a real query, so they're exercised via the existing route/integration tests rather than unit tests.
- [x] `npm test` — 550 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)